### PR TITLE
draft directus PR: V11.9.2 hhh dev skippable item creation

### DIFF
--- a/api/src/emitter.ts
+++ b/api/src/emitter.ts
@@ -31,7 +31,7 @@ export class Emitter {
 		};
 	}
 
-	public async emitFilter<TIn = unknown, TOut extends TIn = TIn>(
+	public async emitFilter<TIn = unknown, TOut = TIn>(
 		event: string | string[],
 		payload: TIn,
 		meta: Record<string, any>,
@@ -44,11 +44,11 @@ export class Emitter {
 			listeners: this.filterEmitter.listeners(event) as FilterHandler<TIn, TOut>[],
 		}));
 
-		let updatedPayload = payload;
+		let updatedPayload: TIn | TOut = payload;
 
 		for (const { event, listeners } of eventListeners) {
 			for (const listener of listeners) {
-				const result = await listener(updatedPayload, { event, ...meta }, context ?? this.getDefaultContext());
+				const result = await listener(payload, { event, ...meta }, context ?? this.getDefaultContext());
 
 				if (result !== undefined) {
 					updatedPayload = result;

--- a/api/src/emitter.ts
+++ b/api/src/emitter.ts
@@ -31,17 +31,17 @@ export class Emitter {
 		};
 	}
 
-	public async emitFilter<T>(
+	public async emitFilter<TIn = unknown, TOut extends TIn = TIn>(
 		event: string | string[],
-		payload: T,
+		payload: TIn,
 		meta: Record<string, any>,
 		context: EventContext | null = null,
-	): Promise<T> {
+	): Promise<TOut | TIn> {
 		const events = Array.isArray(event) ? event : [event];
 
 		const eventListeners = events.map((event) => ({
 			event,
-			listeners: this.filterEmitter.listeners(event) as FilterHandler<T>[],
+			listeners: this.filterEmitter.listeners(event) as FilterHandler<TIn, TOut>[],
 		}));
 
 		let updatedPayload = payload;

--- a/api/src/emitter.ts
+++ b/api/src/emitter.ts
@@ -82,7 +82,7 @@ export class Emitter {
 		}
 	}
 
-	public onFilter<T = unknown>(event: string, handler: FilterHandler<T>): void {
+	public onFilter<TIn = unknown, TOut = TIn>(event: string, handler: FilterHandler<TIn, TOut>): void {
 		this.filterEmitter.on(event, handler);
 	}
 
@@ -94,7 +94,7 @@ export class Emitter {
 		this.initEmitter.on(event, handler);
 	}
 
-	public offFilter<T = unknown>(event: string, handler: FilterHandler<T>): void {
+	public offFilter<TIn = unknown, TOut = TIn>(event: string, handler: FilterHandler<TIn, TOut>): void {
 		this.filterEmitter.off(event, handler);
 	}
 

--- a/api/src/extensions/manager.ts
+++ b/api/src/extensions/manager.ts
@@ -9,15 +9,10 @@ import type {
 	HybridExtension,
 	OperationApiConfig,
 } from '@directus/extensions';
-import { APP_SHARED_DEPS, HYBRID_EXTENSION_TYPES } from '@directus/extensions';
+import { APP_SHARED_DEPS, HYBRID_EXTENSION_TYPES, type RegisterFunctions } from '@directus/extensions';
 import { generateExtensionsEntrypoint } from '@directus/extensions/node';
 import type {
-	ActionHandler,
-	EmbedHandler,
-	FilterHandler,
-	InitHandler,
 	PromiseCallback,
-	ScheduleHandler,
 } from '@directus/types';
 import { isTypeIn, toBoolean } from '@directus/utils';
 import { pathToRelativeUrl, processId } from '@directus/utils/node';
@@ -812,29 +807,29 @@ export class ExtensionManager {
 
 		const unregisterFunctions: PromiseCallback[] = [];
 
-		const hookRegistrationContext = {
-			filter: <T = unknown>(event: string, handler: FilterHandler<T>) => {
+		const hookRegistrationContext: RegisterFunctions = {
+			filter: (event, handler) => {
 				emitter.onFilter(event, handler);
 
 				unregisterFunctions.push(() => {
 					emitter.offFilter(event, handler);
 				});
 			},
-			action: (event: string, handler: ActionHandler) => {
+			action: (event, handler) => {
 				emitter.onAction(event, handler);
 
 				unregisterFunctions.push(() => {
 					emitter.offAction(event, handler);
 				});
 			},
-			init: (event: string, handler: InitHandler) => {
+			init: (event, handler) => {
 				emitter.onInit(event, handler);
 
 				unregisterFunctions.push(() => {
 					emitter.offInit(name, handler);
 				});
 			},
-			schedule: (cron: string, handler: ScheduleHandler) => {
+			schedule: (cron, handler) => {
 				if (validateCron(cron)) {
 					const job = scheduleSynchronizedJob(`${name}:${scheduleIndex}`, cron, async () => {
 						if (this.options.schedule) {
@@ -855,7 +850,7 @@ export class ExtensionManager {
 					this.handleExtensionError({ reason: `Couldn't register cron hook. Provided cron is invalid: ${cron}` });
 				}
 			},
-			embed: (position: 'head' | 'body', code: string | EmbedHandler) => {
+			embed: (position, code) => {
 				const content = typeof code === 'function' ? code() : code;
 
 				if (content.trim().length !== 0) {

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -176,6 +176,14 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					  )
 					: payload;
 
+			if (
+				payloadAfterHooks === null ||
+				typeof payloadAfterHooks === 'string' ||
+				typeof payloadAfterHooks === 'number'
+			) {
+				return payloadAfterHooks;
+			}
+
 			const payloadWithPresets = this.accountability
 				? await processPayload(
 						{

--- a/packages/extensions/src/shared/types/hooks.ts
+++ b/packages/extensions/src/shared/types/hooks.ts
@@ -6,7 +6,7 @@ export type HookExtensionContext = ApiExtensionContext & {
 };
 
 export type RegisterFunctions = {
-	filter: <T = unknown>(event: string, handler: FilterHandler<T>) => void;
+	filter: <TIn = unknown, TOut = TIn>(event: string, handler: FilterHandler<TIn, TOut>) => void;
 	action: (event: string, handler: ActionHandler) => void;
 	init: (event: string, handler: InitHandler) => void;
 	schedule: (cron: string, handler: ScheduleHandler) => void;

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -9,11 +9,11 @@ export type EventContext = {
 	accountability: Accountability | null;
 };
 
-export type FilterHandler<T = unknown> = (
-	payload: T,
+export type FilterHandler<TIn = unknown, TOut = TIn> = (
+	payload: TIn,
 	meta: Record<string, any>,
 	context: EventContext,
-) => T | Promise<T>;
+) => TOut | Promise<TOut>;
 export type ActionHandler = (meta: Record<string, any>, context: EventContext) => void;
 export type InitHandler = (meta: Record<string, any>) => void;
 export type ScheduleHandler = PromiseCallback;

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -9,7 +9,7 @@ export type EventContext = {
 	accountability: Accountability | null;
 };
 
-export type FilterHandler<TIn = unknown, TOut = TIn> = (
+export type FilterHandler<TIn = unknown, TOut extends TIn = TIn> = (
 	payload: TIn,
 	meta: Record<string, any>,
 	context: EventContext,

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -9,11 +9,11 @@ export type EventContext = {
 	accountability: Accountability | null;
 };
 
-export type FilterHandler<TIn = unknown, TOut extends TIn = TIn> = (
+export type FilterHandler<TIn = unknown, TOut = TIn> = (
 	payload: TIn,
 	meta: Record<string, any>,
 	context: EventContext,
-) => TOut | Promise<TOut>;
+) =>  TIn | TOut | Promise<TIn | TOut>;
 export type ActionHandler = (meta: Record<string, any>, context: EventContext) => void;
 export type InitHandler = (meta: Record<string, any>) => void;
 export type ScheduleHandler = PromiseCallback;


### PR DESCRIPTION
## Scope

What's changed:

- support skipping item creation from extension hook
- support replacing a created item by an existing one

## Potential Risks / Drawbacks

- If somebody return a primary key or null (instead of void / undefined) in a filter hook, it would trigger this  

## Review Notes / Questions

- I guess the tests must be implemented here https://github.com/directus/directus/blob/main/tests/blackbox/tests/db/routes/items/no-relation.test.ts and require implementing dedicated hooks

## TODO
- Support SDK createItem input having updateInput in relations loke in planReviewRound

---

Fixes #\<num\>

https://github.com/directus/directus/discussions/25411
