### PR TITLE
draft directus PR: feat(errors): give reasons to ForbiddenErrors

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -80,7 +80,7 @@ export default async function createApp(): Promise<express.Application> {
 	const logger = useLogger();
 	const helmet = await import('helmet');
 
-	injectErrorsDependencies(emitter);
+	injectErrorsDependencies(emitter, env);
 
 	await validateDatabaseConnection();
 

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -1,5 +1,5 @@
 import { useEnv } from '@directus/env';
-import { InvalidPayloadError, ServiceUnavailableError } from '@directus/errors';
+import { InvalidPayloadError, ServiceUnavailableError, injectErrorsDependencies } from '@directus/errors';
 import { handlePressure } from '@directus/pressure';
 import cookieParser from 'cookie-parser';
 import type { Request, RequestHandler, Response } from 'express';
@@ -79,6 +79,8 @@ export default async function createApp(): Promise<express.Application> {
 	const env = useEnv();
 	const logger = useLogger();
 	const helmet = await import('helmet');
+
+	injectErrorsDependencies(emitter);
 
 	await validateDatabaseConnection();
 

--- a/api/src/controllers/extensions.ts
+++ b/api/src/controllers/extensions.ts
@@ -47,7 +47,12 @@ router.get(
 	'/registry',
 	asyncHandler(async (req, res, next) => {
 		if (req.accountability && req.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${req.accountability?.user}' does not have permission to access registry`,
+				values: {
+					accountability: req.accountability,
+				}
+			});
 		}
 
 		const { search, limit, offset, sort, filter } = req.sanitizedQuery;
@@ -82,7 +87,7 @@ router.get(
 
 			if (type) {
 				if (isIn(type, EXTENSION_TYPES) === false) {
-					throw new ForbiddenError();
+					throw new ForbiddenError();  // InvalidPayload ? 404 ?
 				}
 
 				query.type = type;
@@ -115,7 +120,7 @@ router.get(
 	`/registry/account/:pk(${UUID_REGEX})`,
 	asyncHandler(async (req, res, next) => {
 		if (typeof req.params['pk'] !== 'string') {
-			throw new ForbiddenError();
+			throw new ForbiddenError(); // InvalidPayload ?
 		}
 
 		const options: AccountOptions = {};
@@ -136,7 +141,7 @@ router.get(
 	`/registry/extension/:pk(${UUID_REGEX})`,
 	asyncHandler(async (req, res, next) => {
 		if (typeof req.params['pk'] !== 'string') {
-			throw new ForbiddenError();
+			throw new ForbiddenError(); // InvalidPayload ?
 		}
 
 		const options: DescribeOptions = {};
@@ -157,13 +162,18 @@ router.post(
 	'/registry/install',
 	asyncHandler(async (req, _res, next) => {
 		if (req.accountability && req.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${req.accountability?.user}' does not have permission to access registry/install`,
+				values: {
+					accountability: req.accountability,
+				}
+			});
 		}
 
 		const { version, extension } = req.body;
 
 		if (!version || !extension) {
-			throw new ForbiddenError();
+			throw new ForbiddenError(); // InvalidPayload ?
 		}
 
 		const service = new ExtensionsService({
@@ -181,13 +191,18 @@ router.post(
 	'/registry/reinstall',
 	asyncHandler(async (req, _res, next) => {
 		if (req.accountability && req.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${req.accountability?.user}' does not have permission to access registry/reinstall`,
+				values: {
+					accountability: req.accountability,
+				}
+			});
 		}
 
 		const { extension } = req.body;
 
 		if (!extension) {
-			throw new ForbiddenError();
+			throw new ForbiddenError(); // InvalidPayload ?
 		}
 
 		const service = new ExtensionsService({
@@ -205,13 +220,18 @@ router.delete(
 	`/registry/uninstall/:pk(${UUID_REGEX})`,
 	asyncHandler(async (req, _res, next) => {
 		if (req.accountability && req.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${req.accountability?.user}' does not have permission to access registry/uninstall`,
+				values: {
+					accountability: req.accountability,
+				}
+			});
 		}
 
 		const pk = req.params['pk'];
 
 		if (typeof pk !== 'string') {
-			throw new ForbiddenError();
+			throw new ForbiddenError(); // InvalidPayload ?
 		}
 
 		const service = new ExtensionsService({
@@ -229,11 +249,16 @@ router.patch(
 	`/:pk(${UUID_REGEX})`,
 	asyncHandler(async (req, res, next) => {
 		if (req.accountability && req.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${req.accountability?.user}' cannot update extension`,
+				values: {
+					accountability: req.accountability,
+				}
+			});
 		}
 
 		if (typeof req.params['pk'] !== 'string') {
-			throw new ForbiddenError();
+			throw new ForbiddenError(); // InvalidPayload
 		}
 
 		const service = new ExtensionsService({
@@ -267,7 +292,12 @@ router.delete(
 	`/:pk(${UUID_REGEX})`,
 	asyncHandler(async (req, _res, next) => {
 		if (req.accountability && req.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${req.accountability?.user}' can't delete extension`,
+				values: {
+					accountability: req.accountability,
+				}
+			});
 		}
 
 		const service = new ExtensionsService({
@@ -278,7 +308,7 @@ router.delete(
 		const pk = req.params['pk'];
 
 		if (typeof pk !== 'string') {
-			throw new ForbiddenError();
+			throw new ForbiddenError(); // InvalidPayload
 		}
 
 		await service.deleteOne(pk);

--- a/api/src/controllers/extensions.ts
+++ b/api/src/controllers/extensions.ts
@@ -51,7 +51,7 @@ router.get(
 				reason: `'${req.accountability?.user}' does not have permission to access registry`,
 				values: {
 					accountability: req.accountability,
-				}
+				},
 			});
 		}
 
@@ -87,7 +87,7 @@ router.get(
 
 			if (type) {
 				if (isIn(type, EXTENSION_TYPES) === false) {
-					throw new ForbiddenError();  // InvalidPayload ? 404 ?
+					throw new ForbiddenError(); // InvalidPayload ? 404 ?
 				}
 
 				query.type = type;
@@ -166,7 +166,7 @@ router.post(
 				reason: `'${req.accountability?.user}' does not have permission to access registry/install`,
 				values: {
 					accountability: req.accountability,
-				}
+				},
 			});
 		}
 
@@ -195,7 +195,7 @@ router.post(
 				reason: `'${req.accountability?.user}' does not have permission to access registry/reinstall`,
 				values: {
 					accountability: req.accountability,
-				}
+				},
 			});
 		}
 
@@ -224,7 +224,7 @@ router.delete(
 				reason: `'${req.accountability?.user}' does not have permission to access registry/uninstall`,
 				values: {
 					accountability: req.accountability,
-				}
+				},
 			});
 		}
 
@@ -253,7 +253,7 @@ router.patch(
 				reason: `'${req.accountability?.user}' cannot update extension`,
 				values: {
 					accountability: req.accountability,
-				}
+				},
 			});
 		}
 
@@ -296,7 +296,7 @@ router.delete(
 				reason: `'${req.accountability?.user}' can't delete extension`,
 				values: {
 					accountability: req.accountability,
-				}
+				},
 			});
 		}
 

--- a/api/src/controllers/items.ts
+++ b/api/src/controllers/items.ts
@@ -17,7 +17,15 @@ router.post(
 	'/:collection',
 	collectionExists,
 	asyncHandler(async (req, res, next) => {
-		if (isSystemCollection(req.params['collection']!)) throw new ForbiddenError();
+		if (isSystemCollection(req.params['collection']!)) {
+			throw new ForbiddenError({
+				reason: 'Forbidden access to directus_* collections',
+				values: {
+					collection: req.params['collection'],
+					req,
+				}
+			});
+		}
 
 		if (req.singleton) {
 			throw new RouteNotFoundError({ path: req.path });
@@ -60,7 +68,15 @@ router.post(
 );
 
 const readHandler = asyncHandler(async (req, res, next) => {
-	if (isSystemCollection(req.params['collection']!)) throw new ForbiddenError();
+	if (isSystemCollection(req.params['collection']!)) {
+		throw new ForbiddenError({
+			reason: 'Forbidden access to directus_* collections',
+			values: {
+				collection: req.params['collection'],
+				req,
+			}
+		});
+	}
 
 	const service = new ItemsService(req.collection, {
 		accountability: req.accountability,
@@ -99,7 +115,15 @@ router.get(
 	'/:collection/:pk',
 	collectionExists,
 	asyncHandler(async (req, res, next) => {
-		if (isSystemCollection(req.params['collection']!)) throw new ForbiddenError();
+		if (isSystemCollection(req.params['collection']!)) {
+			throw new ForbiddenError({
+				reason: 'Forbidden access to directus_* collections',
+				values: {
+					collection: req.params['collection'],
+					req,
+				}
+			});
+		}
 
 		const service = new ItemsService(req.collection, {
 			accountability: req.accountability,
@@ -123,7 +147,15 @@ router.patch(
 	collectionExists,
 	validateBatch('update'),
 	asyncHandler(async (req, res, next) => {
-		if (isSystemCollection(req.params['collection']!)) throw new ForbiddenError();
+		if (isSystemCollection(req.params['collection']!)) {
+			throw new ForbiddenError({
+				reason: 'Forbidden access to directus_* collections',
+				values: {
+					collection: req.params['collection'],
+					req,
+				}
+			});
+		}
 
 		const service = new ItemsService(req.collection, {
 			accountability: req.accountability,
@@ -169,7 +201,15 @@ router.patch(
 	'/:collection/:pk',
 	collectionExists,
 	asyncHandler(async (req, res, next) => {
-		if (isSystemCollection(req.params['collection']!)) throw new ForbiddenError();
+		if (isSystemCollection(req.params['collection']!)) {
+			throw new ForbiddenError({
+				reason: 'Forbidden access to directus_* collections',
+				values: {
+					collection: req.params['collection'],
+					req,
+				}
+			});
+		}
 
 		if (req.singleton) {
 			throw new RouteNotFoundError({ path: req.path });
@@ -203,7 +243,15 @@ router.delete(
 	collectionExists,
 	validateBatch('delete'),
 	asyncHandler(async (req, _res, next) => {
-		if (isSystemCollection(req.params['collection']!)) throw new ForbiddenError();
+		if (isSystemCollection(req.params['collection']!)) {
+			throw new ForbiddenError({
+				reason: 'Forbidden access to directus_* collections',
+				values: {
+					collection: req.params['collection'],
+					req,
+				}
+			});
+		}
 
 		const service = new ItemsService(req.collection, {
 			accountability: req.accountability,
@@ -228,7 +276,15 @@ router.delete(
 	'/:collection/:pk',
 	collectionExists,
 	asyncHandler(async (req, _res, next) => {
-		if (isSystemCollection(req.params['collection']!)) throw new ForbiddenError();
+		if (isSystemCollection(req.params['collection']!)) {
+			throw new ForbiddenError({
+				reason: 'Forbidden access to directus_* collections',
+				values: {
+					collection: req.params['collection'],
+					req,
+				}
+			});
+		}
 
 		const service = new ItemsService(req.collection, {
 			accountability: req.accountability,

--- a/api/src/controllers/items.ts
+++ b/api/src/controllers/items.ts
@@ -23,7 +23,7 @@ router.post(
 				values: {
 					collection: req.params['collection'],
 					req,
-				}
+				},
 			});
 		}
 
@@ -74,7 +74,7 @@ const readHandler = asyncHandler(async (req, res, next) => {
 			values: {
 				collection: req.params['collection'],
 				req,
-			}
+			},
 		});
 	}
 
@@ -121,7 +121,7 @@ router.get(
 				values: {
 					collection: req.params['collection'],
 					req,
-				}
+				},
 			});
 		}
 
@@ -153,7 +153,7 @@ router.patch(
 				values: {
 					collection: req.params['collection'],
 					req,
-				}
+				},
 			});
 		}
 
@@ -207,7 +207,7 @@ router.patch(
 				values: {
 					collection: req.params['collection'],
 					req,
-				}
+				},
 			});
 		}
 
@@ -249,7 +249,7 @@ router.delete(
 				values: {
 					collection: req.params['collection'],
 					req,
-				}
+				},
 			});
 		}
 
@@ -282,7 +282,7 @@ router.delete(
 				values: {
 					collection: req.params['collection'],
 					req,
-				}
+				},
 			});
 		}
 

--- a/api/src/controllers/metrics.ts
+++ b/api/src/controllers/metrics.ts
@@ -31,7 +31,7 @@ router.get(
 				reason: `Invalid authorization header`,
 				values: {
 					header: req.headers.authorization,
-				}
+				},
 			});
 		}
 
@@ -43,7 +43,7 @@ router.get(
 			reason: `Invalid metrics authorization token`,
 			values: {
 				header: req.headers.authorization,
-			}
+			},
 		});
 	}),
 	asyncHandler(async (_req, res) => {

--- a/api/src/controllers/metrics.ts
+++ b/api/src/controllers/metrics.ts
@@ -19,20 +19,32 @@ router.get(
 		const metricTokens = env['METRICS_TOKENS'] as string[] | undefined;
 
 		if (!req.headers || !req.headers.authorization || !metricTokens) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `Missing authorization header or missing METRICS_TOKENS env variable`,
+			});
 		}
 
 		const parts = req.headers.authorization.split(' ');
 
 		if (parts.length !== 2 || parts[0]!.toLowerCase() !== 'metrics') {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `Invalid authorization header`,
+				values: {
+					header: req.headers.authorization,
+				}
+			});
 		}
 
 		if (metricTokens.find((mt) => mt.toString() === parts[1]) !== undefined) {
 			return next();
 		}
 
-		throw new ForbiddenError();
+		throw new ForbiddenError({
+			reason: `Invalid metrics authorization token`,
+			values: {
+				header: req.headers.authorization,
+			}
+		});
 	}),
 	asyncHandler(async (_req, res) => {
 		res.set('Content-Type', 'text/plain');

--- a/api/src/controllers/permissions.ts
+++ b/api/src/controllers/permissions.ts
@@ -91,8 +91,14 @@ router.search('/', validateBatch('read'), readHandler, respond);
 router.get(
 	'/me',
 	asyncHandler(async (req, res, next) => {
-		if (!req.accountability?.user && !req.accountability?.role && !req.accountability?.share)
-			throw new ForbiddenError();
+		if (!req.accountability?.user && !req.accountability?.role && !req.accountability?.share) {
+			throw new ForbiddenError({
+				reason: `Can't access /me without being logged in`,
+				values: {
+					accountability: req.accountability,
+				}
+			});
+		}
 
 		const result = await fetchAccountabilityCollectionAccess(req.accountability, {
 			schema: req.schema,

--- a/api/src/controllers/permissions.ts
+++ b/api/src/controllers/permissions.ts
@@ -96,7 +96,7 @@ router.get(
 				reason: `Can't access /me without being logged in`,
 				values: {
 					accountability: req.accountability,
-				}
+				},
 			});
 		}
 

--- a/api/src/controllers/policies.ts
+++ b/api/src/controllers/policies.ts
@@ -86,7 +86,14 @@ router.get(
 	'/me/globals',
 	asyncHandler(async (req, res, next) => {
 		try {
-			if (!req.accountability?.user && !req.accountability?.role) throw new ForbiddenError();
+			if (!req.accountability?.user && !req.accountability?.role) {
+				throw new ForbiddenError({
+					reason: `Can't access /me/globals without being logged in`,
+					values: {
+						accountability: req.accountability,
+					}
+				});
+			}
 
 			const result = await fetchAccountabilityPolicyGlobals(req.accountability, {
 				schema: req.schema,

--- a/api/src/controllers/policies.ts
+++ b/api/src/controllers/policies.ts
@@ -91,7 +91,7 @@ router.get(
 					reason: `Can't access /me/globals without being logged in`,
 					values: {
 						accountability: req.accountability,
-					}
+					},
 				});
 			}
 

--- a/api/src/controllers/roles.ts
+++ b/api/src/controllers/roles.ts
@@ -81,7 +81,7 @@ router.get(
 				reason: `Can't access /me without being logged in`,
 				values: {
 					accountability: req.accountability,
-				}
+				},
 			});
 		}
 

--- a/api/src/controllers/roles.ts
+++ b/api/src/controllers/roles.ts
@@ -76,7 +76,14 @@ router.search('/', validateBatch('read'), readHandler, respond);
 router.get(
 	'/me',
 	asyncHandler(async (req, res, next) => {
-		if (!req.accountability?.user && !req.accountability?.role) throw new ForbiddenError();
+		if (!req.accountability?.user && !req.accountability?.role) {
+			throw new ForbiddenError({
+				reason: `Can't access /me without being logged in`,
+				values: {
+					accountability: req.accountability,
+				}
+			});
+		}
 
 		const service = new RolesService({
 			accountability: req.accountability,

--- a/api/src/controllers/users.ts
+++ b/api/src/controllers/users.ts
@@ -424,7 +424,7 @@ router.post(
 				values: {
 					accountability: req.accountability,
 					user: req.params['pk'],
-				}
+				},
 			});
 		}
 

--- a/api/src/controllers/users.ts
+++ b/api/src/controllers/users.ts
@@ -419,7 +419,13 @@ router.post(
 		}
 
 		if (!req.accountability.admin || !req.params['pk']) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `You are not allowed to disable TFA for this user`,
+				values: {
+					accountability: req.accountability,
+					user: req.params['pk'],
+				}
+			});
 		}
 
 		const service = new TFAService({

--- a/api/src/services/assets.ts
+++ b/api/src/services/assets.ts
@@ -77,7 +77,7 @@ export class AssetsService {
 		 * with a wrong type. In case of directus_files where id is a uuid, we'll have to verify the
 		 * validity of the uuid ahead of time.
 		 */
-		if (!isValidUuid(id)) throw new ForbiddenError();
+		if (!isValidUuid(id)) throw new ForbiddenError(); // InvalidPayload ?
 
 		if (systemPublicKeys.includes(id) === false && this.accountability) {
 			await validateAccess(
@@ -95,7 +95,7 @@ export class AssetsService {
 
 		const exists = await storage.location(file.storage).exists(file.filename_disk);
 
-		if (!exists) throw new ForbiddenError();
+		if (!exists) throw new ForbiddenError(); // 404 ?
 
 		if (range) {
 			const missingRangeLimits = range.start === undefined && range.end === undefined;

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -64,7 +64,7 @@ export class CollectionsService {
 				values: {
 					accountability: this.accountability,
 					collection: payload.collection,
-				}
+				},
 			});
 		}
 
@@ -391,9 +391,9 @@ export class CollectionsService {
 				values: {
 					accountability: this.accountability,
 					collection: collectionKey,
-				}
+				},
 			});
-    }
+		}
 
 		return result[0]!;
 	}
@@ -435,7 +435,7 @@ export class CollectionsService {
 				values: {
 					accountability: this.accountability,
 					collection: collectionKey,
-				}
+				},
 			});
 		}
 
@@ -508,7 +508,7 @@ export class CollectionsService {
 				values: {
 					accountability: this.accountability,
 					collections: data,
-				}
+				},
 			});
 		}
 
@@ -580,7 +580,7 @@ export class CollectionsService {
 							...data,
 						};
 					}),
-				}
+				},
 			});
 		}
 

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -59,7 +59,13 @@ export class CollectionsService {
 	 */
 	async createOne(payload: RawCollection, opts?: MutationOptions): Promise<string> {
 		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability.user}' can't create the collection '${payload.collection}' as it's not an admin`,
+				values: {
+					accountability: this.accountability,
+					collection: payload.collection,
+				}
+			});
 		}
 
 		if (!('collection' in payload)) throw new InvalidPayloadError({ reason: `"collection" is required` });
@@ -379,7 +385,15 @@ export class CollectionsService {
 	async readOne(collectionKey: string): Promise<Collection> {
 		const result = await this.readMany([collectionKey]);
 
-		if (result.length === 0) throw new ForbiddenError();
+		if (result.length === 0) {
+			throw new ForbiddenError({
+				reason: `Collection '${collectionKey}' not found`, // 404 ?
+				values: {
+					accountability: this.accountability,
+					collection: collectionKey,
+				}
+			});
+    }
 
 		return result[0]!;
 	}
@@ -416,7 +430,13 @@ export class CollectionsService {
 	 */
 	async updateOne(collectionKey: string, data: Partial<Collection>, opts?: MutationOptions): Promise<string> {
 		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability.user}' does not have permission to update collections`,
+				values: {
+					accountability: this.accountability,
+					collection: collectionKey,
+				}
+			});
 		}
 
 		const nestedActionEvents: ActionEventParams[] = [];
@@ -483,7 +503,13 @@ export class CollectionsService {
 	 */
 	async updateBatch(data: Partial<Collection>[], opts?: MutationOptions): Promise<string[]> {
 		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability.user}' does not have permission to update collections`,
+				values: {
+					accountability: this.accountability,
+					collections: data,
+				}
+			});
 		}
 
 		if (!Array.isArray(data)) {
@@ -544,7 +570,18 @@ export class CollectionsService {
 	 */
 	async updateMany(collectionKeys: string[], data: Partial<Collection>, opts?: MutationOptions): Promise<string[]> {
 		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability.user}' does not have permission to update collections`,
+				values: {
+					accountability: this.accountability,
+					collections: collectionKeys.map((collection) => {
+						return {
+							collection,
+							...data,
+						};
+					}),
+				}
+			});
 		}
 
 		const nestedActionEvents: ActionEventParams[] = [];
@@ -593,7 +630,13 @@ export class CollectionsService {
 	 */
 	async deleteOne(collectionKey: string, opts?: MutationOptions): Promise<string> {
 		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability.user}' does not have permission to delete collections`,
+				values: {
+					accountability: this.accountability,
+					collection: collectionKey,
+				},
+			});
 		}
 
 		const nestedActionEvents: ActionEventParams[] = [];
@@ -604,7 +647,12 @@ export class CollectionsService {
 			const collectionToBeDeleted = collections.find((collection) => collection.collection === collectionKey);
 
 			if (!!collectionToBeDeleted === false) {
-				throw new ForbiddenError();
+				throw new ForbiddenError({
+					reason: `Collection to delete '${collectionKey}' does not exist`, // 404 ?
+					values: {
+						collection: collectionKey,
+					},
+				});
 			}
 
 			await transaction(this.knex, async (trx) => {
@@ -776,7 +824,17 @@ export class CollectionsService {
 	 */
 	async deleteMany(collectionKeys: string[], opts?: MutationOptions): Promise<string[]> {
 		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability.user}' can't delete many collections`,
+				values: {
+					accountability: this.accountability,
+					collections: collectionKeys.map((collection) => {
+						return {
+							collection,
+						};
+					}),
+				},
+			});
 		}
 
 		const nestedActionEvents: ActionEventParams[] = [];

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -241,7 +241,7 @@ export class FieldsService {
 					values: {
 						accountability: this.accountability,
 						collection,
-					}
+					},
 				});
 			}
 
@@ -306,7 +306,7 @@ export class FieldsService {
 						accountability: this.accountability,
 						collection,
 						field,
-					}
+					},
 				});
 			}
 		}
@@ -336,7 +336,7 @@ export class FieldsService {
 					accountability: this.accountability,
 					collection,
 					field,
-				}
+				},
 			});
 		}
 
@@ -373,7 +373,7 @@ export class FieldsService {
 					accountability: this.accountability,
 					collection,
 					field,
-				}
+				},
 			});
 		}
 
@@ -505,7 +505,7 @@ export class FieldsService {
 					accountability: this.accountability,
 					collection,
 					field,
-				}
+				},
 			});
 		}
 
@@ -689,7 +689,7 @@ export class FieldsService {
 					accountability: this.accountability,
 					collection,
 					field,
-				}
+				},
 			});
 		}
 

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -236,7 +236,13 @@ export class FieldsService {
 			});
 
 			if (collection && collection in allowedFieldsInCollection === false) {
-				throw new ForbiddenError();
+				throw new ForbiddenError({
+					reason: `'${this.accountability.user}' does not have permission to read fields from '${collection}'.`,
+					values: {
+						accountability: this.accountability,
+						collection,
+					}
+				});
 			}
 
 			return result.filter((field) => {
@@ -294,7 +300,14 @@ export class FieldsService {
 			}
 
 			if (!hasAccess) {
-				throw new ForbiddenError();
+				throw new ForbiddenError({
+					reason: `'${this.accountability.user}' does not have permission to read '${collection}.${field}'`,
+					values: {
+						accountability: this.accountability,
+						collection,
+						field,
+					}
+				});
 			}
 		}
 
@@ -315,7 +328,17 @@ export class FieldsService {
 			// Do nothing
 		}
 
-		if (!column && !fieldInfo) throw new ForbiddenError();
+		if (!column && !fieldInfo) {
+			// 404 / InvalidPayload / CorruptedSchema?
+			throw new ForbiddenError({
+				reason: `Can't retrieve the schema info for the column '${field}' of '${collection}'`,
+				values: {
+					accountability: this.accountability,
+					collection,
+					field,
+				}
+			});
+		}
 
 		const type = getLocalType(column, fieldInfo);
 
@@ -344,7 +367,14 @@ export class FieldsService {
 		opts?: MutationOptions,
 	): Promise<void> {
 		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability.user}' does not have the permission to create the field '${field}' in '${collection}'`,
+				values: {
+					accountability: this.accountability,
+					collection,
+					field,
+				}
+			});
 		}
 
 		const runPostColumnChange = await this.helpers.schema.preColumnChange();
@@ -469,7 +499,14 @@ export class FieldsService {
 
 	async updateField(collection: string, field: RawField, opts?: MutationOptions): Promise<string> {
 		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability.user}' does not have the permission to update the field '${field}' in '${collection}'`,
+				values: {
+					accountability: this.accountability,
+					collection,
+					field,
+				}
+			});
 		}
 
 		const runPostColumnChange = await this.helpers.schema.preColumnChange();
@@ -646,7 +683,14 @@ export class FieldsService {
 
 	async deleteField(collection: string, field: string, opts?: MutationOptions): Promise<void> {
 		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability.user}' does not have the permission to delete the field '${field}' in '${collection}'`,
+				values: {
+					accountability: this.accountability,
+					collection,
+					field,
+				}
+			});
 		}
 
 		const runPostColumnChange = await this.helpers.schema.preColumnChange();

--- a/api/src/services/import-export.ts
+++ b/api/src/services/import-export.ts
@@ -58,7 +58,16 @@ export class ImportService {
 	}
 
 	async import(collection: string, mimetype: string, stream: Readable): Promise<void> {
-		if (this.accountability?.admin !== true && isSystemCollection(collection)) throw new ForbiddenError();
+		if (this.accountability?.admin !== true && isSystemCollection(collection)) {
+			throw new ForbiddenError({
+				reason: `'${this.accountability?.user}' can't import to '${collection}' as not being an admin`,
+				values: {
+					collection,
+					mimetype,
+					accountability: this.accountability,
+				}
+			});
+    }
 
 		if (this.accountability) {
 			await validateAccess(

--- a/api/src/services/import-export.ts
+++ b/api/src/services/import-export.ts
@@ -65,9 +65,9 @@ export class ImportService {
 					collection,
 					mimetype,
 					accountability: this.accountability,
-				}
+				},
 			});
-    }
+		}
 
 		if (this.accountability) {
 			await validateAccess(

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -579,12 +579,13 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		const results = await this.readByQuery(queryWithKey, opts);
 
 		if (results.length === 0) {
-			throw new ForbiddenError({ // 404 / InvalidPayload?
+			throw new ForbiddenError({
+				// 404 / InvalidPayload?
 				reason: `No result found for key ${key} in ${this.collection} during items.readOne()`,
 				values: {
 					accountability: this.accountability, // should accountability be considered here? 403 or 404?
 					key,
-				}
+				},
 			});
 		}
 

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -525,7 +525,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 		// TODO when would this happen?
 		if (records === null) {
-			throw new ForbiddenError();
+			throw new ForbiddenError(); // 404 / InvalidPayload ?
 		}
 
 		const filteredRecords =
@@ -579,7 +579,13 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		const results = await this.readByQuery(queryWithKey, opts);
 
 		if (results.length === 0) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({ // 404 / InvalidPayload?
+				reason: `No result found for key ${key} in ${this.collection} during items.readOne()`,
+				values: {
+					accountability: this.accountability, // should accountability be considered here? 403 or 404?
+					key,
+				}
+			});
 		}
 
 		return results[0]!;

--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -730,7 +730,14 @@ export class PayloadService {
 
 					if (typeof relatedRecord === 'string' || typeof relatedRecord === 'number') {
 						if (!existingRecord) {
-							throw new ForbiddenError();
+							throw new ForbiddenError({ // 404 / InvalidPayload?
+								reason: `Could not find a '${relation.collection}' record having the primary key ${record} while processing O2M relation`,
+								values: {
+									collection: relation.collection,
+									key: record,
+									accountability: this.accountability,
+								}
+							});
 						}
 
 						// If the related item is already associated to the current item, and there's no

--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -730,13 +730,14 @@ export class PayloadService {
 
 					if (typeof relatedRecord === 'string' || typeof relatedRecord === 'number') {
 						if (!existingRecord) {
-							throw new ForbiddenError({ // 404 / InvalidPayload?
+							throw new ForbiddenError({
+								// 404 / InvalidPayload?
 								reason: `Could not find a '${relation.collection}' record having the primary key ${record} while processing O2M relation`,
 								values: {
 									collection: relation.collection,
 									key: record,
 									accountability: this.accountability,
-								}
+								},
 							});
 						}
 

--- a/api/src/services/relations.ts
+++ b/api/src/services/relations.ts
@@ -142,7 +142,14 @@ export class RelationsService {
 			);
 
 			if (allowedFields.includes('*') === false && allowedFields.includes(field) === false) {
-				throw new ForbiddenError();
+				throw new ForbiddenError({
+					reason: `'${this.accountability.user}' has no permission to read the field '${field}' of '${collection}'`,
+					values: {
+						accountability: this.accountability,
+						collection,
+						field,
+					}
+				});
 			}
 		}
 
@@ -170,7 +177,14 @@ export class RelationsService {
 		const results = await this.filterForbidden(stitched);
 
 		if (results.length === 0) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({ // 404 / InvalidPayload?
+				reason: `No result found for relation ${collection}.${field} during items.readOne()`,
+				values: {
+					accountability: this.accountability,
+					collection,
+					field,
+				}
+			});
 		}
 
 		return results[0]!;
@@ -181,7 +195,12 @@ export class RelationsService {
 	 */
 	async createOne(relation: Partial<Relation>, opts?: MutationOptions): Promise<void> {
 		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability.user}' is not allowed to create a relation`,
+				values: {
+					accountability: this.accountability,
+				}
+			});
 		}
 
 		if (!relation.collection) {
@@ -309,7 +328,15 @@ export class RelationsService {
 		opts?: MutationOptions,
 	): Promise<void> {
 		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability.user}' is not allowed to update a relation`,
+				values: {
+					accountability: this.accountability,
+					collection,
+					field,
+					relation,
+				}
+			});
 		}
 
 		const collectionSchema = this.schema.collections[collection];
@@ -429,7 +456,14 @@ export class RelationsService {
 	 */
 	async deleteOne(collection: string, field: string, opts?: MutationOptions): Promise<void> {
 		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability.user}' is not allowed to delete a relation`,
+				values: {
+					accountability: this.accountability,
+					collection,
+					field,
+				}
+			});
 		}
 
 		if (collection in this.schema.collections === false) {

--- a/api/src/services/relations.ts
+++ b/api/src/services/relations.ts
@@ -148,7 +148,7 @@ export class RelationsService {
 						accountability: this.accountability,
 						collection,
 						field,
-					}
+					},
 				});
 			}
 		}
@@ -177,13 +177,14 @@ export class RelationsService {
 		const results = await this.filterForbidden(stitched);
 
 		if (results.length === 0) {
-			throw new ForbiddenError({ // 404 / InvalidPayload?
+			throw new ForbiddenError({
+				// 404 / InvalidPayload?
 				reason: `No result found for relation ${collection}.${field} during items.readOne()`,
 				values: {
 					accountability: this.accountability,
 					collection,
 					field,
-				}
+				},
 			});
 		}
 
@@ -199,7 +200,7 @@ export class RelationsService {
 				reason: `'${this.accountability.user}' is not allowed to create a relation`,
 				values: {
 					accountability: this.accountability,
-				}
+				},
 			});
 		}
 
@@ -335,7 +336,7 @@ export class RelationsService {
 					collection,
 					field,
 					relation,
-				}
+				},
 			});
 		}
 
@@ -462,7 +463,7 @@ export class RelationsService {
 					accountability: this.accountability,
 					collection,
 					field,
-				}
+				},
 			});
 		}
 

--- a/api/src/services/utils.ts
+++ b/api/src/services/utils.ts
@@ -51,7 +51,14 @@ export class UtilsService {
 			);
 
 			if (allowedFields[0] !== '*' && allowedFields.includes(sortField) === false) {
-				throw new ForbiddenError();
+				throw new ForbiddenError({
+					reason: `'${this.accountability.user}' does not have permission to read the sort field '${collection}.${sortField}'`,
+					values: {
+						accountability: this.accountability,
+						collection,
+						field: sortField,
+					}
+				});
 			}
 		}
 
@@ -159,7 +166,12 @@ export class UtilsService {
 
 	async clearCache({ system }: { system: boolean }): Promise<void> {
 		if (this.accountability?.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability?.user}' does not have permission to clear the cache as not being an admin`,
+				values: {
+					accountability: this.accountability,
+				}
+			});
 		}
 
 		const { cache } = getCache();

--- a/api/src/services/utils.ts
+++ b/api/src/services/utils.ts
@@ -57,7 +57,7 @@ export class UtilsService {
 						accountability: this.accountability,
 						collection,
 						field: sortField,
-					}
+					},
 				});
 			}
 		}
@@ -170,7 +170,7 @@ export class UtilsService {
 				reason: `'${this.accountability?.user}' does not have permission to clear the cache as not being an admin`,
 				values: {
 					accountability: this.accountability,
-				}
+				},
 			});
 		}
 

--- a/api/src/utils/get-service.ts
+++ b/api/src/utils/get-service.ts
@@ -80,7 +80,7 @@ export function getService(collection: string, opts: AbstractServiceOptions): It
 					reason: 'Forbidden access to directus_* collections',
 					values: {
 						collection,
-					}
+					},
 				});
 			}
 

--- a/api/src/utils/get-service.ts
+++ b/api/src/utils/get-service.ts
@@ -75,7 +75,14 @@ export function getService(collection: string, opts: AbstractServiceOptions): It
 			return new WebhooksService(opts);
 		default:
 			// Deny usage of other system collections via ItemsService
-			if (collection.startsWith('directus_')) throw new ForbiddenError();
+			if (collection.startsWith('directus_')) {
+				throw new ForbiddenError({
+					reason: 'Forbidden access to directus_* collections',
+					values: {
+						collection,
+					}
+				});
+			}
 
 			return new ItemsService(collection, opts);
 	}

--- a/api/src/utils/validate-keys.ts
+++ b/api/src/utils/validate-keys.ts
@@ -19,9 +19,23 @@ export function validateKeys(
 		const primaryKeyFieldType = schema.collections[collection]?.fields[keyField]?.type;
 
 		if (primaryKeyFieldType === 'uuid' && !isValidUuid(String(keys))) {
-			throw new ForbiddenError();
+			// Should this be a forbidden error? InvalidPayload?
+			throw new ForbiddenError({
+				reason: `Primary key of ${collection} must be a uuid instead of ${JSON.stringify(keys, null, 2)}`,
+				values: {
+					collection,
+					key: keys,
+				}
+			});
 		} else if (primaryKeyFieldType === 'integer' && !Number.isInteger(Number(keys))) {
-			throw new ForbiddenError();
+			// Should this be a forbidden error? InvalidPayload?
+			throw new ForbiddenError({
+				reason: `Primary key of ${collection} must be an integer instead of ${JSON.stringify(keys, null, 2)}`,
+				values: {
+					collection,
+					key: keys,
+				}
+			});
 		}
 	}
 }

--- a/api/src/utils/validate-keys.ts
+++ b/api/src/utils/validate-keys.ts
@@ -25,7 +25,7 @@ export function validateKeys(
 				values: {
 					collection,
 					key: keys,
-				}
+				},
 			});
 		} else if (primaryKeyFieldType === 'integer' && !Number.isInteger(Number(keys))) {
 			// Should this be a forbidden error? InvalidPayload?
@@ -34,7 +34,7 @@ export function validateKeys(
 				values: {
 					collection,
 					key: keys,
-				}
+				},
 			});
 		}
 	}

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -1,2 +1,1 @@
-export * from './types/env.js';
 export { useEnv } from './lib/use-env.js';

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -1,1 +1,2 @@
+export * from './types/env.js';
 export { useEnv } from './lib/use-env.js';

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -31,6 +31,7 @@
 	},
 	"devDependencies": {
 		"@directus/random": "workspace:*",
+		"@directus/env": "workspace:*",
 		"@directus/tsconfig": "3.0.0",
 		"@types/ms": "2.1.0",
 		"@vitest/coverage-v8": "2.1.9",

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -32,6 +32,7 @@
 	"devDependencies": {
 		"@directus/random": "workspace:*",
 		"@directus/env": "workspace:*",
+		"@directus/types": "workspace:*",
 		"@directus/tsconfig": "3.0.0",
 		"@types/ms": "2.1.0",
 		"@vitest/coverage-v8": "2.1.9",

--- a/packages/errors/src/errors/forbidden.ts
+++ b/packages/errors/src/errors/forbidden.ts
@@ -1,3 +1,4 @@
+import { useEnv } from '@directus/env';
 import { createError, ErrorCode } from '../index.js';
 import {
   useEmitter,
@@ -58,6 +59,8 @@ interface ForbiddenErrorExtensions {
 export const messageConstructor = (ext: ForbiddenErrorExtensions | void) => {
 	const defaultReason =  `You don't have permission to access this.`;
 
+  const env = useEnv();
+  console.info('env', env); // eslint-disable-line no-console
 
   const emitter = useEmitter();
 

--- a/packages/errors/src/errors/forbidden.ts
+++ b/packages/errors/src/errors/forbidden.ts
@@ -1,81 +1,94 @@
 import { useEnv } from '@directus/env';
 import { createError, ErrorCode } from '../index.js';
 import {
-  useEmitter,
+	useEmitter,
 } from '../injected-dependencies.js'
 // import type { Request } from 'express';
 
 import type {
-  Accountability,
-  PrimaryKey,
-  Field,
-  RawField,
-  Type,
-  Relation,
-  // Collection, // Not the same Collection type as in services/collection.ts
+	Accountability,
+	PrimaryKey,
+	Field,
+	RawField,
+	Type,
+	Relation,
+	// Collection, // Not the same Collection type as in services/collection.ts
 } from '@directus/types';
 
 import type { Collection } from '../../../../api/src/types/collection.js';
 
 interface ForbiddenErrorExtensions {
 	reason: string;
-  values?:{ // Controllers
-    collection?: string | undefined,
-    req?: any,
-    // req?: Request,
-  }
-  | { // Permissions
-    accountability: Accountability | null,
-    collection: string,
-    field?: string | RawField | (Partial<Field> & { field: string; type: Type | null }),
-    relation?: Partial<Relation>,
-  }
-  | { // Permissions many / batch
-    accountability: Accountability | null,
-    collections: Partial<Collection>[],
-  }
-  | { // validate keys
-    collection: string,
-    key: PrimaryKey,
-  }
-  | { // imports
-    collection: string,
-    mimetype: any,
-  }
-  | { // 404
-    accountability?: Accountability | null,
-    collection?: string,
-    key?: PrimaryKey,
-  }
-  | { // Metrics controller
-    header: string,
-  }
-  | { // TFA controller
-    accountability: Accountability | null,
-    user: PrimaryKey,
-  }
+	values?:{ // Controllers
+		collection?: string | undefined,
+		req?: any,
+		// req?: Request,
+	}
+	| { // Permissions
+		accountability: Accountability | null,
+		collection: string,
+		field?: string | RawField | (Partial<Field> & { field: string; type: Type | null }),
+		relation?: Partial<Relation>,
+	}
+	| { // Permissions many / batch
+		accountability: Accountability | null,
+		collections: Partial<Collection>[],
+	}
+	| { // validate keys
+		collection: string,
+		key: PrimaryKey,
+	}
+	| { // imports
+		collection: string,
+		mimetype: any,
+	}
+	| { // 404
+		accountability?: Accountability | null,
+		collection?: string,
+		key?: PrimaryKey,
+	}
+	| { // Metrics controller
+		header: string,
+	}
+	| { // TFA controller
+		accountability: Accountability | null,
+		user: PrimaryKey,
+	}
 }
 
 export const messageConstructor = (ext: ForbiddenErrorExtensions | void) => {
 	const defaultReason =  `You don't have permission to access this.`;
 
-  const env = useEnv();
-  console.info('env', env); // eslint-disable-line no-console
+	const env = useEnv();
+	console.info('env', env); // eslint-disable-line no-console
 
-  const emitter = useEmitter();
+	const emitter = useEmitter();
 
-  emitter?.emitAction(
-    'permission.error',
-    {
-      defaultReason,
-      values: ext && ext.values,
-    },
-    {
-      database: null,
-      schema: null,
-      accountability: ext && ext.values && ('accountability' in ext.values ? ext.values.accountability : null),
-    },
-  );
+	emitter?.emitAction(
+		'permission.error',
+		{
+			defaultReason,
+			values: ext && ext.values,
+		},
+		{
+			database: null,
+			schema: null,
+			accountability: ext && ext.values && ('accountability' in ext.values ? ext.values.accountability : null),
+		},
+	);
+
+	// const hookError = await emitter.emitFilter(
+	//   'permission.error',
+	//   ext && ext.values,
+	//   {
+	//     defaultReason,
+	//   },
+	//   {
+	//     database: null,
+	//     schema: null,
+	//     accountability: ext && (ext.values?.accountability ?? null),
+	//   },
+	// );
 
 	if (ext?.reason) return ext.reason;
 

--- a/packages/errors/src/errors/forbidden.ts
+++ b/packages/errors/src/errors/forbidden.ts
@@ -25,13 +25,13 @@ interface ForbiddenErrorExtensions {
 		// req?: Request,
 	}
 	| { // Permissions
-		accountability: Accountability | null,
+		accountability: Accountability | null | undefined,
 		collection: string,
 		field?: string | RawField | (Partial<Field> & { field: string; type: Type | null }),
 		relation?: Partial<Relation>,
 	}
 	| { // Permissions many / batch
-		accountability: Accountability | null,
+		accountability: Accountability | null | undefined,
 		collections: Partial<Collection>[],
 	}
 	| { // validate keys
@@ -43,7 +43,7 @@ interface ForbiddenErrorExtensions {
 		mimetype: any,
 	}
 	| { // 404
-		accountability?: Accountability | null,
+		accountability?: Accountability | null | undefined,
 		collection?: string,
 		key?: PrimaryKey,
 	}
@@ -51,7 +51,7 @@ interface ForbiddenErrorExtensions {
 		header: string,
 	}
 	| { // TFA controller
-		accountability: Accountability | null,
+		accountability: Accountability | null | undefined,
 		user: PrimaryKey,
 	}
 }

--- a/packages/errors/src/errors/forbidden.ts
+++ b/packages/errors/src/errors/forbidden.ts
@@ -1,7 +1,55 @@
 import { createError, ErrorCode } from '../index.js';
+// import type { Request } from 'express';
+
+import type {
+  Accountability,
+  PrimaryKey,
+  Field,
+  RawField,
+  Type,
+  Relation,
+  // Collection, // Not the same Collection type as in services/collection.ts
+} from '@directus/types';
+
+import type { Collection } from '../../../../api/src/types/collection.js';
 
 interface ForbiddenErrorExtensions {
 	reason: string;
+  values?:{ // Controllers
+    collection?: string | undefined,
+    req?: any,
+    // req?: Request,
+  }
+  | { // Permissions
+    accountability: Accountability | null,
+    collection: string,
+    field?: string | RawField | (Partial<Field> & { field: string; type: Type | null }),
+    relation?: Partial<Relation>,
+  }
+  | { // Permissions many / batch
+    accountability: Accountability | null,
+    collections: Partial<Collection>[],
+  }
+  | { // validate keys
+    collection: string,
+    key: PrimaryKey,
+  }
+  | { // imports
+    collection: string,
+    mimetype: any,
+  }
+  | { // 404
+    accountability?: Accountability | null,
+    collection?: string,
+    key?: PrimaryKey,
+  }
+  | { // Metrics controller
+    header: string,
+  }
+  | { // TFA controller
+    accountability: Accountability | null,
+    user: PrimaryKey,
+  }
 }
 
 export const messageConstructor = (ext: ForbiddenErrorExtensions | void) => {

--- a/packages/errors/src/errors/forbidden.ts
+++ b/packages/errors/src/errors/forbidden.ts
@@ -1,8 +1,5 @@
 import { createError, ErrorCode } from '../index.js';
-import {
-	useEmitter,
-	useEnv,
-} from '../injected-dependencies.js'
+import { useEmitter, useEnv } from '../injected-dependencies.js';
 // import type { Request } from 'express';
 
 import type {
@@ -19,45 +16,54 @@ import type { Collection } from '../../../../api/src/types/collection.js';
 
 interface ForbiddenErrorExtensions {
 	reason: string;
-	values?:{ // Controllers
-		collection?: string | undefined,
-		req?: any,
-		// req?: Request,
-	}
-	| { // Permissions
-		accountability: Accountability | null | undefined,
-		collection: string,
-		field?: string | RawField | (Partial<Field> & { field: string; type: Type | null }),
-		relation?: Partial<Relation>,
-	}
-	| { // Permissions many / batch
-		accountability: Accountability | null | undefined,
-		collections: Partial<Collection>[],
-	}
-	| { // validate keys
-		collection: string,
-		key: PrimaryKey,
-	}
-	| { // imports
-		collection: string,
-		mimetype: any,
-	}
-	| { // 404
-		accountability?: Accountability | null | undefined,
-		collection?: string,
-		key?: PrimaryKey,
-	}
-	| { // Metrics controller
-		header: string,
-	}
-	| { // TFA controller
-		accountability: Accountability | null | undefined,
-		user: PrimaryKey,
-	}
+	values?:
+		| {
+				// Controllers
+				collection?: string | undefined;
+				req?: any;
+				// req?: Request,
+		  }
+		| {
+				// Permissions
+				accountability: Accountability | null | undefined;
+				collection: string;
+				field?: string | RawField | (Partial<Field> & { field: string; type: Type | null });
+				relation?: Partial<Relation>;
+		  }
+		| {
+				// Permissions many / batch
+				accountability: Accountability | null | undefined;
+				collections: Partial<Collection>[];
+		  }
+		| {
+				// validate keys
+				collection: string;
+				key: PrimaryKey;
+		  }
+		| {
+				// imports
+				collection: string;
+				mimetype: any;
+		  }
+		| {
+				// 404
+				accountability?: Accountability | null | undefined;
+				collection?: string;
+				key?: PrimaryKey;
+		  }
+		| {
+				// Metrics controller
+				header: string;
+		  }
+		| {
+				// TFA controller
+				accountability: Accountability | null | undefined;
+				user: PrimaryKey;
+		  };
 }
 
 export const messageConstructor = (ext: ForbiddenErrorExtensions | void) => {
-	const defaultReason =  `You don't have permission to access this.`;
+	const defaultReason = `You don't have permission to access this.`;
 
 	const env = useEnv();
 	console.info('env', env); // eslint-disable-line no-console

--- a/packages/errors/src/errors/forbidden.ts
+++ b/packages/errors/src/errors/forbidden.ts
@@ -1,4 +1,7 @@
 import { createError, ErrorCode } from '../index.js';
+import {
+  useEmitter,
+} from '../injected-dependencies.js'
 // import type { Request } from 'express';
 
 import type {
@@ -53,9 +56,27 @@ interface ForbiddenErrorExtensions {
 }
 
 export const messageConstructor = (ext: ForbiddenErrorExtensions | void) => {
+	const defaultReason =  `You don't have permission to access this.`;
+
+
+  const emitter = useEmitter();
+
+  emitter?.emitAction(
+    'permission.error',
+    {
+      defaultReason,
+      values: ext && ext.values,
+    },
+    {
+      database: null,
+      schema: null,
+      accountability: ext && ext.values && ('accountability' in ext.values ? ext.values.accountability : null),
+    },
+  );
+
 	if (ext?.reason) return ext.reason;
 
-	return `You don't have permission to access this.`;
+	return defaultReason;
 };
 
 export const ForbiddenError = createError(ErrorCode.Forbidden, messageConstructor, 403);

--- a/packages/errors/src/errors/forbidden.ts
+++ b/packages/errors/src/errors/forbidden.ts
@@ -1,7 +1,7 @@
-import { useEnv } from '@directus/env';
 import { createError, ErrorCode } from '../index.js';
 import {
 	useEmitter,
+	useEnv,
 } from '../injected-dependencies.js'
 // import type { Request } from 'express';
 

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -2,3 +2,4 @@ export * from './create-error.js';
 export * from './codes.js';
 export * from './is-directus-error.js';
 export * from './errors/index.js';
+export * from './injected-dependencies.js';

--- a/packages/errors/src/injected-dependencies.ts
+++ b/packages/errors/src/injected-dependencies.ts
@@ -1,0 +1,22 @@
+
+type Emitter = {
+  emitAction: (event: string | string[], meta: Record<string, any>, context: any) => void
+  emitFilter: (event: string | string[], payload: any, meta: Record<string, any>, context: any) => Promise<any>
+}
+
+// TODO makeand Emitter exportable like Env
+export const injectedDependencies: {
+  emitter: Emitter | undefined
+} = {
+  emitter: undefined,
+}
+
+export function injectErrorsDependencies(
+  emitter: Emitter,
+) {
+  injectedDependencies.emitter = emitter;
+}
+
+export function useEmitter() {
+  return injectedDependencies.emitter
+}

--- a/packages/errors/src/injected-dependencies.ts
+++ b/packages/errors/src/injected-dependencies.ts
@@ -2,28 +2,28 @@
 type Env = Record<string, unknown>;
 
 type Emitter = {
-  emitAction: (event: string | string[], meta: Record<string, any>, context: any) => void
-  emitFilter: (event: string | string[], payload: any, meta: Record<string, any>, context: any) => Promise<any>
-}
+	emitAction: (event: string | string[], meta: Record<string, any>, context: any) => void;
+	emitFilter: (event: string | string[], payload: any, meta: Record<string, any>, context: any) => Promise<any>;
+};
 
 // TODO makeand Emitter exportable like Env
 export const injectedDependencies: {
-  emitter?: Emitter | undefined,
-  env?: Env | undefined,
-} = {}
+	emitter?: Emitter | undefined;
+	env?: Env | undefined;
+} = {};
 
 export function injectErrorsDependencies(
-  emitter: Emitter,
-  env: Env, // Must be injected as @directus/errors is built for Node and Vite
+	emitter: Emitter,
+	env: Env, // Must be injected as @directus/errors is built for Node and Vite
 ) {
-  injectedDependencies.emitter = emitter;
-  injectedDependencies.env = env;
+	injectedDependencies.emitter = emitter;
+	injectedDependencies.env = env;
 }
 
 export function useEmitter() {
-  return injectedDependencies.emitter
+	return injectedDependencies.emitter;
 }
 
 export function useEnv() {
-  return injectedDependencies.env
+	return injectedDependencies.env;
 }

--- a/packages/errors/src/injected-dependencies.ts
+++ b/packages/errors/src/injected-dependencies.ts
@@ -1,4 +1,5 @@
-import { type Env } from '@directus/env';
+// import { type Env } from '@directus/env'; // Produces a Vite error due to the use of node:fs
+type Env = Record<string, unknown>;
 
 type Emitter = {
   emitAction: (event: string | string[], meta: Record<string, any>, context: any) => void

--- a/packages/errors/src/injected-dependencies.ts
+++ b/packages/errors/src/injected-dependencies.ts
@@ -1,3 +1,4 @@
+import { type Env } from '@directus/env';
 
 type Emitter = {
   emitAction: (event: string | string[], meta: Record<string, any>, context: any) => void
@@ -6,17 +7,22 @@ type Emitter = {
 
 // TODO makeand Emitter exportable like Env
 export const injectedDependencies: {
-  emitter: Emitter | undefined
-} = {
-  emitter: undefined,
-}
+  emitter?: Emitter | undefined,
+  env?: Env | undefined,
+} = {}
 
 export function injectErrorsDependencies(
   emitter: Emitter,
+  env: Env, // Must be injected as @directus/errors is built for Node and Vite
 ) {
   injectedDependencies.emitter = emitter;
+  injectedDependencies.env = env;
 }
 
 export function useEmitter() {
   return injectedDependencies.emitter
+}
+
+export function useEnv() {
+  return injectedDependencies.env
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1178,6 +1178,9 @@ importers:
         specifier: 2.1.3
         version: 2.1.3
     devDependencies:
+      '@directus/env':
+        specifier: workspace:*
+        version: link:../env
       '@directus/random':
         specifier: workspace:*
         version: link:../random

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1187,6 +1187,9 @@ importers:
       '@directus/tsconfig':
         specifier: 3.0.0
         version: 3.0.0
+      '@directus/types':
+        specifier: workspace:*
+        version: link:../types
       '@types/ms':
         specifier: 2.1.0
         version: 2.1.0


### PR DESCRIPTION
### Goals
- [ ] Better / Faster DX
- [ ] Upgrade Directus

### Todo
- [ ] Map reasons and valuable variables of ForbiddenErrors
    - [ ] Services
        - [x] items
        - [x] assets
        - [x] collections
        - [x] fields
        - [x] import-export
        - [x] payload
        - [x] relations
        - [x] utils
        - [ ] comments
        - [ ] extensions
        - [ ] graphql/resolvers/system-global
        - [ ] permissions
        - [ ] schema
        - [ ] shares
        - [ ] users
        - [ ] versions
    - [x] Controllers
        - [x] items
        - [x] extensions
        - [x] metrics
        - [x] permissions
        - [x] policies
        - [x] roles
        - [x] users
    - [x] Utils
        - [x] validate-keys
        - [x] get-service
- [ ] Model listed ForbiddenError use cases
    - `Not Found`: Some forbidden errors are triggered when object is not found (no accountability involved)
        - Some can't be found as not belonging to the user. Should we trigger a 404 / InvalidPayload error or ForbiddenError?
        - NotExposedMissingError to display 404 in dev mode / to admins and 403 to everybody else ?
    - `System Collections`: Forbidden access to system collection (no accountability invlolved)
    - `Schema Inconsistency`: Some ForbiddenErrors are triggered due to schema inconsitency (missing fieldInfo) => 500 ?
    - `PermissionError`: Create a PermissionError for all the errors based on accountability / collection / field ?
    - `AdminOnlyError`: Some actions require to be admin ?
    - `InvalidTokenError`: error during auth via a token (metrics)
    - `Others`: TFA, import-exports
- [x] DX needs / scope
    - Some errors reasons must be displayed to the user (like in validateAccess)
    - Some reasons must be displayed to developers / admin only (trying to access a system collection...)
    - Being able to customize behavior on error to
        - log the reasons / track errors
        - Customize the displayed message
- [ ] Experiments
    - [x] Implement an emitter on forbidden errors
        - `emitAction` works with a dirty kind of dependency injection. Moving Emitter to dedicated package seems required
        - `emitFilter` would required a syntax like `throw await createForbiddenError(...)` inspired by `throw await translateDatabaseError(err, data);` 
    - [ ] Create new types of errors 
        - [ ] Goals 
            - reduce boilerplate
            - Display or not the detailed reason based on their type
        - [ ] Implementation
            - [ ] `SystemCollectionAccessError`
            - [ ] `PermissionError`
            - [ ] `AdminAccessRequiredError`
            - [ ] `InvalidTokenError`
            - [ ] `GenericForbiddenError`
            - [ ] `NotExposedMissingError`
            - [ ] What is the proper way to implement inheritance ? Should we ?
    - [ ] Other solution: Pass a variable allowing or not the display of the extension reason to the user
- [ ] Open questions
    - [ ] Shouldn't all the errors be filterable with the emitter ?


Directus discussion https://github.com/directus/directus/discussions/4368