### PR TITLE
perf(items): use knex.batchInsert when possible

### DIFF
--- a/api/src/database/helpers/capabilities/dialects/mssql.ts
+++ b/api/src/database/helpers/capabilities/dialects/mssql.ts
@@ -1,5 +1,4 @@
 import { useEnv } from '@directus/env';
-import { toBoolean } from '@directus/utils';
 import { CapabilitiesHelperDefault } from './default.js';
 
 const env = useEnv();
@@ -20,6 +19,6 @@ export class CapabilitiesHelperMSSQL extends CapabilitiesHelperDefault {
 	 * would.
 	 */
 	override async preservesInsertOrderInReturning(): Promise<boolean> {
-		return toBoolean(env['DB_MSSQL_TRUST_BATCH_RETURNING']);
+		return env['DB_MSSQL_TRUST_BATCH_RETURNING'] as boolean;
 	}
 }

--- a/api/src/database/helpers/capabilities/dialects/mssql.ts
+++ b/api/src/database/helpers/capabilities/dialects/mssql.ts
@@ -38,4 +38,14 @@ export class CapabilitiesHelperMSSQL extends CapabilitiesHelperDefault {
 	override async preservesInsertOrderInReturning(): Promise<boolean> {
 		return env['DB_MSSQL_TRUST_BATCH_RETURNING'] as boolean;
 	}
+
+	/**
+	 * MSSQL: tables with enabled triggers reject `OUTPUT INSERTED.<col>` unless the
+	 * server is told to redirect OUTPUT into a temp table via knex's
+	 * `includeTriggerModifications` option. Apply it on every per-row insert so
+	 * triggered tables work transparently.
+	 */
+	override insertReturningOptions(): { includeTriggerModifications: true } {
+		return { includeTriggerModifications: true };
+	}
 }

--- a/api/src/database/helpers/capabilities/dialects/mssql.ts
+++ b/api/src/database/helpers/capabilities/dialects/mssql.ts
@@ -26,7 +26,12 @@ export class CapabilitiesHelperMSSQL extends CapabilitiesHelperDefault {
 	 *     `.insert().returning()` path does).
 	 *   - So the OUTPUT clause is emitted without `INTO`, which SQL Server rejects on any
 	 *     table with an enabled trigger.
-	 *   - Tracked upstream at https://github.com/knex/knex/issues/4151.
+	 *   - Won't be closed without a knex redesign: maintainers consider
+	 *     `batchInsert` a second-class helper that shouldn't gain feature parity
+	 *     with `.insert()` (https://github.com/knex/knex/issues/3590 — open;
+	 *     `includeTriggerModifications` was added for `.insert().returning()` in
+	 *     https://github.com/knex/knex/issues/2446 but never extended to
+	 *     `batchInsert`).
 	 *   - Keep this flag off for trigger-bearing schemas; the default-false per-row dispatch
 	 *     retains trigger support.
 	 */

--- a/api/src/database/helpers/capabilities/dialects/mssql.ts
+++ b/api/src/database/helpers/capabilities/dialects/mssql.ts
@@ -1,0 +1,25 @@
+import { useEnv } from '@directus/env';
+import { toBoolean } from '@directus/utils';
+import { CapabilitiesHelperDefault } from './default.js';
+
+const env = useEnv();
+
+export class CapabilitiesHelperMSSQL extends CapabilitiesHelperDefault {
+	/**
+	 * MSSQL: opt-in via `DB_MSSQL_TRUST_BATCH_RETURNING` (default `false`). Microsoft says
+	 * OUTPUT row order isn't guaranteed
+	 * (https://learn.microsoft.com/sql/t-sql/queries/output-clause-transact-sql); knex emits
+	 * `OUTPUT INSERTED.<col> INTO #out; SELECT … FROM #out` with no `ORDER BY`
+	 * (https://github.com/knex/knex/blob/3.2.10/lib/dialects/mssql/query/mssql-querycompiler.js#L358-L381).
+	 * Empirically it stays insertion-ordered because OUTPUT into a temp table forces a
+	 * serial plan, but that's not contractual. knex's docs list MSSQL as fully supported
+	 * and warn only about triggers, silent on ordering
+	 * (https://knexjs.org/guide/query-builder.html#returning) — hence the flag: knex says
+	 * trust, Microsoft says don't. No SQL Server version, compat level, trace flag, or
+	 * `OUTPUT ORDERED` clause unlocks a guarantee; only a knex-side row-number passthrough
+	 * would.
+	 */
+	override async preservesInsertOrderInReturning(): Promise<boolean> {
+		return toBoolean(env['DB_MSSQL_TRUST_BATCH_RETURNING']);
+	}
+}

--- a/api/src/database/helpers/capabilities/dialects/mssql.ts
+++ b/api/src/database/helpers/capabilities/dialects/mssql.ts
@@ -5,18 +5,30 @@ const env = useEnv();
 
 export class CapabilitiesHelperMSSQL extends CapabilitiesHelperDefault {
 	/**
-	 * MSSQL: opt-in via `DB_MSSQL_TRUST_BATCH_RETURNING` (default `false`). Microsoft says
-	 * OUTPUT row order isn't guaranteed
-	 * (https://learn.microsoft.com/sql/t-sql/queries/output-clause-transact-sql); knex emits
-	 * `OUTPUT INSERTED.<col> INTO #out; SELECT … FROM #out` with no `ORDER BY`
-	 * (https://github.com/knex/knex/blob/3.2.10/lib/dialects/mssql/query/mssql-querycompiler.js#L358-L381).
-	 * Empirically it stays insertion-ordered because OUTPUT into a temp table forces a
-	 * serial plan, but that's not contractual. knex's docs list MSSQL as fully supported
-	 * and warn only about triggers, silent on ordering
-	 * (https://knexjs.org/guide/query-builder.html#returning) — hence the flag: knex says
-	 * trust, Microsoft says don't. No SQL Server version, compat level, trace flag, or
-	 * `OUTPUT ORDERED` clause unlocks a guarantee; only a knex-side row-number passthrough
-	 * would.
+	 * MSSQL: opt-in via `DB_MSSQL_TRUST_BATCH_RETURNING` (default `false`).
+	 *
+	 * - Why the flag exists (Microsoft vs knex disagree on whether OUTPUT order is safe):
+	 *   - Microsoft says OUTPUT row order isn't guaranteed
+	 *     (https://learn.microsoft.com/sql/t-sql/queries/output-clause-transact-sql).
+	 *   - knex emits `OUTPUT INSERTED.<col> INTO #out; SELECT … FROM #out` with no `ORDER BY`
+	 *     (https://github.com/knex/knex/blob/3.2.10/lib/dialects/mssql/query/mssql-querycompiler.js#L358-L381).
+	 *   - Empirically it stays insertion-ordered because OUTPUT into a temp table forces a
+	 *     serial plan, but that's not contractual.
+	 *   - knex's docs list MSSQL as fully supported and warn only about triggers, silent
+	 *     on ordering (https://knexjs.org/guide/query-builder.html#returning).
+	 *   - Hence the flag: knex says trust, Microsoft says don't.
+	 *   - No SQL Server version, compat level, trace flag, or `OUTPUT ORDERED` clause
+	 *     unlocks a guarantee; only a knex-side row-number passthrough would.
+	 *
+	 * - Caveat for triggered tables (opting in breaks inserts on tables with triggers):
+	 *   - `knex.batchInsert(...).returning(...)` has no signature to thread
+	 *     `{ includeTriggerModifications: true }` through (only the per-row
+	 *     `.insert().returning()` path does).
+	 *   - So the OUTPUT clause is emitted without `INTO`, which SQL Server rejects on any
+	 *     table with an enabled trigger.
+	 *   - Tracked upstream at https://github.com/knex/knex/issues/4151.
+	 *   - Keep this flag off for trigger-bearing schemas; the default-false per-row dispatch
+	 *     retains trigger support.
 	 */
 	override async preservesInsertOrderInReturning(): Promise<boolean> {
 		return env['DB_MSSQL_TRUST_BATCH_RETURNING'] as boolean;

--- a/api/src/database/helpers/capabilities/dialects/mysql.ts
+++ b/api/src/database/helpers/capabilities/dialects/mysql.ts
@@ -7,4 +7,23 @@ export class CapabilitiesHelperMySQL extends CapabilitiesHelper {
 		//   column aliases, or column positions. Column positions are integers and begin with 1:
 		return true;
 	}
+
+	/**
+	 * MySQL: no native `INSERT … RETURNING`.
+	 *
+	 * MariaDB ≥ 10.5 (2020-06) does support it (https://mariadb.com/kb/en/insertreturning/),
+	 * but knex treats `.returning()` as a no-op for the mysql dialect and logs
+	 * `".returning() is not supported by mysql and will not have any effect."`
+	 * Tracked upstream at https://github.com/knex/knex/issues/6254. Both MariaDB
+	 * and MySQL route through `Client_MySQL2` and surface as `'mysql'` in
+	 * `getDatabaseClient()`, so we can't dispatch them separately at this layer
+	 * either.
+	 *
+	 * When knex grows MariaDB-aware RETURNING emission and Directus exposes MariaDB
+	 * as its own `DatabaseClient` value, this method can probe `SELECT VERSION()`
+	 * for the `-MariaDB` suffix and return `true` for ≥ 10.5.
+	 */
+	override async preservesInsertOrderInReturning(): Promise<boolean> {
+		return false;
+	}
 }

--- a/api/src/database/helpers/capabilities/dialects/mysql.ts
+++ b/api/src/database/helpers/capabilities/dialects/mysql.ts
@@ -11,17 +11,19 @@ export class CapabilitiesHelperMySQL extends CapabilitiesHelper {
 	/**
 	 * MySQL: no native `INSERT … RETURNING`.
 	 *
-	 * MariaDB ≥ 10.5 (2020-06) does support it (https://mariadb.com/kb/en/insertreturning/),
-	 * but knex treats `.returning()` as a no-op for the mysql dialect and logs
-	 * `".returning() is not supported by mysql and will not have any effect."`
-	 * Tracked upstream at https://github.com/knex/knex/issues/6254. Both MariaDB
-	 * and MySQL route through `Client_MySQL2` and surface as `'mysql'` in
-	 * `getDatabaseClient()`, so we can't dispatch them separately at this layer
-	 * either.
+	 * - MariaDB does support RETURNING since 10.5 (2020-06)
+	 *   (https://mariadb.com/kb/en/insertreturning/), but:
+	 *   - knex treats `.returning()` as a no-op for the mysql dialect and logs
+	 *     `".returning() is not supported by mysql and will not have any effect."`
+	 *   - Tracked upstream at https://github.com/knex/knex/issues/6254.
+	 *   - Both MariaDB and MySQL route through `Client_MySQL2` and surface as
+	 *     `'mysql'` in `getDatabaseClient()`, so we can't dispatch them separately
+	 *     at this layer either.
 	 *
-	 * When knex grows MariaDB-aware RETURNING emission and Directus exposes MariaDB
-	 * as its own `DatabaseClient` value, this method can probe `SELECT VERSION()`
-	 * for the `-MariaDB` suffix and return `true` for ≥ 10.5.
+	 * - Future enablement path: when knex grows MariaDB-aware RETURNING emission
+	 *   and Directus exposes MariaDB as its own `DatabaseClient` value, this method
+	 *   can probe `SELECT VERSION()` for the `-MariaDB` suffix and return `true`
+	 *   for ≥ 10.5.
 	 */
 	override async preservesInsertOrderInReturning(): Promise<boolean> {
 		return false;

--- a/api/src/database/helpers/capabilities/dialects/oracle.ts
+++ b/api/src/database/helpers/capabilities/dialects/oracle.ts
@@ -1,0 +1,11 @@
+import { CapabilitiesHelperDefault } from './default.js';
+
+export class CapabilitiesHelperOracle extends CapabilitiesHelperDefault {
+	override async preservesInsertOrderInReturning(): Promise<boolean> {
+		// knex's oracledb compiler emits one `INSERT … RETURNING … INTO :bind` per row inside
+		// a single BEGIN…END; block and collects per-row PKs via positional OUT binds, so the
+		// returned array follows JS-array order by construction.
+		// https://github.com/knex/knex/blob/3.2.10/lib/dialects/oracledb/query/oracledb-querycompiler.js
+		return true;
+	}
+}

--- a/api/src/database/helpers/capabilities/dialects/postgres.ts
+++ b/api/src/database/helpers/capabilities/dialects/postgres.ts
@@ -13,4 +13,11 @@ export class CapabilitiesHelperPostgres extends CapabilitiesHelper {
 		// See https://www.postgresql.org/docs/current/sql-prepare.html
 		return false;
 	}
+
+	override async preservesInsertOrderInReturning(): Promise<boolean> {
+		// Postgres's INSERT … RETURNING returns one row per inserted row, in insertion order,
+		// within a single statement. Same semantics inherited by CockroachDB and Redshift.
+		// https://www.postgresql.org/docs/current/sql-insert.html
+		return true;
+	}
 }

--- a/api/src/database/helpers/capabilities/dialects/sqlite.ts
+++ b/api/src/database/helpers/capabilities/dialects/sqlite.ts
@@ -1,3 +1,4 @@
+import type { FieldOverview } from '@directus/types';
 import { CapabilitiesHelperDefault } from './default.js';
 
 /**
@@ -21,5 +22,29 @@ export class CapabilitiesHelperSqlite extends CapabilitiesHelperDefault {
 
 		this.preservesOrderCache = major > minMajor || (major === minMajor && minor >= minMinor);
 		return this.preservesOrderCache;
+	}
+
+	/**
+	 * SQLite batchInsert workaround (https://github.com/knex/knex/issues/332):
+	 *
+	 * - knex normalizes columns across all rows in the chunk.
+	 * - Columns missing from a row are bound as `undefined`.
+	 * - The sqlite3 driver translates that to `NULL` and the insert fails for
+	 *   non-nullable columns.
+	 *
+	 * Spread per-column defaults for non-nullable fields first so the payload
+	 * only overrides what it explicitly sets.
+	 */
+	override padRowsForBatchInsert<T extends Record<string, unknown>>(
+		rows: T[],
+		opts: { fields: Record<string, FieldOverview>; primaryKeyField: string },
+	): T[] {
+		const fieldsRequiringValue = Object.fromEntries(
+			Object.entries(opts.fields)
+				.filter(([fieldName, field]) => fieldName !== opts.primaryKeyField && field.nullable === false)
+				.map(([fieldName, field]) => [fieldName, field.defaultValue]),
+		);
+
+		return rows.map((row) => ({ ...fieldsRequiringValue, ...row }));
 	}
 }

--- a/api/src/database/helpers/capabilities/dialects/sqlite.ts
+++ b/api/src/database/helpers/capabilities/dialects/sqlite.ts
@@ -1,0 +1,25 @@
+import { CapabilitiesHelperDefault } from './default.js';
+
+/**
+ * SQLite gained `INSERT … RETURNING` in 3.35.0 (2021-03-12). Below that version the only
+ * id available after an insert is `last_insert_rowid()` (the last item only), so the
+ * batch path can't be trusted. Probe the runtime version once per knex client.
+ * https://www.sqlite.org/lang_returning.html
+ */
+const MIN_SQLITE_RETURNING_VERSION: [number, number] = [3, 35];
+
+export class CapabilitiesHelperSqlite extends CapabilitiesHelperDefault {
+	private preservesOrderCache?: boolean;
+
+	override async preservesInsertOrderInReturning(): Promise<boolean> {
+		if (this.preservesOrderCache !== undefined) return this.preservesOrderCache;
+
+		const row = await this.knex.select(this.knex.raw('sqlite_version() as version')).first<{ version?: string }>();
+		const versionStr = String(row?.version ?? '0');
+		const [major = 0, minor = 0] = versionStr.split('.').map(Number);
+		const [minMajor, minMinor] = MIN_SQLITE_RETURNING_VERSION;
+
+		this.preservesOrderCache = major > minMajor || (major === minMajor && minor >= minMinor);
+		return this.preservesOrderCache;
+	}
+}

--- a/api/src/database/helpers/capabilities/index.ts
+++ b/api/src/database/helpers/capabilities/index.ts
@@ -1,7 +1,7 @@
 export { CapabilitiesHelperPostgres as postgres } from './dialects/postgres.js';
 export { CapabilitiesHelperPostgres as redshift } from './dialects/postgres.js';
 export { CapabilitiesHelperPostgres as cockroachdb } from './dialects/postgres.js';
-export { CapabilitiesHelperDefault as oracle } from './dialects/default.js';
+export { CapabilitiesHelperOracle as oracle } from './dialects/oracle.js';
 export { CapabilitiesHelperMySQL as mysql } from './dialects/mysql.js';
-export { CapabilitiesHelperDefault as mssql } from './dialects/default.js';
-export { CapabilitiesHelperDefault as sqlite } from './dialects/default.js';
+export { CapabilitiesHelperMSSQL as mssql } from './dialects/mssql.js';
+export { CapabilitiesHelperSqlite as sqlite } from './dialects/sqlite.js';

--- a/api/src/database/helpers/capabilities/types.ts
+++ b/api/src/database/helpers/capabilities/types.ts
@@ -16,14 +16,18 @@ export class CapabilitiesHelper extends DatabaseHelper {
 	}
 
 	/**
-	 * Whether `INSERT … RETURNING` (or the dialect equivalent) yields rows in insertion
-	 * order with a contractual guarantee. When true, `ItemsService.createMany` can use a
-	 * single multi-row `knex.batchInsert` and map the returned PKs back positionally;
-	 * when false it must fall back to a per-row insert loop.
+	 * Whether `INSERT … RETURNING` (or the dialect equivalent) yields rows in
+	 * insertion order with a contractual guarantee.
 	 *
-	 * Default: `false` — the conservative answer. Override only in dialects where both
-	 * the underlying RETURNING semantics AND the knex driver path emitting them preserve
-	 * order.
+	 * - When `true`: `ItemsService.createMany` uses a single multi-row
+	 *   `knex.batchInsert` and maps the returned PKs back positionally.
+	 * - When `false`: it falls back to a per-row insert loop.
+	 *
+	 * Default: `false` — the conservative answer. Override only in dialects where
+	 * both:
+	 * - the underlying RETURNING semantics, AND
+	 * - the knex driver path emitting them
+	 * preserve order.
 	 */
 	async preservesInsertOrderInReturning(): Promise<boolean> {
 		return false;

--- a/api/src/database/helpers/capabilities/types.ts
+++ b/api/src/database/helpers/capabilities/types.ts
@@ -45,4 +45,13 @@ export class CapabilitiesHelper extends DatabaseHelper {
 	): T[] {
 		return rows;
 	}
+
+	/**
+	 * Options to pass as the second arg of knex's per-row `.insert().returning(pk, ...)`.
+	 * Default `undefined` (no dialect-specific options); override where the driver
+	 * needs a hint (e.g. MSSQL trigger tables — see its helper).
+	 */
+	insertReturningOptions(): { includeTriggerModifications: true } | undefined {
+		return undefined;
+	}
 }

--- a/api/src/database/helpers/capabilities/types.ts
+++ b/api/src/database/helpers/capabilities/types.ts
@@ -1,3 +1,4 @@
+import type { FieldOverview } from '@directus/types';
 import { DatabaseHelper } from '../types.js';
 
 export class CapabilitiesHelper extends DatabaseHelper {
@@ -31,5 +32,17 @@ export class CapabilitiesHelper extends DatabaseHelper {
 	 */
 	async preservesInsertOrderInReturning(): Promise<boolean> {
 		return false;
+	}
+
+	/**
+	 * Pre-process rows before handing them to `knex.batchInsert`. Default is a
+	 * no-op; override in dialects whose driver requires column normalization
+	 * (e.g. SQLite, see its helper for the issue).
+	 */
+	padRowsForBatchInsert<T extends Record<string, unknown>>(
+		rows: T[],
+		_opts: { fields: Record<string, FieldOverview>; primaryKeyField: string },
+	): T[] {
+		return rows;
 	}
 }

--- a/api/src/database/helpers/capabilities/types.ts
+++ b/api/src/database/helpers/capabilities/types.ts
@@ -14,4 +14,18 @@ export class CapabilitiesHelper extends DatabaseHelper {
 	supportsDeduplicationOfParameters(): boolean {
 		return true;
 	}
+
+	/**
+	 * Whether `INSERT … RETURNING` (or the dialect equivalent) yields rows in insertion
+	 * order with a contractual guarantee. When true, `ItemsService.createMany` can use a
+	 * single multi-row `knex.batchInsert` and map the returned PKs back positionally;
+	 * when false it must fall back to a per-row insert loop.
+	 *
+	 * Default: `false` — the conservative answer. Override only in dialects where both
+	 * the underlying RETURNING semantics AND the knex driver path emitting them preserve
+	 * order.
+	 */
+	async preservesInsertOrderInReturning(): Promise<boolean> {
+		return false;
+	}
 }

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -48,7 +48,10 @@ export function getDatabase(): Knex {
 		connectionString,
 		pool: poolConfig = {},
 		...connectionConfig
-	} = getConfigFromEnv('DB_', { omitPrefix: 'DB_EXCLUDE_TABLES' });
+	} = getConfigFromEnv('DB_', {
+		omitPrefix: 'DB_EXCLUDE_TABLES',
+		omitKey: ['DB_BATCH_INSERT_CHUNK_SIZE', 'DB_DEFAULT_ORDER_READS_BY_PK', 'DB_MSSQL_TRUST_BATCH_RETURNING'],
+	});
 
 	const requiredEnvVars = ['DB_CLIENT'];
 

--- a/api/src/services/comments.ts
+++ b/api/src/services/comments.ts
@@ -27,13 +27,11 @@ export class CommentsService extends ItemsService {
 	}
 
 	override async createMany(data: Partial<Comment>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
-		if (!this.accountability?.user) throw new ForbiddenError();
+		const results: PrimaryKey[] = [];
 
-		// Pre-insert: validate every payload before any insert runs so a bad row
-		// aborts the batch cleanly. `ItemsService.createMany` is the single insert
-		// path now (`createOne` wraps it), so this is the only place per-row
-		// validation can live.
 		for (const item of data) {
+			if (!this.accountability?.user) throw new ForbiddenError();
+
 			if (!item['comment']) {
 				throw new InvalidPayloadError({ reason: `"comment" is required` });
 			}
@@ -46,112 +44,102 @@ export class CommentsService extends ItemsService {
 				throw new InvalidPayloadError({ reason: `"item" is required` });
 			}
 
-			await validateAccess(
-				{
-					accountability: this.accountability,
-					action: 'read',
-					collection: item['collection'],
-					primaryKeys: [item['item']],
-				},
-				{
-					schema: this.schema,
-					knex: this.knex,
-				},
-			);
-		}
-
-		const result = await super.createMany(data, opts);
-
-		// Post-insert: process @mentions per row. Errors per mention are swallowed
-		// (warn-and-continue) inside `sendMentionNotifications`.
-		for (const item of data) {
-			await this.sendMentionNotifications(item);
-		}
-
-		return result;
-	}
-
-	private async sendMentionNotifications(data: Partial<Comment>): Promise<void> {
-		if (!this.accountability?.user) return;
-
-		const usersRegExp = new RegExp(/@[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}/gi);
-
-		const mentions = uniq(data['comment']!.match(usersRegExp) ?? []);
-
-		if (mentions.length === 0) {
-			return;
-		}
-
-		const sender = await this.usersService.readOne(this.accountability.user, {
-			fields: ['id', 'first_name', 'last_name', 'email'],
-		});
-
-		for (const mention of mentions) {
-			const userID = mention.substring(1);
-
-			const user = await this.usersService.readOne(userID, {
-				fields: ['id', 'first_name', 'last_name', 'email', 'role.id'],
-			});
-
-			const accountability: Accountability = {
-				user: userID,
-				role: user['role']?.id ?? null,
-				admin: false,
-				app: false,
-				roles: await fetchRolesTree(user['role']?.id ?? null, { knex: this.knex }),
-				ip: null,
-			};
-
-			const userGlobalAccess = await fetchGlobalAccess(accountability, { knex: this.knex });
-
-			accountability.admin = userGlobalAccess.admin;
-			accountability.app = userGlobalAccess.app;
-
-			const usersService = new UsersService({ schema: this.schema, accountability });
-
-			try {
+			if (this.accountability) {
 				await validateAccess(
 					{
-						accountability,
+						accountability: this.accountability,
 						action: 'read',
-						collection: data['collection']!,
-						primaryKeys: [data['item']!],
+						collection: item['collection'],
+						primaryKeys: [item['item']],
 					},
 					{
 						schema: this.schema,
 						knex: this.knex,
 					},
 				);
+			}
 
-				const templateData = await usersService.readByQuery({
-					fields: ['id', 'first_name', 'last_name', 'email'],
-					filter: { id: { _in: mentions.map((mention) => mention.substring(1)) } },
+			const [result] = await super.createMany([item], opts);
+
+			const usersRegExp = new RegExp(/@[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}/gi);
+
+			const mentions = uniq(item['comment'].match(usersRegExp) ?? []);
+
+			if (mentions.length === 0) {
+				results.push(result!);
+				continue;
+			}
+
+			const sender = await this.usersService.readOne(this.accountability.user, {
+				fields: ['id', 'first_name', 'last_name', 'email'],
+			});
+
+			for (const mention of mentions) {
+				const userID = mention.substring(1);
+
+				const user = await this.usersService.readOne(userID, {
+					fields: ['id', 'first_name', 'last_name', 'email', 'role.id'],
 				});
 
-				const userPreviews = templateData.reduce(
-					(acc, user) => {
-						acc[user['id']] = `<em>${userName(user)}</em>`;
-						return acc;
-					},
-					{} as Record<string, string>,
-				);
+				const accountability: Accountability = {
+					user: userID,
+					role: user['role']?.id ?? null,
+					admin: false,
+					app: false,
+					roles: await fetchRolesTree(user['role']?.id ?? null, { knex: this.knex }),
+					ip: null,
+				};
 
-				let comment = data['comment']!;
+				const userGlobalAccess = await fetchGlobalAccess(accountability, { knex: this.knex });
 
-				for (const mention of mentions) {
-					const uuid = mention.substring(1);
-					// We only match on UUIDs in the first place. This is just an extra sanity check.
-					if (isValidUuid(uuid) === false) continue;
-					comment = comment.replace(new RegExp(mention, 'gm'), userPreviews[uuid] ?? '@Unknown User');
-				}
+				accountability.admin = userGlobalAccess.admin;
+				accountability.app = userGlobalAccess.app;
 
-				comment = `> ${comment.replace(/\n+/gm, '\n> ')}`;
+				const usersService = new UsersService({ schema: this.schema, accountability });
 
-				const href = new Url(env['PUBLIC_URL'] as string)
-					.addPath('admin', 'content', data['collection']!, data['item']!)
-					.toString();
+				try {
+					await validateAccess(
+						{
+							accountability,
+							action: 'read',
+							collection: item['collection'],
+							primaryKeys: [item['item']],
+						},
+						{
+							schema: this.schema,
+							knex: this.knex,
+						},
+					);
 
-				const message = `
+					const templateData = await usersService.readByQuery({
+						fields: ['id', 'first_name', 'last_name', 'email'],
+						filter: { id: { _in: mentions.map((mention) => mention.substring(1)) } },
+					});
+
+					const userPreviews = templateData.reduce(
+						(acc, user) => {
+							acc[user['id']] = `<em>${userName(user)}</em>`;
+							return acc;
+						},
+						{} as Record<string, string>,
+					);
+
+					let comment = item['comment'];
+
+					for (const mention of mentions) {
+						const uuid = mention.substring(1);
+						// We only match on UUIDs in the first place. This is just an extra sanity check.
+						if (isValidUuid(uuid) === false) continue;
+						comment = comment.replace(new RegExp(mention, 'gm'), userPreviews[uuid] ?? '@Unknown User');
+					}
+
+					comment = `> ${comment.replace(/\n+/gm, '\n> ')}`;
+
+					const href = new Url(env['PUBLIC_URL'] as string)
+						.addPath('admin', 'content', item['collection'], item['item'])
+						.toString();
+
+					const message = `
 Hello ${userName(user)},
 
 ${userName(sender)} has mentioned you in a comment:
@@ -161,22 +149,27 @@ ${comment}
 <a href="${href}">Click here to view.</a>
 `;
 
-				await this.notificationsService.createOne({
-					recipient: userID,
-					sender: sender['id'],
-					subject: `You were mentioned in ${data['collection']}`,
-					message,
-					collection: data['collection']!,
-					item: data['item']!,
-				});
-			} catch (err: any) {
-				if (isDirectusError(err, ErrorCode.Forbidden)) {
-					logger.warn(`User ${userID} doesn't have proper permissions to receive notification for this item.`);
-				} else {
-					throw err;
+					await this.notificationsService.createOne({
+						recipient: userID,
+						sender: sender['id'],
+						subject: `You were mentioned in ${item['collection']}`,
+						message,
+						collection: item['collection'],
+						item: item['item'],
+					});
+				} catch (err: any) {
+					if (isDirectusError(err, ErrorCode.Forbidden)) {
+						logger.warn(`User ${userID} doesn't have proper permissions to receive notification for this item.`);
+					} else {
+						throw err;
+					}
 				}
 			}
+
+			results.push(result!);
 		}
+
+		return results;
 	}
 
 	override updateOne(key: PrimaryKey, data: Partial<Comment>, opts?: MutationOptions): Promise<PrimaryKey> {

--- a/api/src/services/comments.ts
+++ b/api/src/services/comments.ts
@@ -26,28 +26,32 @@ export class CommentsService extends ItemsService {
 		this.usersService = new UsersService({ schema: this.schema });
 	}
 
-	override async createOne(data: Partial<Comment>, opts?: MutationOptions): Promise<PrimaryKey> {
+	override async createMany(data: Partial<Comment>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
 		if (!this.accountability?.user) throw new ForbiddenError();
 
-		if (!data['comment']) {
-			throw new InvalidPayloadError({ reason: `"comment" is required` });
-		}
+		// Pre-insert: validate every payload before any insert runs so a bad row
+		// aborts the batch cleanly. `ItemsService.createMany` is the single insert
+		// path now (`createOne` wraps it), so this is the only place per-row
+		// validation can live.
+		for (const item of data) {
+			if (!item['comment']) {
+				throw new InvalidPayloadError({ reason: `"comment" is required` });
+			}
 
-		if (!data['collection']) {
-			throw new InvalidPayloadError({ reason: `"collection" is required` });
-		}
+			if (!item['collection']) {
+				throw new InvalidPayloadError({ reason: `"collection" is required` });
+			}
 
-		if (!data['item']) {
-			throw new InvalidPayloadError({ reason: `"item" is required` });
-		}
+			if (!item['item']) {
+				throw new InvalidPayloadError({ reason: `"item" is required` });
+			}
 
-		if (this.accountability) {
 			await validateAccess(
 				{
 					accountability: this.accountability,
 					action: 'read',
-					collection: data['collection'],
-					primaryKeys: [data['item']],
+					collection: item['collection'],
+					primaryKeys: [item['item']],
 				},
 				{
 					schema: this.schema,
@@ -56,14 +60,26 @@ export class CommentsService extends ItemsService {
 			);
 		}
 
-		const result = await super.createOne(data, opts);
+		const result = await super.createMany(data, opts);
+
+		// Post-insert: process @mentions per row. Errors per mention are swallowed
+		// (warn-and-continue) inside `sendMentionNotifications`.
+		for (const item of data) {
+			await this.sendMentionNotifications(item);
+		}
+
+		return result;
+	}
+
+	private async sendMentionNotifications(data: Partial<Comment>): Promise<void> {
+		if (!this.accountability?.user) return;
 
 		const usersRegExp = new RegExp(/@[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}/gi);
 
-		const mentions = uniq(data['comment'].match(usersRegExp) ?? []);
+		const mentions = uniq(data['comment']!.match(usersRegExp) ?? []);
 
 		if (mentions.length === 0) {
-			return result;
+			return;
 		}
 
 		const sender = await this.usersService.readOne(this.accountability.user, {
@@ -98,8 +114,8 @@ export class CommentsService extends ItemsService {
 					{
 						accountability,
 						action: 'read',
-						collection: data['collection'],
-						primaryKeys: [data['item']],
+						collection: data['collection']!,
+						primaryKeys: [data['item']!],
 					},
 					{
 						schema: this.schema,
@@ -120,7 +136,7 @@ export class CommentsService extends ItemsService {
 					{} as Record<string, string>,
 				);
 
-				let comment = data['comment'];
+				let comment = data['comment']!;
 
 				for (const mention of mentions) {
 					const uuid = mention.substring(1);
@@ -132,7 +148,7 @@ export class CommentsService extends ItemsService {
 				comment = `> ${comment.replace(/\n+/gm, '\n> ')}`;
 
 				const href = new Url(env['PUBLIC_URL'] as string)
-					.addPath('admin', 'content', data['collection'], data['item'])
+					.addPath('admin', 'content', data['collection']!, data['item']!)
 					.toString();
 
 				const message = `
@@ -150,8 +166,8 @@ ${comment}
 					sender: sender['id'],
 					subject: `You were mentioned in ${data['collection']}`,
 					message,
-					collection: data['collection'],
-					item: data['item'],
+					collection: data['collection']!,
+					item: data['item']!,
 				});
 			} catch (err: any) {
 				if (isDirectusError(err, ErrorCode.Forbidden)) {
@@ -161,8 +177,6 @@ ${comment}
 				}
 			}
 		}
-
-		return result;
 	}
 
 	override updateOne(key: PrimaryKey, data: Partial<Comment>, opts?: MutationOptions): Promise<PrimaryKey> {

--- a/api/src/services/files.test.ts
+++ b/api/src/services/files.test.ts
@@ -68,12 +68,6 @@ describe('Service / Files', () => {
 				schema: { collections: {}, relations: [] },
 			});
 
-			// `createOne` is a thin `[pk] = await this.createMany([data])` wrapper
-			// since the batchInsert refactor. The shared `mockItemsService` test
-			// helper mocks createOne to a no-op spy, which would short-circuit the
-			// wrapper before FilesService.createMany's validation runs — patch the
-			// mock here to flow through to createMany so these tests still cover
-			// the FilesService override.
 			vi.mocked(ItemsService.prototype.createOne).mockImplementation(async function (this: ItemsService, data, opts) {
 				const [pk] = await this.createMany([data], opts ?? {});
 				return pk as PrimaryKey;

--- a/api/src/services/files.test.ts
+++ b/api/src/services/files.test.ts
@@ -214,6 +214,71 @@ describe('Service / Files', () => {
 				{},
 			);
 		});
+
+		test('throws InvalidPayloadError when any file in a multi-file payload is missing "type"', async () => {
+			try {
+				await service.createMany([
+					{ type: 'application/octet-stream', filename_download: 'good.txt' },
+					{ storage: 'local', filename_download: 'no-type.txt' },
+				]);
+			} catch (err: any) {
+				expect(err).toBeInstanceOf(InvalidPayloadError);
+				expect(err.message).toBe('Invalid payload. "type" is required.');
+			}
+
+			expect(ItemsService.prototype.createMany).not.toHaveBeenCalled();
+		});
+
+		test('should throw ForbiddenError deferred when any filename_disk in a multi-file payload is not unique', async () => {
+			tracker.on
+				.select('select "filename_disk" from "directus_files" where "filename_disk" = ?')
+				.response([{ filename_disk: 'existing-file.jpg' }]);
+
+			await service.createMany([
+				{ type: 'application/octet-stream', filename_disk: 'first-file.jpg' },
+				{ type: 'application/octet-stream', filename_disk: 'second-file.jpg' },
+			]);
+
+			expect(ItemsService.prototype.createMany).toHaveBeenCalledWith(
+				[
+					{ type: 'application/octet-stream', filename_disk: 'first-file.jpg' },
+					{ type: 'application/octet-stream', filename_disk: 'second-file.jpg' },
+				],
+				expect.objectContaining({ preMutationError: expect.any(ForbiddenError) }),
+			);
+		});
+
+		test('creates multiple file entries when all "type" fields are provided', async () => {
+			await service.createMany([
+				{ type: 'application/octet-stream', filename_download: 'first.txt' },
+				{ type: 'image/jpeg', filename_download: 'second.jpg' },
+			]);
+
+			expect(ItemsService.prototype.createMany).toHaveBeenCalledWith(
+				[
+					{ type: 'application/octet-stream', filename_download: 'first.txt' },
+					{ type: 'image/jpeg', filename_download: 'second.jpg' },
+				],
+				{},
+			);
+		});
+
+		test('should normalize each filename_disk path in a multi-file payload', async () => {
+			tracker.on.select('select "filename_disk" from "directus_files" where "filename_disk" = ?').response([]);
+
+			await service.createMany([
+				{ type: 'application/octet-stream', filename_disk: '/folder/../first.jpg' },
+				{ type: 'application/octet-stream', filename_disk: '/other/../second.jpg' },
+			]);
+
+			expect(ItemsService.prototype.createMany).toHaveBeenCalledWith(
+				[
+					{ type: 'application/octet-stream', filename_disk: 'first.jpg' },
+					{ type: 'application/octet-stream', filename_disk: 'second.jpg' },
+				],
+				{},
+			);
+		});
 	});
 
 	describe('uploadOne', () => {

--- a/api/src/services/files.test.ts
+++ b/api/src/services/files.test.ts
@@ -58,7 +58,11 @@ describe('Service / Files', () => {
 		resetKnexMocks(tracker, mockSchemaBuilder);
 	});
 
-	describe('createOne', () => {
+	// Since the batchInsert refactor, `createOne` is a thin `await createMany([data])`
+	// wrapper on `ItemsService`. FilesService's per-row validation moved to its
+	// `createMany` override — so these assertions spy on `createMany` rather than
+	// `createOne` to verify what the override forwarded to the parent class.
+	describe('createMany', () => {
 		let service: FilesService;
 
 		beforeEach(() => {
@@ -70,17 +74,19 @@ describe('Service / Files', () => {
 
 		test('throws InvalidPayloadError when "type" is not provided', async () => {
 			try {
-				await service.createOne({
-					title: 'Test File',
-					storage: 'local',
-					filename_download: 'test_file',
-				});
+				await service.createMany([
+					{
+						title: 'Test File',
+						storage: 'local',
+						filename_download: 'test_file',
+					},
+				]);
 			} catch (err: any) {
 				expect(err).toBeInstanceOf(InvalidPayloadError);
 				expect(err.message).toBe('Invalid payload. "type" is required.');
 			}
 
-			expect(ItemsService.prototype.createOne).not.toHaveBeenCalled();
+			expect(ItemsService.prototype.createMany).not.toHaveBeenCalled();
 		});
 
 		test('should throw ForbiddenError deferred when filename_disk is not unique', async () => {
@@ -88,41 +94,49 @@ describe('Service / Files', () => {
 				.select('select "filename_disk" from "directus_files" where "filename_disk" = ?')
 				.response([{ filename_disk: 'existing-file.jpg' }]);
 
-			await service.createOne({
-				type: 'application/octet-stream',
-				filename_disk: 'existing-file.jpg',
-			});
-
-			expect(ItemsService.prototype.createOne).toHaveBeenCalledWith(
+			await service.createMany([
 				{
 					type: 'application/octet-stream',
 					filename_disk: 'existing-file.jpg',
 				},
+			]);
+
+			expect(ItemsService.prototype.createMany).toHaveBeenCalledWith(
+				[
+					{
+						type: 'application/octet-stream',
+						filename_disk: 'existing-file.jpg',
+					},
+				],
 				expect.objectContaining({ preMutationError: expect.any(ForbiddenError) }),
 			);
 		});
 
 		test('creates a file entry when "type" is provided', async () => {
-			await service.createOne({
-				title: 'Test File',
-				storage: 'local',
-				filename_download: 'test_file',
-				type: 'application/octet-stream',
-			});
+			await service.createMany([
+				{
+					title: 'Test File',
+					storage: 'local',
+					filename_download: 'test_file',
+					type: 'application/octet-stream',
+				},
+			]);
 
-			expect(ItemsService.prototype.createOne).toHaveBeenCalled();
+			expect(ItemsService.prototype.createMany).toHaveBeenCalled();
 		});
 
 		test('should normalize filename_disk path', async () => {
 			tracker.on.select('select "filename_disk" from "directus_files" where "filename_disk" = ?').response([]);
 
-			await service.createOne({
-				type: 'application/octet-stream',
-				filename_disk: '/folder/../new-file.jpg',
-			});
+			await service.createMany([
+				{
+					type: 'application/octet-stream',
+					filename_disk: '/folder/../new-file.jpg',
+				},
+			]);
 
-			expect(ItemsService.prototype.createOne).toHaveBeenCalledWith(
-				{ filename_disk: 'new-file.jpg', type: 'application/octet-stream' },
+			expect(ItemsService.prototype.createMany).toHaveBeenCalledWith(
+				[{ filename_disk: 'new-file.jpg', type: 'application/octet-stream' }],
 				{},
 			);
 		});

--- a/api/src/services/files.test.ts
+++ b/api/src/services/files.test.ts
@@ -2,6 +2,7 @@ import { PassThrough, Readable } from 'node:stream';
 import { useEnv } from '@directus/env';
 import { ForbiddenError, InternalServerError, InvalidPayloadError, ServiceUnavailableError } from '@directus/errors';
 import { Driver, StorageManager } from '@directus/storage';
+import type { PrimaryKey } from '@directus/types';
 import { afterEach, beforeEach, describe, expect, it, type MockInstance, test, vi } from 'vitest';
 import { getAxios } from '../request/index.js';
 import { getStorage } from '../storage/index.js';
@@ -58,10 +59,89 @@ describe('Service / Files', () => {
 		resetKnexMocks(tracker, mockSchemaBuilder);
 	});
 
-	// Since the batchInsert refactor, `createOne` is a thin `await createMany([data])`
-	// wrapper on `ItemsService`. FilesService's per-row validation moved to its
-	// `createMany` override — so these assertions spy on `createMany` rather than
-	// `createOne` to verify what the override forwarded to the parent class.
+	describe('createOne', () => {
+		let service: FilesService;
+
+		beforeEach(() => {
+			service = new FilesService({
+				knex: db,
+				schema: { collections: {}, relations: [] },
+			});
+
+			// `createOne` is a thin `[pk] = await this.createMany([data])` wrapper
+			// since the batchInsert refactor. The shared `mockItemsService` test
+			// helper mocks createOne to a no-op spy, which would short-circuit the
+			// wrapper before FilesService.createMany's validation runs — patch the
+			// mock here to flow through to createMany so these tests still cover
+			// the FilesService override.
+			vi.mocked(ItemsService.prototype.createOne).mockImplementation(async function (this: ItemsService, data, opts) {
+				const [pk] = await this.createMany([data], opts ?? {});
+				return pk as PrimaryKey;
+			});
+		});
+
+		test('throws InvalidPayloadError when "type" is not provided', async () => {
+			try {
+				await service.createOne({
+					title: 'Test File',
+					storage: 'local',
+					filename_download: 'test_file',
+				});
+			} catch (err: any) {
+				expect(err).toBeInstanceOf(InvalidPayloadError);
+				expect(err.message).toBe('Invalid payload. "type" is required.');
+			}
+
+			expect(ItemsService.prototype.createMany).not.toHaveBeenCalled();
+		});
+
+		test('should throw ForbiddenError deferred when filename_disk is not unique', async () => {
+			tracker.on
+				.select('select "filename_disk" from "directus_files" where "filename_disk" = ?')
+				.response([{ filename_disk: 'existing-file.jpg' }]);
+
+			await service.createOne({
+				type: 'application/octet-stream',
+				filename_disk: 'existing-file.jpg',
+			});
+
+			expect(ItemsService.prototype.createMany).toHaveBeenCalledWith(
+				[
+					{
+						type: 'application/octet-stream',
+						filename_disk: 'existing-file.jpg',
+					},
+				],
+				expect.objectContaining({ preMutationError: expect.any(ForbiddenError) }),
+			);
+		});
+
+		test('creates a file entry when "type" is provided', async () => {
+			await service.createOne({
+				title: 'Test File',
+				storage: 'local',
+				filename_download: 'test_file',
+				type: 'application/octet-stream',
+			});
+
+			expect(ItemsService.prototype.createMany).toHaveBeenCalled();
+		});
+
+		test('should normalize filename_disk path', async () => {
+			tracker.on.select('select "filename_disk" from "directus_files" where "filename_disk" = ?').response([]);
+
+			await service.createOne({
+				type: 'application/octet-stream',
+				filename_disk: '/folder/../new-file.jpg',
+			});
+
+			expect(ItemsService.prototype.createMany).toHaveBeenCalledWith(
+				[{ filename_disk: 'new-file.jpg', type: 'application/octet-stream' }],
+				{},
+			);
+		});
+	});
+
 	describe('createMany', () => {
 		let service: FilesService;
 

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -337,24 +337,28 @@ export class FilesService extends ItemsService<File> {
 	/**
 	 * Create a file
 	 */
-	override async createOne(data: Partial<File>, opts: MutationOptions = {}): Promise<PrimaryKey> {
-		if (!data.type) {
-			throw new InvalidPayloadError({ reason: `"type" is required` });
-		}
+	override async createMany(data: Partial<File>[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
+		// `ItemsService.createMany` is the single insert path now (`createOne` wraps
+		// it); run the per-row validation + filename rewrite up front so a bad row
+		// aborts the whole batch before any insert happens.
+		for (const item of data) {
+			if (!item.type) {
+				throw new InvalidPayloadError({ reason: `"type" is required` });
+			}
 
-		if (data.filename_disk) {
-			data.filename_disk = this.generateFilenamePath(data.filename_disk);
+			if (item.filename_disk) {
+				item.filename_disk = this.generateFilenamePath(item.filename_disk);
 
-			try {
-				await this.checkUniqueFilename(data.filename_disk);
-			} catch (err: any) {
-				// Defer the error to be thrown until after permission checks
-				opts.preMutationError = err;
+				try {
+					await this.checkUniqueFilename(item.filename_disk);
+				} catch (err: any) {
+					// Defer the error to be thrown until after permission checks
+					opts.preMutationError = err;
+				}
 			}
 		}
 
-		const key = await super.createOne(data, opts);
-		return key;
+		return super.createMany(data, opts);
 	}
 
 	/**

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -338,9 +338,6 @@ export class FilesService extends ItemsService<File> {
 	 * Create a file
 	 */
 	override async createMany(data: Partial<File>[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
-		// `ItemsService.createMany` is the single insert path now (`createOne` wraps
-		// it); run the per-row validation + filename rewrite up front so a bad row
-		// aborts the whole batch before any insert happens.
 		for (const item of data) {
 			if (!item.type) {
 				throw new InvalidPayloadError({ reason: `"type" is required` });

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -287,26 +287,12 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				if (useBatchInsert) {
 					const chunkSize = env['DB_BATCH_INSERT_CHUNK_SIZE'] as number | undefined;
 
-					// SQLite batchInsert workaround (https://github.com/knex/knex/issues/332):
-					// - knex normalizes columns across all rows in the chunk.
-					// - Columns missing from a row are bound as `undefined`.
-					// - The sqlite3 driver translates that to `NULL` and the insert fails for
-					//   non-nullable columns.
-					// Spread per-column defaults for non-nullable fields first so the payload
-					// only overrides what it explicitly sets.
-					const isSqlite = getDatabaseClient(trx) === 'sqlite';
-					const collectionFieldsSchema = this.schema.collections[this.collection]!.fields;
-
-					const sqliteFieldsRequiringValue: Record<string, unknown> = isSqlite
-						? Object.fromEntries(
-								Object.entries(collectionFieldsSchema)
-									.filter(([fieldName, field]) => fieldName !== primaryKeyField && field.nullable === false)
-									.map(([fieldName, field]) => [fieldName, field.defaultValue]),
-							)
-						: {};
-
-					const rowsToInsert = prepared.map((p) =>
-						isSqlite ? { ...sqliteFieldsRequiringValue, ...p.payloadWithoutAliases } : p.payloadWithoutAliases,
+					const rowsToInsert = getHelpers(trx).capabilities.padRowsForBatchInsert(
+						prepared.map((p) => p.payloadWithoutAliases),
+						{
+							fields: this.schema.collections[this.collection]!.fields,
+							primaryKeyField,
+						},
 					);
 
 					const insertedRows = (await trx

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -179,6 +179,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			for (const [index, payloadInput] of data.entries()) {
 				const payload: AnyItem = cloneDeep(payloadInput);
 
+				// Run all hooks that are attached to this event so the end user has the chance to augment the
+				// item that is about to be saved
 				const payloadAfterHooks =
 					opts.emitEvents !== false
 						? await emitter.emitFilter(
@@ -212,8 +214,10 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					throw opts.preMutationError;
 				}
 
+				// Ensure the action hook payload has the post filter hook + preset changes
 				const actionHookPayload = payloadWithPresets;
 
+				// We're creating new services instances so they can use the transaction as their Knex interface
 				const payloadService = new PayloadService(this.collection, {
 					accountability: this.accountability,
 					knex: trx,
@@ -239,12 +243,17 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				const payloadWithoutAliases = pick(payloadWithA2O, without(fields, ...aliases));
 				const payloadWithTypeCasting = await payloadService.processValues('create', payloadWithoutAliases);
 
+				// The primary key can already exist in the payload.
+				// In case of manual string / UUID primary keys it's always provided at this point.
+				// In case of an (big) integer primary key, it might be provided as the user can specify the value manually.
 				const primaryKey: PrimaryKey | undefined = payloadWithTypeCasting[primaryKeyField];
 
 				if (primaryKey) {
 					validateKeys(this.schema, this.collection, primaryKeyField, primaryKey);
 				}
 
+				// If a PK of type number was provided, although the PK is set the auto_increment,
+				// depending on the database, the sequence might need to be reset to protect future PK collisions.
 				if (
 					primaryKey &&
 					pkField &&
@@ -347,14 +356,18 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 							p.primaryKey = (p.primaryKey ?? returnedKey) as PrimaryKey;
 						}
 
+						// Most database support returning, those who don't tend to return the PK anyways
+						// (MySQL/SQLite). In case the primary key isn't know yet, we'll do a best-attempt at
+						// fetching it based on the last inserted row
 						if (!p.primaryKey) {
-							// Best-effort PK lookup for vendors / driver paths where
-							// RETURNING didn't surface one (legacy MySQL / SQLite).
+							// Fetching it with max should be safe, as we're in the context of the current transaction
 							const maxResult = await trx.max(primaryKeyField, { as: 'id' }).from(this.collection).first();
 
 							p.primaryKey = maxResult?.id;
 						}
 
+						// Set the primary key on the input item, in order for the "after" event hook to be able
+						// to read from it
 						p.actionHookPayload[primaryKeyField] = p.primaryKey;
 					}
 				}
@@ -362,6 +375,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				const dbError = await translateDatabaseError(err, data);
 
 				if (isDirectusError(dbError, ErrorCode.RecordNotUnique) && dbError.extensions.primaryKey) {
+					// This is a MySQL specific thing we need to handle here, since MySQL does not return the field name
+					// if the unique constraint is the primary key
 					dbError.extensions.field = pkField?.field ?? null;
 					delete dbError.extensions.primaryKey;
 				}
@@ -378,6 +393,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			const postPrepared: PostRow[] = [];
 
 			for (const p of prepared) {
+				// At this point, the primary key is guaranteed to be set.
 				const primaryKey = p.primaryKey as PrimaryKey;
 
 				const {
@@ -407,6 +423,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				}
 			}
 
+			// If this is an authenticated action, and accountability tracking is enabled, save activity row
 			if (
 				opts.skipTracking !== true &&
 				this.accountability &&
@@ -429,6 +446,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					})),
 				);
 
+				// If revisions are tracked, create revisions record
 				if (this.schema.collections[this.collection]!.accountability === 'all') {
 					const revisionsService = new RevisionsService({ knex: trx, schema: this.schema });
 					const relationalFields = getRelationsForCollection(this.schema, this.collection);
@@ -452,6 +470,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					for (let i = 0; i < postPrepared.length; i++) {
 						const p = postPrepared[i]!;
 						const revisionId = revisionIds[i]!;
+						// Make sure to set the parent field of the child-revision rows
 						const childrenRevisions = [...p.revisionsM2O, ...p.revisionsA2O, ...p.revisionsO2M];
 
 						if (childrenRevisions.length > 0) {

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -24,7 +24,7 @@ import { getCache } from '../cache.js';
 import { translateDatabaseError } from '../database/errors/translate.js';
 import { getAstFromQuery } from '../database/get-ast-from-query/get-ast-from-query.js';
 import { getHelpers } from '../database/helpers/index.js';
-import getDatabase, { getDatabaseClient } from '../database/index.js';
+import getDatabase from '../database/index.js';
 import { runAst } from '../database/run-ast/run-ast.js';
 import emitter from '../emitter.js';
 import { processAst } from '../permissions/modules/process-ast/process-ast.js';
@@ -319,12 +319,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 						p.actionHookPayload[primaryKeyField] = p.primaryKey;
 					}
 				} else {
-					let returningOptions: { includeTriggerModifications: true } | undefined;
-
-					// Support MSSQL tables that have triggers.
-					if (getDatabaseClient(trx) === 'mssql') {
-						returningOptions = { includeTriggerModifications: true };
-					}
+					const returningOptions = getHelpers(trx).capabilities.insertReturningOptions();
 
 					for (const p of prepared) {
 						const result = await trx

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -287,11 +287,13 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				if (useBatchInsert) {
 					const chunkSize = env['DB_BATCH_INSERT_CHUNK_SIZE'] as number | undefined;
 
-					// SQLite's batchInsert path normalizes columns across all rows in the
-					// chunk; columns missing from a row are bound as `undefined`, which the
-					// driver translates to `NULL` and fails for non-nullable fields. Spread
-					// per-column defaults for non-nullable fields first so the payload only
-					// overrides what it explicitly sets. https://github.com/knex/knex/issues/332
+					// SQLite batchInsert workaround (https://github.com/knex/knex/issues/332):
+					// - knex normalizes columns across all rows in the chunk.
+					// - Columns missing from a row are bound as `undefined`.
+					// - The sqlite3 driver translates that to `NULL` and the insert fails for
+					//   non-nullable columns.
+					// Spread per-column defaults for non-nullable fields first so the payload
+					// only overrides what it explicitly sets.
 					const isSqlite = getDatabaseClient(trx) === 'sqlite';
 					const collectionFieldsSchema = this.schema.collections[this.collection]!.fields;
 
@@ -568,24 +570,28 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				: query;
 
 		// Default to ORDER BY <primary key> ASC for integer / bigInteger PKs when no
-		// explicit sort was requested. Auto-increment integer PKs encode insertion
-		// order, so this restores temporal ordering that batch insert broke: rows in
-		// the same transaction share `date_created` (NOW() per transaction), breaking
-		// consumers that relied on date_created as a stable tiebreaker.
+		// explicit sort was requested.
 		//
-		// UUID / string PKs are deliberately excluded — sorting by a random UUID or a
-		// user-supplied string is deterministic but not semantically meaningful, so
-		// changing the default for those collections would be a surprise with no
-		// payoff. Callers can still pass an explicit `sort` for any pkType.
+		// - Why this restores ordering broken by batch insert:
+		//   - Auto-increment integer PKs encode insertion order.
+		//   - Batch insert collapses N transactions into one, so all rows share
+		//     `date_created` (NOW() per transaction).
+		//   - That breaks consumers that relied on `date_created` as a stable tiebreaker.
 		//
-		// Skipped also when the query uses `group` or `aggregate`: ORDER BY a column
-		// not in the GROUP BY / aggregate list is a SQL error on every dialect.
+		// - Excluded cases (deliberately not defaulted):
+		//   - UUID / string PKs — sorting by a random UUID or user-supplied string is
+		//     deterministic but not semantically meaningful; changing the default for
+		//     those collections would be a surprise with no payoff.
+		//   - Queries using `group` or `aggregate` — `ORDER BY` a column not in the
+		//     `GROUP BY` / aggregate list is a SQL error on every dialect.
+		//   - Callers can still pass an explicit `sort` for any pkType.
 		//
-		// Disable via DB_DEFAULT_ORDER_READS_BY_PK=false to restore the prior behavior
-		// (e.g. while you migrate existing queries to pass their own sort).
+		// - Escape hatch: disable via `DB_DEFAULT_ORDER_READS_BY_PK=false` (e.g. while
+		//   migrating existing queries to pass their own sort).
 		//
-		// Note: `updatedQuery` returned by emitFilter is frozen / non-extensible, so
-		// we replace the reference with a spread instead of mutating in place.
+		// - Implementation note: `updatedQuery` returned by emitFilter is frozen /
+		//   non-extensible, so we replace the reference with a spread instead of
+		//   mutating in place.
 		if (
 			env['DB_DEFAULT_ORDER_READS_BY_PK'] &&
 			!updatedQuery.sort?.length &&

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -16,7 +16,7 @@ import type {
 	SchemaOverview,
 } from '@directus/types';
 import { UserIntegrityCheckFlag } from '@directus/types';
-import { getRelationsForCollection } from '@directus/utils';
+import { getRelationsForCollection, toBoolean } from '@directus/utils';
 import type Keyv from 'keyv';
 import type { Knex } from 'knex';
 import { assign, clone, cloneDeep, difference, omit, pick, without } from 'lodash-es';
@@ -166,7 +166,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 								schema: this.schema,
 								accountability: this.accountability,
 							},
-						)
+					  )
 					: payload;
 
 			const payloadWithPresets = this.accountability
@@ -182,7 +182,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 							knex: trx,
 							schema: this.schema,
 						},
-					)
+				  )
 				: payloadAfterHooks;
 
 			if (opts.preMutationError) {
@@ -426,14 +426,33 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	}
 
 	/**
-	 * Create multiple new items at once. Inserts all provided records sequentially wrapped in a transaction.
+	 * Create multiple new items at once, wrapped in a transaction.
 	 *
-	 * Uses `this.createOne` under the hood.
+	 * Fast path: vendors whose `INSERT … RETURNING` is contractually ordered
+	 * (see `CapabilitiesHelper.preservesInsertOrderInReturning`) use a single
+	 * `knex.batchInsert` and map the returned PKs back positionally.
+	 *
+	 * Fallback: per-row `this.createOne` loop (identical to the pre-batchInsert
+	 * implementation), used for MySQL/MariaDB and other vendors where RETURNING
+	 * order isn't guaranteed.
+	 *
+	 * The `DB_BATCH_INSERT_CHUNK_SIZE` env var (knex passthrough, default 1000)
+	 * tunes the fast path; `DB_MSSQL_TRUST_BATCH_RETURNING` opts MSSQL into it.
 	 */
 	async createMany(data: Partial<Item>[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
 
+		if (data.length === 0) {
+			return [];
+		}
+
 		const { primaryKeys, nestedActionEvents } = await transaction(this.knex, async (knex) => {
+			const useBatchInsert = data.length > 1 && (await getHelpers(knex).capabilities.preservesInsertOrderInReturning());
+
+			if (useBatchInsert) {
+				return await this.createManyBatched(data, opts, knex);
+			}
+
 			const service = this.fork({ knex });
 
 			let userIntegrityCheckFlags = opts.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None;
@@ -494,10 +513,324 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	}
 
 	/**
+	 * Batched `createMany` fast path: prep every payload up front, run one
+	 * multi-row INSERT (`knex.batchInsert`), then process O2M / activity /
+	 * revisions in bulk. Only safe for vendors where RETURNING preserves
+	 * insertion order — gated by `CapabilitiesHelper.preservesInsertOrderInReturning`.
+	 */
+	private async createManyBatched(
+		data: Partial<Item>[],
+		opts: MutationOptions,
+		trx: Knex.Transaction,
+	): Promise<{ primaryKeys: PrimaryKey[]; nestedActionEvents: ActionEventParams[] }> {
+		if (!opts.bypassLimits) {
+			opts.mutationTracker!.trackMutations(data.length);
+		}
+
+		const primaryKeyField = this.schema.collections[this.collection]!.primary;
+		const fields = Object.keys(this.schema.collections[this.collection]!.fields);
+
+		const aliases = Object.values(this.schema.collections[this.collection]!.fields)
+			.filter((field) => field.alias === true)
+			.map((field) => field.field);
+
+		const pkField = this.schema.collections[this.collection]!.fields[primaryKeyField];
+
+		const nestedActionEvents: ActionEventParams[] = [];
+		let userIntegrityCheckFlags = opts.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None;
+		let autoIncrementSequenceNeedsToBeReset = false;
+
+		type PreparedRow = {
+			actionHookPayload: AnyItem;
+			payloadAfterHooks: AnyItem;
+			payloadWithPresets: AnyItem;
+			payloadWithoutAliases: Record<string, unknown>;
+			primaryKey: PrimaryKey | undefined;
+			revisionsM2O: Awaited<ReturnType<PayloadService['processM2O']>>['revisions'];
+			revisionsA2O: Awaited<ReturnType<PayloadService['processA2O']>>['revisions'];
+			nestedActionEventsM2O: ActionEventParams[];
+			nestedActionEventsA2O: ActionEventParams[];
+			userIntegrityCheckFlagsM2O: UserIntegrityCheckFlag;
+			userIntegrityCheckFlagsA2O: UserIntegrityCheckFlag;
+			payloadService: PayloadService;
+		};
+
+		const prepared: PreparedRow[] = [];
+
+		for (const [index, payloadInput] of data.entries()) {
+			const payload: AnyItem = cloneDeep(payloadInput);
+
+			const payloadAfterHooks =
+				opts.emitEvents !== false
+					? await emitter.emitFilter(
+							this.eventScope === 'items'
+								? ['items.create', `${this.collection}.items.create`]
+								: `${this.eventScope}.create`,
+							payload,
+							{ collection: this.collection },
+							{
+								database: trx,
+								schema: this.schema,
+								accountability: this.accountability,
+							},
+					  )
+					: payload;
+
+			const payloadWithPresets = this.accountability
+				? await processPayload(
+						{
+							accountability: this.accountability,
+							action: 'create',
+							collection: this.collection,
+							payload: payloadAfterHooks,
+							nested: this.nested,
+						},
+						{ knex: trx, schema: this.schema },
+				  )
+				: payloadAfterHooks;
+
+			if (opts.preMutationError) {
+				throw opts.preMutationError;
+			}
+
+			const actionHookPayload = payloadWithPresets;
+
+			const payloadService = new PayloadService(this.collection, {
+				accountability: this.accountability,
+				knex: trx,
+				schema: this.schema,
+				nested: this.nested,
+				overwriteDefaults: opts.overwriteDefaults?.[index],
+			});
+
+			const {
+				payload: payloadWithM2O,
+				revisions: revisionsM2O,
+				nestedActionEvents: nestedActionEventsM2O,
+				userIntegrityCheckFlags: userIntegrityCheckFlagsM2O,
+			} = await payloadService.processM2O(payloadWithPresets, opts);
+
+			const {
+				payload: payloadWithA2O,
+				revisions: revisionsA2O,
+				nestedActionEvents: nestedActionEventsA2O,
+				userIntegrityCheckFlags: userIntegrityCheckFlagsA2O,
+			} = await payloadService.processA2O(payloadWithM2O, opts);
+
+			const payloadWithoutAliases = pick(payloadWithA2O, without(fields, ...aliases));
+			const payloadWithTypeCasting = await payloadService.processValues('create', payloadWithoutAliases);
+
+			let primaryKey: PrimaryKey | undefined = payloadWithTypeCasting[primaryKeyField];
+
+			if (primaryKey) {
+				validateKeys(this.schema, this.collection, primaryKeyField, primaryKey);
+			}
+
+			if (
+				primaryKey &&
+				pkField &&
+				!opts.bypassAutoIncrementSequenceReset &&
+				['integer', 'bigInteger'].includes(pkField.type) &&
+				pkField.defaultValue === 'AUTO_INCREMENT'
+			) {
+				autoIncrementSequenceNeedsToBeReset = true;
+			}
+
+			prepared.push({
+				actionHookPayload,
+				payloadAfterHooks,
+				payloadWithPresets,
+				payloadWithoutAliases,
+				primaryKey,
+				revisionsM2O,
+				revisionsA2O,
+				nestedActionEventsM2O,
+				nestedActionEventsA2O,
+				userIntegrityCheckFlagsM2O,
+				userIntegrityCheckFlagsA2O,
+				payloadService,
+			});
+		}
+
+		try {
+			const rowsToInsert = prepared.map((p) => p.payloadWithoutAliases);
+
+			// undefined → knex default chunk size (1000): https://knexjs.org/guide/query-builder.html#batchinsert
+			const chunkSizeEnv = env['DB_BATCH_INSERT_CHUNK_SIZE'];
+			const chunkSize = chunkSizeEnv !== undefined ? Number(chunkSizeEnv) : undefined;
+
+			const insertedRows = (await trx
+				.batchInsert(this.collection, rowsToInsert, chunkSize)
+				.returning(primaryKeyField)) as unknown as Array<Record<string, unknown> | PrimaryKey>;
+
+			if (insertedRows.length !== prepared.length) {
+				throw new Error(`batchInsert returned ${insertedRows.length} rows but expected ${prepared.length}`);
+			}
+
+			for (let i = 0; i < prepared.length; i++) {
+				const row = insertedRows[i]!;
+				const p = prepared[i]!;
+
+				const returnedKey =
+					typeof row === 'object' && row !== null ? (row as Record<string, unknown>)[primaryKeyField] : row;
+
+				if (pkField?.type === 'uuid') {
+					p.primaryKey = getHelpers(trx).schema.formatUUID((p.primaryKey ?? (returnedKey as string)) as string);
+				} else {
+					p.primaryKey = (p.primaryKey ?? returnedKey) as PrimaryKey;
+				}
+
+				p.actionHookPayload[primaryKeyField] = p.primaryKey;
+			}
+		} catch (err: any) {
+			const dbError = await translateDatabaseError(err, data);
+
+			if (isDirectusError(dbError, ErrorCode.RecordNotUnique) && dbError.extensions.primaryKey) {
+				dbError.extensions.field = pkField?.field ?? null;
+				delete dbError.extensions.primaryKey;
+			}
+
+			throw dbError;
+		}
+
+		type PostRow = PreparedRow & {
+			primaryKey: PrimaryKey;
+			revisionsO2M: Awaited<ReturnType<PayloadService['processO2M']>>['revisions'];
+			nestedActionEventsO2M: ActionEventParams[];
+		};
+
+		const postPrepared: PostRow[] = [];
+
+		for (const p of prepared) {
+			const primaryKey = p.primaryKey as PrimaryKey;
+
+			const {
+				revisions: revisionsO2M,
+				nestedActionEvents: nestedActionEventsO2M,
+				userIntegrityCheckFlags: userIntegrityCheckFlagsO2M,
+			} = await p.payloadService.processO2M(p.payloadWithPresets, primaryKey, opts);
+
+			userIntegrityCheckFlags |=
+				p.userIntegrityCheckFlagsM2O | p.userIntegrityCheckFlagsA2O | userIntegrityCheckFlagsO2M;
+
+			nestedActionEvents.push(...p.nestedActionEventsM2O, ...p.nestedActionEventsA2O, ...nestedActionEventsO2M);
+
+			postPrepared.push({
+				...p,
+				primaryKey,
+				revisionsO2M,
+				nestedActionEventsO2M,
+			});
+		}
+
+		if (userIntegrityCheckFlags) {
+			if (opts.onRequireUserIntegrityCheck) {
+				opts.onRequireUserIntegrityCheck(userIntegrityCheckFlags);
+			} else {
+				await validateUserCountIntegrity({ flags: userIntegrityCheckFlags, knex: trx });
+			}
+		}
+
+		if (
+			opts.skipTracking !== true &&
+			this.accountability &&
+			this.schema.collections[this.collection]!.accountability !== null
+		) {
+			const { ActivityService } = await import('./activity.js');
+			const { RevisionsService } = await import('./revisions.js');
+
+			const activityService = new ActivityService({ knex: trx, schema: this.schema });
+
+			const activityIds = await activityService.createMany(
+				postPrepared.map((p) => ({
+					action: Action.CREATE,
+					user: this.accountability!.user,
+					collection: this.collection,
+					ip: this.accountability!.ip,
+					user_agent: this.accountability!.userAgent,
+					origin: this.accountability!.origin,
+					item: p.primaryKey,
+				})),
+			);
+
+			if (this.schema.collections[this.collection]!.accountability === 'all') {
+				const revisionsService = new RevisionsService({ knex: trx, schema: this.schema });
+				const relationalFields = getRelationsForCollection(this.schema, this.collection);
+
+				const revisionInputs = await Promise.all(
+					postPrepared.map(async (p, index) => {
+						const revisionPayload = await p.payloadService.prepareDelta(omit(p.payloadWithPresets, relationalFields));
+
+						return {
+							activity: activityIds[index]!,
+							collection: this.collection,
+							item: p.primaryKey,
+							data: revisionPayload,
+							delta: revisionPayload,
+						};
+					}),
+				);
+
+				const revisionIds = await revisionsService.createMany(revisionInputs);
+
+				for (let i = 0; i < postPrepared.length; i++) {
+					const p = postPrepared[i]!;
+					const revisionId = revisionIds[i]!;
+					const childrenRevisions = [...p.revisionsM2O, ...p.revisionsA2O, ...p.revisionsO2M];
+
+					if (childrenRevisions.length > 0) {
+						await revisionsService.updateMany(childrenRevisions, { parent: revisionId });
+					}
+
+					if (opts.onRevisionCreate) {
+						opts.onRevisionCreate(revisionId);
+					}
+				}
+			}
+		}
+
+		if (autoIncrementSequenceNeedsToBeReset) {
+			await getHelpers(trx).sequence.resetAutoIncrementSequence(this.collection, primaryKeyField);
+		}
+
+		if (opts.onItemCreate) {
+			for (const p of postPrepared) {
+				opts.onItemCreate(this.collection, p.primaryKey);
+			}
+		}
+
+		if (opts.emitEvents !== false) {
+			for (const p of postPrepared) {
+				nestedActionEvents.push({
+					event:
+						this.eventScope === 'items'
+							? ['items.create', `${this.collection}.items.create`]
+							: `${this.eventScope}.create`,
+					meta: {
+						payload: p.actionHookPayload,
+						key: p.primaryKey,
+						collection: this.collection,
+					},
+					context: {
+						database: getDatabase(),
+						schema: this.schema,
+						accountability: this.accountability,
+					},
+				});
+			}
+		}
+
+		return {
+			primaryKeys: postPrepared.map((p) => p.primaryKey),
+			nestedActionEvents,
+		};
+	}
+
+	/**
 	 * Get items by query.
 	 */
 	async readByQuery(query: Query, opts?: QueryOptions): Promise<Item[]> {
-		const updatedQuery =
+		let updatedQuery =
 			opts?.emitEvents !== false
 				? await emitter.emitFilter(
 						this.eventScope === 'items'
@@ -512,8 +845,41 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 							schema: this.schema,
 							accountability: this.accountability,
 						},
-					)
+				  )
 				: query;
+
+		// Default to ORDER BY <primary key> ASC for integer / bigInteger PKs when no
+		// explicit sort was requested. Auto-increment integer PKs encode insertion
+		// order, so this restores temporal ordering that batch insert broke: rows in
+		// the same transaction share `date_created` (NOW() per transaction), breaking
+		// consumers that relied on date_created as a stable tiebreaker.
+		//
+		// UUID / string PKs are deliberately excluded — sorting by a random UUID or a
+		// user-supplied string is deterministic but not semantically meaningful, so
+		// changing the default for those collections would be a surprise with no
+		// payoff. Callers can still pass an explicit `sort` for any pkType.
+		//
+		// Skipped also when the query uses `group` or `aggregate`: ORDER BY a column
+		// not in the GROUP BY / aggregate list is a SQL error on every dialect.
+		//
+		// Disable via DB_DEFAULT_ORDER_READS_BY_PK=false to restore the prior behavior
+		// (e.g. while you migrate existing queries to pass their own sort).
+		//
+		// Note: `updatedQuery` returned by emitFilter is frozen / non-extensible, so
+		// we replace the reference with a spread instead of mutating in place.
+		if (
+			toBoolean(env['DB_DEFAULT_ORDER_READS_BY_PK'] ?? true) &&
+			!updatedQuery.sort?.length &&
+			!updatedQuery.group?.length &&
+			!updatedQuery.aggregate
+		) {
+			const primaryKeyField = this.schema.collections[this.collection]!.primary;
+			const pkFieldType = this.schema.collections[this.collection]!.fields[primaryKeyField]?.type;
+
+			if (pkFieldType === 'integer' || pkFieldType === 'bigInteger') {
+				updatedQuery = { ...updatedQuery, sort: [primaryKeyField] };
+			}
+		}
 
 		let ast = await getAstFromQuery(
 			{
@@ -557,7 +923,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 							schema: this.schema,
 							accountability: this.accountability,
 						},
-					)
+				  )
 				: records;
 
 		if (opts?.emitEvents !== false) {
@@ -743,7 +1109,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 							schema: this.schema,
 							accountability: this.accountability,
 						},
-					)
+				  )
 				: payload;
 
 		// Sort keys to ensure that the order is maintained
@@ -778,7 +1144,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 						knex: this.knex,
 						schema: this.schema,
 					},
-				)
+			  )
 			: payloadAfterHooks;
 
 		if (opts.preMutationError) {
@@ -1092,7 +1458,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 							schema: this.schema,
 							accountability: this.accountability,
 						},
-					)
+				  )
 				: keys;
 
 		if (this.accountability) {

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -16,7 +16,7 @@ import type {
 	SchemaOverview,
 } from '@directus/types';
 import { UserIntegrityCheckFlag } from '@directus/types';
-import { getRelationsForCollection, toBoolean } from '@directus/utils';
+import { getRelationsForCollection } from '@directus/utils';
 import type Keyv from 'keyv';
 import type { Knex } from 'knex';
 import { assign, clone, cloneDeep, difference, omit, pick, without } from 'lodash-es';
@@ -276,8 +276,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 			try {
 				if (useBatchInsert) {
-					const chunkSizeEnv = env['DB_BATCH_INSERT_CHUNK_SIZE'];
-					const chunkSize = chunkSizeEnv !== undefined ? Number(chunkSizeEnv) : undefined;
+					const chunkSize = env['DB_BATCH_INSERT_CHUNK_SIZE'] as number | undefined;
 
 					// SQLite's batchInsert path normalizes columns across all rows in the
 					// chunk; columns missing from a row are bound as `undefined`, which the
@@ -569,7 +568,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		// Note: `updatedQuery` returned by emitFilter is frozen / non-extensible, so
 		// we replace the reference with a spread instead of mutating in place.
 		if (
-			toBoolean(env['DB_DEFAULT_ORDER_READS_BY_PK'] ?? true) &&
+			env['DB_DEFAULT_ORDER_READS_BY_PK'] &&
 			!updatedQuery.sort?.length &&
 			!updatedQuery.group?.length &&
 			!updatedQuery.aggregate

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -166,7 +166,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 								schema: this.schema,
 								accountability: this.accountability,
 							},
-					  )
+						)
 					: payload;
 
 			const payloadWithPresets = this.accountability
@@ -182,7 +182,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 							knex: trx,
 							schema: this.schema,
 						},
-				  )
+					)
 				: payloadAfterHooks;
 
 			if (opts.preMutationError) {
@@ -573,7 +573,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 								schema: this.schema,
 								accountability: this.accountability,
 							},
-					  )
+						)
 					: payload;
 
 			const payloadWithPresets = this.accountability
@@ -586,7 +586,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 							nested: this.nested,
 						},
 						{ knex: trx, schema: this.schema },
-				  )
+					)
 				: payloadAfterHooks;
 
 			if (opts.preMutationError) {
@@ -620,7 +620,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			const payloadWithoutAliases = pick(payloadWithA2O, without(fields, ...aliases));
 			const payloadWithTypeCasting = await payloadService.processValues('create', payloadWithoutAliases);
 
-			let primaryKey: PrimaryKey | undefined = payloadWithTypeCasting[primaryKeyField];
+			const primaryKey: PrimaryKey | undefined = payloadWithTypeCasting[primaryKeyField];
 
 			if (primaryKey) {
 				validateKeys(this.schema, this.collection, primaryKeyField, primaryKey);
@@ -845,7 +845,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 							schema: this.schema,
 							accountability: this.accountability,
 						},
-				  )
+					)
 				: query;
 
 		// Default to ORDER BY <primary key> ASC for integer / bigInteger PKs when no
@@ -923,7 +923,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 							schema: this.schema,
 							accountability: this.accountability,
 						},
-				  )
+					)
 				: records;
 
 		if (opts?.emitEvents !== false) {
@@ -1109,7 +1109,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 							schema: this.schema,
 							accountability: this.accountability,
 						},
-				  )
+					)
 				: payload;
 
 		// Sort keys to ensure that the order is maintained
@@ -1144,7 +1144,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 						knex: this.knex,
 						schema: this.schema,
 					},
-			  )
+				)
 			: payloadAfterHooks;
 
 		if (opts.preMutationError) {
@@ -1458,7 +1458,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 							schema: this.schema,
 							accountability: this.accountability,
 						},
-				  )
+					)
 				: keys;
 
 		if (this.accountability) {

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -122,9 +122,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	}
 
 	/**
-	 * Create a single new item. Thin wrapper around {@link createMany} so the
-	 * fast `knex.batchInsert` dispatch is the single insert path; both single-
-	 * and multi-row callers benefit from one tested implementation.
+	 * Create a single new item.
 	 */
 	async createOne(data: Partial<Item>, opts: MutationOptions = {}): Promise<PrimaryKey> {
 		const [primaryKey] = await this.createMany([data], opts);
@@ -133,18 +131,6 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 	/**
 	 * Create one or more new items, wrapped in a transaction.
-	 *
-	 * Fast path: vendors whose `INSERT … RETURNING` is contractually ordered
-	 * (see `CapabilitiesHelper.preservesInsertOrderInReturning`) emit a single
-	 * `knex.batchInsert` and map the returned PKs back positionally.
-	 *
-	 * Slow path: per-row `trx.insert(row).into(...).returning(pk, returningOptions)`
-	 * inline (no recursion through `createOne`). Used for MySQL / MariaDB and
-	 * MSSQL when `DB_MSSQL_TRUST_BATCH_RETURNING` isn't opted in. The MSSQL
-	 * `includeTriggerModifications` returning option is preserved on this path.
-	 *
-	 * The `DB_BATCH_INSERT_CHUNK_SIZE` env var (knex passthrough, default 1000)
-	 * tunes the fast path; `DB_MSSQL_TRUST_BATCH_RETURNING` opts MSSQL into it.
 	 */
 	async createMany(data: Partial<Item>[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
@@ -188,7 +174,6 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				payloadService: PayloadService;
 			};
 
-			// === Per-row prep: filter hooks, presets, M2O / A2O processing ===
 			const prepared: PreparedRow[] = [];
 
 			for (const [index, payloadInput] of data.entries()) {
@@ -286,7 +271,6 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				});
 			}
 
-			// === Insert dispatch: batched (fast) or per-row (slow) ===
 			const useBatchInsert =
 				prepared.length > 1 && (await getHelpers(trx).capabilities.preservesInsertOrderInReturning());
 
@@ -339,11 +323,9 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 						p.actionHookPayload[primaryKeyField] = p.primaryKey;
 					}
 				} else {
-					// Per-row insert path. Mirrors upstream's pre-batchInsert `createOne`
-					// so MSSQL triggers + the max(pk) fallback for vendors that don't
-					// return a PK both still work.
 					let returningOptions: { includeTriggerModifications: true } | undefined;
 
+					// Support MSSQL tables that have triggers.
 					if (getDatabaseClient(trx) === 'mssql') {
 						returningOptions = { includeTriggerModifications: true };
 					}
@@ -388,7 +370,6 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				throw dbError;
 			}
 
-			// === Per-row post-insert: O2M, integrity flags, nested action events ===
 			type PostRow = PreparedRow & {
 				primaryKey: PrimaryKey;
 				revisionsO2M: Awaited<ReturnType<PayloadService['processO2M']>>['revisions'];
@@ -427,7 +408,6 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				}
 			}
 
-			// === Activity + revisions, batched via createMany on those services ===
 			if (
 				opts.skipTracking !== true &&
 				this.accountability &&
@@ -505,8 +485,6 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			};
 		});
 
-		// Top-level action events fire AFTER the transaction commits, so listeners
-		// observe a durable row.
 		if (opts.emitEvents !== false) {
 			const eventName =
 				this.eventScope === 'items' ? ['items.create', `${this.collection}.items.create`] : `${this.eventScope}.create`;

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -295,7 +295,25 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					const chunkSizeEnv = env['DB_BATCH_INSERT_CHUNK_SIZE'];
 					const chunkSize = chunkSizeEnv !== undefined ? Number(chunkSizeEnv) : undefined;
 
-					const rowsToInsert = prepared.map((p) => p.payloadWithoutAliases);
+					// SQLite's batchInsert path normalizes columns across all rows in the
+					// chunk; columns missing from a row are bound as `undefined`, which the
+					// driver translates to `NULL` and fails for non-nullable fields. Spread
+					// per-column defaults for non-nullable fields first so the payload only
+					// overrides what it explicitly sets. https://github.com/knex/knex/issues/332
+					const isSqlite = getDatabaseClient(trx) === 'sqlite';
+					const collectionFieldsSchema = this.schema.collections[this.collection]!.fields;
+
+					const sqliteFieldsRequiringValue: Record<string, unknown> = isSqlite
+						? Object.fromEntries(
+								Object.entries(collectionFieldsSchema)
+									.filter(([fieldName, field]) => fieldName !== primaryKeyField && field.nullable === false)
+									.map(([fieldName, field]) => [fieldName, field.defaultValue]),
+							)
+						: {};
+
+					const rowsToInsert = prepared.map((p) =>
+						isSqlite ? { ...sqliteFieldsRequiringValue, ...p.payloadWithoutAliases } : p.payloadWithoutAliases,
+					);
 
 					const insertedRows = (await trx
 						.batchInsert(this.collection, rowsToInsert, chunkSize)

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -122,319 +122,26 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	}
 
 	/**
-	 * Create a single new item.
+	 * Create a single new item. Thin wrapper around {@link createMany} so the
+	 * fast `knex.batchInsert` dispatch is the single insert path; both single-
+	 * and multi-row callers benefit from one tested implementation.
 	 */
 	async createOne(data: Partial<Item>, opts: MutationOptions = {}): Promise<PrimaryKey> {
-		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
-
-		if (!opts.bypassLimits) {
-			opts.mutationTracker.trackMutations(1);
-		}
-
-		const primaryKeyField = this.schema.collections[this.collection]!.primary;
-		const fields = Object.keys(this.schema.collections[this.collection]!.fields);
-
-		const aliases = Object.values(this.schema.collections[this.collection]!.fields)
-			.filter((field) => field.alias === true)
-			.map((field) => field.field);
-
-		const payload: AnyItem = cloneDeep(data);
-		let actionHookPayload = payload;
-		const nestedActionEvents: ActionEventParams[] = [];
-
-		/**
-		 * By wrapping the logic in a transaction, we make sure we automatically roll back all the
-		 * changes in the DB if any of the parts contained within throws an error. This also means
-		 * that any errors thrown in any nested relational changes will bubble up and cancel the whole
-		 * update tree
-		 */
-		const primaryKey: PrimaryKey = await transaction(this.knex, async (trx) => {
-			// Run all hooks that are attached to this event so the end user has the chance to augment the
-			// item that is about to be saved
-			const payloadAfterHooks =
-				opts.emitEvents !== false
-					? await emitter.emitFilter(
-							this.eventScope === 'items'
-								? ['items.create', `${this.collection}.items.create`]
-								: `${this.eventScope}.create`,
-							payload,
-							{
-								collection: this.collection,
-							},
-							{
-								database: trx,
-								schema: this.schema,
-								accountability: this.accountability,
-							},
-						)
-					: payload;
-
-			const payloadWithPresets = this.accountability
-				? await processPayload(
-						{
-							accountability: this.accountability,
-							action: 'create',
-							collection: this.collection,
-							payload: payloadAfterHooks,
-							nested: this.nested,
-						},
-						{
-							knex: trx,
-							schema: this.schema,
-						},
-					)
-				: payloadAfterHooks;
-
-			if (opts.preMutationError) {
-				throw opts.preMutationError;
-			}
-
-			// Ensure the action hook payload has the post filter hook + preset changes
-			actionHookPayload = payloadWithPresets;
-
-			// We're creating new services instances so they can use the transaction as their Knex interface
-			const payloadService = new PayloadService(this.collection, {
-				accountability: this.accountability,
-				knex: trx,
-				schema: this.schema,
-				nested: this.nested,
-				overwriteDefaults: opts.overwriteDefaults,
-			});
-
-			const {
-				payload: payloadWithM2O,
-				revisions: revisionsM2O,
-				nestedActionEvents: nestedActionEventsM2O,
-				userIntegrityCheckFlags: userIntegrityCheckFlagsM2O,
-			} = await payloadService.processM2O(payloadWithPresets, opts);
-
-			const {
-				payload: payloadWithA2O,
-				revisions: revisionsA2O,
-				nestedActionEvents: nestedActionEventsA2O,
-				userIntegrityCheckFlags: userIntegrityCheckFlagsA2O,
-			} = await payloadService.processA2O(payloadWithM2O, opts);
-
-			const payloadWithoutAliases = pick(payloadWithA2O, without(fields, ...aliases));
-			const payloadWithTypeCasting = await payloadService.processValues('create', payloadWithoutAliases);
-
-			// The primary key can already exist in the payload.
-			// In case of manual string / UUID primary keys it's always provided at this point.
-			// In case of an (big) integer primary key, it might be provided as the user can specify the value manually.
-			let primaryKey: undefined | PrimaryKey = payloadWithTypeCasting[primaryKeyField];
-
-			if (primaryKey) {
-				validateKeys(this.schema, this.collection, primaryKeyField, primaryKey);
-			}
-
-			// If a PK of type number was provided, although the PK is set the auto_increment,
-			// depending on the database, the sequence might need to be reset to protect future PK collisions.
-			let autoIncrementSequenceNeedsToBeReset = false;
-
-			const pkField = this.schema.collections[this.collection]!.fields[primaryKeyField];
-
-			if (
-				primaryKey &&
-				pkField &&
-				!opts.bypassAutoIncrementSequenceReset &&
-				['integer', 'bigInteger'].includes(pkField.type) &&
-				pkField.defaultValue === 'AUTO_INCREMENT'
-			) {
-				autoIncrementSequenceNeedsToBeReset = true;
-			}
-
-			try {
-				let returningOptions = undefined;
-
-				// Support MSSQL tables that have triggers.
-				if (getDatabaseClient(trx) === 'mssql') {
-					returningOptions = { includeTriggerModifications: true };
-				}
-
-				const result = await trx
-					.insert(payloadWithoutAliases)
-					.into(this.collection)
-					.returning(primaryKeyField, returningOptions)
-					.then((result) => result[0]);
-
-				const returnedKey = typeof result === 'object' ? result[primaryKeyField] : result;
-
-				if (pkField!.type === 'uuid') {
-					primaryKey = getHelpers(trx).schema.formatUUID(primaryKey ?? returnedKey);
-				} else {
-					primaryKey = primaryKey ?? returnedKey;
-				}
-			} catch (err: any) {
-				const dbError = await translateDatabaseError(err, data);
-
-				if (isDirectusError(dbError, ErrorCode.RecordNotUnique) && dbError.extensions.primaryKey) {
-					// This is a MySQL specific thing we need to handle here, since MySQL does not return the field name
-					// if the unique constraint is the primary key
-					dbError.extensions.field = pkField?.field ?? null;
-
-					delete dbError.extensions.primaryKey;
-				}
-
-				throw dbError;
-			}
-
-			// Most database support returning, those who don't tend to return the PK anyways
-			// (MySQL/SQLite). In case the primary key isn't know yet, we'll do a best-attempt at
-			// fetching it based on the last inserted row
-			if (!primaryKey) {
-				// Fetching it with max should be safe, as we're in the context of the current transaction
-				const result = await trx.max(primaryKeyField, { as: 'id' }).from(this.collection).first();
-				primaryKey = result.id;
-
-				// Set the primary key on the input item, in order for the "after" event hook to be able
-				// to read from it
-				actionHookPayload[primaryKeyField] = primaryKey;
-			}
-
-			// At this point, the primary key is guaranteed to be set.
-			primaryKey = primaryKey as PrimaryKey;
-
-			const {
-				revisions: revisionsO2M,
-				nestedActionEvents: nestedActionEventsO2M,
-				userIntegrityCheckFlags: userIntegrityCheckFlagsO2M,
-			} = await payloadService.processO2M(payloadWithPresets, primaryKey, opts);
-
-			nestedActionEvents.push(...nestedActionEventsM2O);
-			nestedActionEvents.push(...nestedActionEventsA2O);
-			nestedActionEvents.push(...nestedActionEventsO2M);
-
-			const userIntegrityCheckFlags =
-				(opts.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None) |
-				userIntegrityCheckFlagsM2O |
-				userIntegrityCheckFlagsA2O |
-				userIntegrityCheckFlagsO2M;
-
-			if (userIntegrityCheckFlags) {
-				if (opts.onRequireUserIntegrityCheck) {
-					opts.onRequireUserIntegrityCheck(userIntegrityCheckFlags);
-				} else {
-					await validateUserCountIntegrity({ flags: userIntegrityCheckFlags, knex: trx });
-				}
-			}
-
-			// If this is an authenticated action, and accountability tracking is enabled, save activity row
-			if (
-				opts.skipTracking !== true &&
-				this.accountability &&
-				this.schema.collections[this.collection]!.accountability !== null
-			) {
-				const { ActivityService } = await import('./activity.js');
-				const { RevisionsService } = await import('./revisions.js');
-
-				const activityService = new ActivityService({
-					knex: trx,
-					schema: this.schema,
-				});
-
-				const activity = await activityService.createOne({
-					action: Action.CREATE,
-					user: this.accountability!.user,
-					collection: this.collection,
-					ip: this.accountability!.ip,
-					user_agent: this.accountability!.userAgent,
-					origin: this.accountability!.origin,
-					item: primaryKey,
-				});
-
-				// If revisions are tracked, create revisions record
-				if (this.schema.collections[this.collection]!.accountability === 'all') {
-					const revisionsService = new RevisionsService({
-						knex: trx,
-						schema: this.schema,
-					});
-
-					const relationalFields = getRelationsForCollection(this.schema, this.collection);
-
-					const revisionPayload = await payloadService.prepareDelta(omit(payloadWithPresets, relationalFields));
-
-					const revision = await revisionsService.createOne({
-						activity: activity,
-						collection: this.collection,
-						item: primaryKey,
-						data: revisionPayload,
-						delta: revisionPayload,
-					});
-
-					// Make sure to set the parent field of the child-revision rows
-					const childrenRevisions = [...revisionsM2O, ...revisionsA2O, ...revisionsO2M];
-
-					if (childrenRevisions.length > 0) {
-						await revisionsService.updateMany(childrenRevisions, { parent: revision });
-					}
-
-					if (opts.onRevisionCreate) {
-						opts.onRevisionCreate(revision);
-					}
-				}
-			}
-
-			if (autoIncrementSequenceNeedsToBeReset) {
-				await getHelpers(trx).sequence.resetAutoIncrementSequence(this.collection, primaryKeyField);
-			}
-
-			if (opts.onItemCreate) {
-				opts.onItemCreate(this.collection, primaryKey);
-			}
-
-			return primaryKey;
-		});
-
-		if (opts.emitEvents !== false) {
-			const actionEvent = {
-				event:
-					this.eventScope === 'items'
-						? ['items.create', `${this.collection}.items.create`]
-						: `${this.eventScope}.create`,
-				meta: {
-					payload: actionHookPayload,
-					key: primaryKey,
-					collection: this.collection,
-				},
-				context: {
-					database: getDatabase(),
-					schema: this.schema,
-					accountability: this.accountability,
-				},
-			};
-
-			if (opts.bypassEmitAction) {
-				opts.bypassEmitAction(actionEvent);
-			} else {
-				emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context);
-			}
-
-			for (const nestedActionEvent of nestedActionEvents) {
-				if (opts.bypassEmitAction) {
-					opts.bypassEmitAction(nestedActionEvent);
-				} else {
-					emitter.emitAction(nestedActionEvent.event, nestedActionEvent.meta, nestedActionEvent.context);
-				}
-			}
-		}
-
-		if (shouldClearCache(this.cache, opts, this.collection)) {
-			await this.cache.clear();
-		}
-
-		return primaryKey;
+		const [primaryKey] = await this.createMany([data], opts);
+		return primaryKey as PrimaryKey;
 	}
 
 	/**
-	 * Create multiple new items at once, wrapped in a transaction.
+	 * Create one or more new items, wrapped in a transaction.
 	 *
 	 * Fast path: vendors whose `INSERT … RETURNING` is contractually ordered
-	 * (see `CapabilitiesHelper.preservesInsertOrderInReturning`) use a single
+	 * (see `CapabilitiesHelper.preservesInsertOrderInReturning`) emit a single
 	 * `knex.batchInsert` and map the returned PKs back positionally.
 	 *
-	 * Fallback: per-row `this.createOne` loop (identical to the pre-batchInsert
-	 * implementation), used for MySQL/MariaDB and other vendors where RETURNING
-	 * order isn't guaranteed.
+	 * Slow path: per-row `trx.insert(row).into(...).returning(pk, returningOptions)`
+	 * inline (no recursion through `createOne`). Used for MySQL / MariaDB and
+	 * MSSQL when `DB_MSSQL_TRUST_BATCH_RETURNING` isn't opted in. The MSSQL
+	 * `includeTriggerModifications` returning option is preserved on this path.
 	 *
 	 * The `DB_BATCH_INSERT_CHUNK_SIZE` env var (knex passthrough, default 1000)
 	 * tunes the fast path; `DB_MSSQL_TRUST_BATCH_RETURNING` opts MSSQL into it.
@@ -446,56 +153,368 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			return [];
 		}
 
-		const { primaryKeys, nestedActionEvents } = await transaction(this.knex, async (knex) => {
-			const useBatchInsert = data.length > 1 && (await getHelpers(knex).capabilities.preservesInsertOrderInReturning());
+		if (!opts.bypassLimits) {
+			opts.mutationTracker.trackMutations(data.length);
+		}
 
-			if (useBatchInsert) {
-				return await this.createManyBatched(data, opts, knex);
-			}
+		const primaryKeyField = this.schema.collections[this.collection]!.primary;
+		const fields = Object.keys(this.schema.collections[this.collection]!.fields);
 
-			const service = this.fork({ knex });
+		const aliases = Object.values(this.schema.collections[this.collection]!.fields)
+			.filter((field) => field.alias === true)
+			.map((field) => field.field);
 
-			let userIntegrityCheckFlags = opts.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None;
+		const pkField = this.schema.collections[this.collection]!.fields[primaryKeyField];
 
-			const primaryKeys: PrimaryKey[] = [];
+		type ActionPayload = { primaryKey: PrimaryKey; actionHookPayload: AnyItem };
+
+		const { primaryKeys, nestedActionEvents, actionPayloads } = await transaction(this.knex, async (trx) => {
 			const nestedActionEvents: ActionEventParams[] = [];
+			let userIntegrityCheckFlags = opts.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None;
+			let autoIncrementSequenceNeedsToBeReset = false;
 
-			const pkField = this.schema.collections[this.collection]!.primary;
+			type PreparedRow = {
+				actionHookPayload: AnyItem;
+				payloadAfterHooks: AnyItem;
+				payloadWithPresets: AnyItem;
+				payloadWithoutAliases: Record<string, unknown>;
+				primaryKey: PrimaryKey | undefined;
+				revisionsM2O: Awaited<ReturnType<PayloadService['processM2O']>>['revisions'];
+				revisionsA2O: Awaited<ReturnType<PayloadService['processA2O']>>['revisions'];
+				nestedActionEventsM2O: ActionEventParams[];
+				nestedActionEventsA2O: ActionEventParams[];
+				userIntegrityCheckFlagsM2O: UserIntegrityCheckFlag;
+				userIntegrityCheckFlagsA2O: UserIntegrityCheckFlag;
+				payloadService: PayloadService;
+			};
 
-			for (const [index, payload] of data.entries()) {
-				let bypassAutoIncrementSequenceReset = true;
+			// === Per-row prep: filter hooks, presets, M2O / A2O processing ===
+			const prepared: PreparedRow[] = [];
 
-				// the auto_increment sequence needs to be reset if the current item contains a manual PK and
-				// if it's the last item of the batch or if the next item doesn't include a PK and hence one needs to be generated
-				if (payload[pkField] && (index === data.length - 1 || !data[index + 1]?.[pkField])) {
-					bypassAutoIncrementSequenceReset = false;
+			for (const [index, payloadInput] of data.entries()) {
+				const payload: AnyItem = cloneDeep(payloadInput);
+
+				const payloadAfterHooks =
+					opts.emitEvents !== false
+						? await emitter.emitFilter(
+								this.eventScope === 'items'
+									? ['items.create', `${this.collection}.items.create`]
+									: `${this.eventScope}.create`,
+								payload,
+								{ collection: this.collection },
+								{
+									database: trx,
+									schema: this.schema,
+									accountability: this.accountability,
+								},
+							)
+						: payload;
+
+				const payloadWithPresets = this.accountability
+					? await processPayload(
+							{
+								accountability: this.accountability,
+								action: 'create',
+								collection: this.collection,
+								payload: payloadAfterHooks,
+								nested: this.nested,
+							},
+							{ knex: trx, schema: this.schema },
+						)
+					: payloadAfterHooks;
+
+				if (opts.preMutationError) {
+					throw opts.preMutationError;
 				}
 
-				const primaryKey = await service.createOne(payload, {
-					...(opts || {}),
-					autoPurgeCache: false,
-					onRequireUserIntegrityCheck: (flags) => (userIntegrityCheckFlags |= flags),
-					bypassEmitAction: (params) => nestedActionEvents.push(params),
-					mutationTracker: opts.mutationTracker,
+				const actionHookPayload = payloadWithPresets;
+
+				const payloadService = new PayloadService(this.collection, {
+					accountability: this.accountability,
+					knex: trx,
+					schema: this.schema,
+					nested: this.nested,
 					overwriteDefaults: opts.overwriteDefaults?.[index],
-					bypassAutoIncrementSequenceReset,
 				});
 
-				primaryKeys.push(primaryKey);
+				const {
+					payload: payloadWithM2O,
+					revisions: revisionsM2O,
+					nestedActionEvents: nestedActionEventsM2O,
+					userIntegrityCheckFlags: userIntegrityCheckFlagsM2O,
+				} = await payloadService.processM2O(payloadWithPresets, opts);
+
+				const {
+					payload: payloadWithA2O,
+					revisions: revisionsA2O,
+					nestedActionEvents: nestedActionEventsA2O,
+					userIntegrityCheckFlags: userIntegrityCheckFlagsA2O,
+				} = await payloadService.processA2O(payloadWithM2O, opts);
+
+				const payloadWithoutAliases = pick(payloadWithA2O, without(fields, ...aliases));
+				const payloadWithTypeCasting = await payloadService.processValues('create', payloadWithoutAliases);
+
+				const primaryKey: PrimaryKey | undefined = payloadWithTypeCasting[primaryKeyField];
+
+				if (primaryKey) {
+					validateKeys(this.schema, this.collection, primaryKeyField, primaryKey);
+				}
+
+				if (
+					primaryKey &&
+					pkField &&
+					!opts.bypassAutoIncrementSequenceReset &&
+					['integer', 'bigInteger'].includes(pkField.type) &&
+					pkField.defaultValue === 'AUTO_INCREMENT'
+				) {
+					autoIncrementSequenceNeedsToBeReset = true;
+				}
+
+				prepared.push({
+					actionHookPayload,
+					payloadAfterHooks,
+					payloadWithPresets,
+					payloadWithoutAliases,
+					primaryKey,
+					revisionsM2O,
+					revisionsA2O,
+					nestedActionEventsM2O,
+					nestedActionEventsA2O,
+					userIntegrityCheckFlagsM2O,
+					userIntegrityCheckFlagsA2O,
+					payloadService,
+				});
+			}
+
+			// === Insert dispatch: batched (fast) or per-row (slow) ===
+			const useBatchInsert =
+				prepared.length > 1 && (await getHelpers(trx).capabilities.preservesInsertOrderInReturning());
+
+			try {
+				if (useBatchInsert) {
+					const chunkSizeEnv = env['DB_BATCH_INSERT_CHUNK_SIZE'];
+					const chunkSize = chunkSizeEnv !== undefined ? Number(chunkSizeEnv) : undefined;
+
+					const rowsToInsert = prepared.map((p) => p.payloadWithoutAliases);
+
+					const insertedRows = (await trx
+						.batchInsert(this.collection, rowsToInsert, chunkSize)
+						.returning(primaryKeyField)) as unknown as Array<Record<string, unknown> | PrimaryKey>;
+
+					if (insertedRows.length !== prepared.length) {
+						throw new Error(`batchInsert returned ${insertedRows.length} rows but expected ${prepared.length}`);
+					}
+
+					for (let i = 0; i < prepared.length; i++) {
+						const row = insertedRows[i]!;
+						const p = prepared[i]!;
+
+						const returnedKey =
+							typeof row === 'object' && row !== null ? (row as Record<string, unknown>)[primaryKeyField] : row;
+
+						if (pkField?.type === 'uuid') {
+							p.primaryKey = getHelpers(trx).schema.formatUUID((p.primaryKey ?? (returnedKey as string)) as string);
+						} else {
+							p.primaryKey = (p.primaryKey ?? returnedKey) as PrimaryKey;
+						}
+
+						p.actionHookPayload[primaryKeyField] = p.primaryKey;
+					}
+				} else {
+					// Per-row insert path. Mirrors upstream's pre-batchInsert `createOne`
+					// so MSSQL triggers + the max(pk) fallback for vendors that don't
+					// return a PK both still work.
+					let returningOptions: { includeTriggerModifications: true } | undefined;
+
+					if (getDatabaseClient(trx) === 'mssql') {
+						returningOptions = { includeTriggerModifications: true };
+					}
+
+					for (const p of prepared) {
+						const result = await trx
+							.insert(p.payloadWithoutAliases)
+							.into(this.collection)
+							.returning(primaryKeyField, returningOptions)
+							.then((rows) => rows[0]);
+
+						const returnedKey =
+							typeof result === 'object' && result !== null
+								? (result as Record<string, unknown>)[primaryKeyField]
+								: result;
+
+						if (pkField?.type === 'uuid') {
+							p.primaryKey = getHelpers(trx).schema.formatUUID((p.primaryKey ?? (returnedKey as string)) as string);
+						} else {
+							p.primaryKey = (p.primaryKey ?? returnedKey) as PrimaryKey;
+						}
+
+						if (!p.primaryKey) {
+							// Best-effort PK lookup for vendors / driver paths where
+							// RETURNING didn't surface one (legacy MySQL / SQLite).
+							const maxResult = await trx.max(primaryKeyField, { as: 'id' }).from(this.collection).first();
+
+							p.primaryKey = maxResult?.id;
+						}
+
+						p.actionHookPayload[primaryKeyField] = p.primaryKey;
+					}
+				}
+			} catch (err: any) {
+				const dbError = await translateDatabaseError(err, data);
+
+				if (isDirectusError(dbError, ErrorCode.RecordNotUnique) && dbError.extensions.primaryKey) {
+					dbError.extensions.field = pkField?.field ?? null;
+					delete dbError.extensions.primaryKey;
+				}
+
+				throw dbError;
+			}
+
+			// === Per-row post-insert: O2M, integrity flags, nested action events ===
+			type PostRow = PreparedRow & {
+				primaryKey: PrimaryKey;
+				revisionsO2M: Awaited<ReturnType<PayloadService['processO2M']>>['revisions'];
+				nestedActionEventsO2M: ActionEventParams[];
+			};
+
+			const postPrepared: PostRow[] = [];
+
+			for (const p of prepared) {
+				const primaryKey = p.primaryKey as PrimaryKey;
+
+				const {
+					revisions: revisionsO2M,
+					nestedActionEvents: nestedActionEventsO2M,
+					userIntegrityCheckFlags: userIntegrityCheckFlagsO2M,
+				} = await p.payloadService.processO2M(p.payloadWithPresets, primaryKey, opts);
+
+				userIntegrityCheckFlags |=
+					p.userIntegrityCheckFlagsM2O | p.userIntegrityCheckFlagsA2O | userIntegrityCheckFlagsO2M;
+
+				nestedActionEvents.push(...p.nestedActionEventsM2O, ...p.nestedActionEventsA2O, ...nestedActionEventsO2M);
+
+				postPrepared.push({
+					...p,
+					primaryKey,
+					revisionsO2M,
+					nestedActionEventsO2M,
+				});
 			}
 
 			if (userIntegrityCheckFlags) {
 				if (opts.onRequireUserIntegrityCheck) {
 					opts.onRequireUserIntegrityCheck(userIntegrityCheckFlags);
 				} else {
-					await validateUserCountIntegrity({ flags: userIntegrityCheckFlags, knex });
+					await validateUserCountIntegrity({ flags: userIntegrityCheckFlags, knex: trx });
 				}
 			}
 
-			return { primaryKeys, nestedActionEvents };
+			// === Activity + revisions, batched via createMany on those services ===
+			if (
+				opts.skipTracking !== true &&
+				this.accountability &&
+				this.schema.collections[this.collection]!.accountability !== null
+			) {
+				const { ActivityService } = await import('./activity.js');
+				const { RevisionsService } = await import('./revisions.js');
+
+				const activityService = new ActivityService({ knex: trx, schema: this.schema });
+
+				const activityIds = await activityService.createMany(
+					postPrepared.map((p) => ({
+						action: Action.CREATE,
+						user: this.accountability!.user,
+						collection: this.collection,
+						ip: this.accountability!.ip,
+						user_agent: this.accountability!.userAgent,
+						origin: this.accountability!.origin,
+						item: p.primaryKey,
+					})),
+				);
+
+				if (this.schema.collections[this.collection]!.accountability === 'all') {
+					const revisionsService = new RevisionsService({ knex: trx, schema: this.schema });
+					const relationalFields = getRelationsForCollection(this.schema, this.collection);
+
+					const revisionInputs = await Promise.all(
+						postPrepared.map(async (p, index) => {
+							const revisionPayload = await p.payloadService.prepareDelta(omit(p.payloadWithPresets, relationalFields));
+
+							return {
+								activity: activityIds[index]!,
+								collection: this.collection,
+								item: p.primaryKey,
+								data: revisionPayload,
+								delta: revisionPayload,
+							};
+						}),
+					);
+
+					const revisionIds = await revisionsService.createMany(revisionInputs);
+
+					for (let i = 0; i < postPrepared.length; i++) {
+						const p = postPrepared[i]!;
+						const revisionId = revisionIds[i]!;
+						const childrenRevisions = [...p.revisionsM2O, ...p.revisionsA2O, ...p.revisionsO2M];
+
+						if (childrenRevisions.length > 0) {
+							await revisionsService.updateMany(childrenRevisions, { parent: revisionId });
+						}
+
+						if (opts.onRevisionCreate) {
+							opts.onRevisionCreate(revisionId);
+						}
+					}
+				}
+			}
+
+			if (autoIncrementSequenceNeedsToBeReset) {
+				await getHelpers(trx).sequence.resetAutoIncrementSequence(this.collection, primaryKeyField);
+			}
+
+			if (opts.onItemCreate) {
+				for (const p of postPrepared) {
+					opts.onItemCreate(this.collection, p.primaryKey);
+				}
+			}
+
+			return {
+				primaryKeys: postPrepared.map((p) => p.primaryKey),
+				nestedActionEvents,
+				actionPayloads: postPrepared.map(
+					(p): ActionPayload => ({ primaryKey: p.primaryKey, actionHookPayload: p.actionHookPayload }),
+				),
+			};
 		});
 
+		// Top-level action events fire AFTER the transaction commits, so listeners
+		// observe a durable row.
 		if (opts.emitEvents !== false) {
+			const eventName =
+				this.eventScope === 'items' ? ['items.create', `${this.collection}.items.create`] : `${this.eventScope}.create`;
+
+			for (const { primaryKey, actionHookPayload } of actionPayloads) {
+				const actionEvent = {
+					event: eventName,
+					meta: {
+						payload: actionHookPayload,
+						key: primaryKey,
+						collection: this.collection,
+					},
+					context: {
+						database: getDatabase(),
+						schema: this.schema,
+						accountability: this.accountability,
+					},
+				};
+
+				if (opts.bypassEmitAction) {
+					opts.bypassEmitAction(actionEvent);
+				} else {
+					emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context);
+				}
+			}
+
 			for (const nestedActionEvent of nestedActionEvents) {
 				if (opts.bypassEmitAction) {
 					opts.bypassEmitAction(nestedActionEvent);
@@ -510,320 +529,6 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		}
 
 		return primaryKeys;
-	}
-
-	/**
-	 * Batched `createMany` fast path: prep every payload up front, run one
-	 * multi-row INSERT (`knex.batchInsert`), then process O2M / activity /
-	 * revisions in bulk. Only safe for vendors where RETURNING preserves
-	 * insertion order — gated by `CapabilitiesHelper.preservesInsertOrderInReturning`.
-	 */
-	private async createManyBatched(
-		data: Partial<Item>[],
-		opts: MutationOptions,
-		trx: Knex.Transaction,
-	): Promise<{ primaryKeys: PrimaryKey[]; nestedActionEvents: ActionEventParams[] }> {
-		if (!opts.bypassLimits) {
-			opts.mutationTracker!.trackMutations(data.length);
-		}
-
-		const primaryKeyField = this.schema.collections[this.collection]!.primary;
-		const fields = Object.keys(this.schema.collections[this.collection]!.fields);
-
-		const aliases = Object.values(this.schema.collections[this.collection]!.fields)
-			.filter((field) => field.alias === true)
-			.map((field) => field.field);
-
-		const pkField = this.schema.collections[this.collection]!.fields[primaryKeyField];
-
-		const nestedActionEvents: ActionEventParams[] = [];
-		let userIntegrityCheckFlags = opts.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None;
-		let autoIncrementSequenceNeedsToBeReset = false;
-
-		type PreparedRow = {
-			actionHookPayload: AnyItem;
-			payloadAfterHooks: AnyItem;
-			payloadWithPresets: AnyItem;
-			payloadWithoutAliases: Record<string, unknown>;
-			primaryKey: PrimaryKey | undefined;
-			revisionsM2O: Awaited<ReturnType<PayloadService['processM2O']>>['revisions'];
-			revisionsA2O: Awaited<ReturnType<PayloadService['processA2O']>>['revisions'];
-			nestedActionEventsM2O: ActionEventParams[];
-			nestedActionEventsA2O: ActionEventParams[];
-			userIntegrityCheckFlagsM2O: UserIntegrityCheckFlag;
-			userIntegrityCheckFlagsA2O: UserIntegrityCheckFlag;
-			payloadService: PayloadService;
-		};
-
-		const prepared: PreparedRow[] = [];
-
-		for (const [index, payloadInput] of data.entries()) {
-			const payload: AnyItem = cloneDeep(payloadInput);
-
-			const payloadAfterHooks =
-				opts.emitEvents !== false
-					? await emitter.emitFilter(
-							this.eventScope === 'items'
-								? ['items.create', `${this.collection}.items.create`]
-								: `${this.eventScope}.create`,
-							payload,
-							{ collection: this.collection },
-							{
-								database: trx,
-								schema: this.schema,
-								accountability: this.accountability,
-							},
-						)
-					: payload;
-
-			const payloadWithPresets = this.accountability
-				? await processPayload(
-						{
-							accountability: this.accountability,
-							action: 'create',
-							collection: this.collection,
-							payload: payloadAfterHooks,
-							nested: this.nested,
-						},
-						{ knex: trx, schema: this.schema },
-					)
-				: payloadAfterHooks;
-
-			if (opts.preMutationError) {
-				throw opts.preMutationError;
-			}
-
-			const actionHookPayload = payloadWithPresets;
-
-			const payloadService = new PayloadService(this.collection, {
-				accountability: this.accountability,
-				knex: trx,
-				schema: this.schema,
-				nested: this.nested,
-				overwriteDefaults: opts.overwriteDefaults?.[index],
-			});
-
-			const {
-				payload: payloadWithM2O,
-				revisions: revisionsM2O,
-				nestedActionEvents: nestedActionEventsM2O,
-				userIntegrityCheckFlags: userIntegrityCheckFlagsM2O,
-			} = await payloadService.processM2O(payloadWithPresets, opts);
-
-			const {
-				payload: payloadWithA2O,
-				revisions: revisionsA2O,
-				nestedActionEvents: nestedActionEventsA2O,
-				userIntegrityCheckFlags: userIntegrityCheckFlagsA2O,
-			} = await payloadService.processA2O(payloadWithM2O, opts);
-
-			const payloadWithoutAliases = pick(payloadWithA2O, without(fields, ...aliases));
-			const payloadWithTypeCasting = await payloadService.processValues('create', payloadWithoutAliases);
-
-			const primaryKey: PrimaryKey | undefined = payloadWithTypeCasting[primaryKeyField];
-
-			if (primaryKey) {
-				validateKeys(this.schema, this.collection, primaryKeyField, primaryKey);
-			}
-
-			if (
-				primaryKey &&
-				pkField &&
-				!opts.bypassAutoIncrementSequenceReset &&
-				['integer', 'bigInteger'].includes(pkField.type) &&
-				pkField.defaultValue === 'AUTO_INCREMENT'
-			) {
-				autoIncrementSequenceNeedsToBeReset = true;
-			}
-
-			prepared.push({
-				actionHookPayload,
-				payloadAfterHooks,
-				payloadWithPresets,
-				payloadWithoutAliases,
-				primaryKey,
-				revisionsM2O,
-				revisionsA2O,
-				nestedActionEventsM2O,
-				nestedActionEventsA2O,
-				userIntegrityCheckFlagsM2O,
-				userIntegrityCheckFlagsA2O,
-				payloadService,
-			});
-		}
-
-		try {
-			const rowsToInsert = prepared.map((p) => p.payloadWithoutAliases);
-
-			// undefined → knex default chunk size (1000): https://knexjs.org/guide/query-builder.html#batchinsert
-			const chunkSizeEnv = env['DB_BATCH_INSERT_CHUNK_SIZE'];
-			const chunkSize = chunkSizeEnv !== undefined ? Number(chunkSizeEnv) : undefined;
-
-			const insertedRows = (await trx
-				.batchInsert(this.collection, rowsToInsert, chunkSize)
-				.returning(primaryKeyField)) as unknown as Array<Record<string, unknown> | PrimaryKey>;
-
-			if (insertedRows.length !== prepared.length) {
-				throw new Error(`batchInsert returned ${insertedRows.length} rows but expected ${prepared.length}`);
-			}
-
-			for (let i = 0; i < prepared.length; i++) {
-				const row = insertedRows[i]!;
-				const p = prepared[i]!;
-
-				const returnedKey =
-					typeof row === 'object' && row !== null ? (row as Record<string, unknown>)[primaryKeyField] : row;
-
-				if (pkField?.type === 'uuid') {
-					p.primaryKey = getHelpers(trx).schema.formatUUID((p.primaryKey ?? (returnedKey as string)) as string);
-				} else {
-					p.primaryKey = (p.primaryKey ?? returnedKey) as PrimaryKey;
-				}
-
-				p.actionHookPayload[primaryKeyField] = p.primaryKey;
-			}
-		} catch (err: any) {
-			const dbError = await translateDatabaseError(err, data);
-
-			if (isDirectusError(dbError, ErrorCode.RecordNotUnique) && dbError.extensions.primaryKey) {
-				dbError.extensions.field = pkField?.field ?? null;
-				delete dbError.extensions.primaryKey;
-			}
-
-			throw dbError;
-		}
-
-		type PostRow = PreparedRow & {
-			primaryKey: PrimaryKey;
-			revisionsO2M: Awaited<ReturnType<PayloadService['processO2M']>>['revisions'];
-			nestedActionEventsO2M: ActionEventParams[];
-		};
-
-		const postPrepared: PostRow[] = [];
-
-		for (const p of prepared) {
-			const primaryKey = p.primaryKey as PrimaryKey;
-
-			const {
-				revisions: revisionsO2M,
-				nestedActionEvents: nestedActionEventsO2M,
-				userIntegrityCheckFlags: userIntegrityCheckFlagsO2M,
-			} = await p.payloadService.processO2M(p.payloadWithPresets, primaryKey, opts);
-
-			userIntegrityCheckFlags |=
-				p.userIntegrityCheckFlagsM2O | p.userIntegrityCheckFlagsA2O | userIntegrityCheckFlagsO2M;
-
-			nestedActionEvents.push(...p.nestedActionEventsM2O, ...p.nestedActionEventsA2O, ...nestedActionEventsO2M);
-
-			postPrepared.push({
-				...p,
-				primaryKey,
-				revisionsO2M,
-				nestedActionEventsO2M,
-			});
-		}
-
-		if (userIntegrityCheckFlags) {
-			if (opts.onRequireUserIntegrityCheck) {
-				opts.onRequireUserIntegrityCheck(userIntegrityCheckFlags);
-			} else {
-				await validateUserCountIntegrity({ flags: userIntegrityCheckFlags, knex: trx });
-			}
-		}
-
-		if (
-			opts.skipTracking !== true &&
-			this.accountability &&
-			this.schema.collections[this.collection]!.accountability !== null
-		) {
-			const { ActivityService } = await import('./activity.js');
-			const { RevisionsService } = await import('./revisions.js');
-
-			const activityService = new ActivityService({ knex: trx, schema: this.schema });
-
-			const activityIds = await activityService.createMany(
-				postPrepared.map((p) => ({
-					action: Action.CREATE,
-					user: this.accountability!.user,
-					collection: this.collection,
-					ip: this.accountability!.ip,
-					user_agent: this.accountability!.userAgent,
-					origin: this.accountability!.origin,
-					item: p.primaryKey,
-				})),
-			);
-
-			if (this.schema.collections[this.collection]!.accountability === 'all') {
-				const revisionsService = new RevisionsService({ knex: trx, schema: this.schema });
-				const relationalFields = getRelationsForCollection(this.schema, this.collection);
-
-				const revisionInputs = await Promise.all(
-					postPrepared.map(async (p, index) => {
-						const revisionPayload = await p.payloadService.prepareDelta(omit(p.payloadWithPresets, relationalFields));
-
-						return {
-							activity: activityIds[index]!,
-							collection: this.collection,
-							item: p.primaryKey,
-							data: revisionPayload,
-							delta: revisionPayload,
-						};
-					}),
-				);
-
-				const revisionIds = await revisionsService.createMany(revisionInputs);
-
-				for (let i = 0; i < postPrepared.length; i++) {
-					const p = postPrepared[i]!;
-					const revisionId = revisionIds[i]!;
-					const childrenRevisions = [...p.revisionsM2O, ...p.revisionsA2O, ...p.revisionsO2M];
-
-					if (childrenRevisions.length > 0) {
-						await revisionsService.updateMany(childrenRevisions, { parent: revisionId });
-					}
-
-					if (opts.onRevisionCreate) {
-						opts.onRevisionCreate(revisionId);
-					}
-				}
-			}
-		}
-
-		if (autoIncrementSequenceNeedsToBeReset) {
-			await getHelpers(trx).sequence.resetAutoIncrementSequence(this.collection, primaryKeyField);
-		}
-
-		if (opts.onItemCreate) {
-			for (const p of postPrepared) {
-				opts.onItemCreate(this.collection, p.primaryKey);
-			}
-		}
-
-		if (opts.emitEvents !== false) {
-			for (const p of postPrepared) {
-				nestedActionEvents.push({
-					event:
-						this.eventScope === 'items'
-							? ['items.create', `${this.collection}.items.create`]
-							: `${this.eventScope}.create`,
-					meta: {
-						payload: p.actionHookPayload,
-						key: p.primaryKey,
-						collection: this.collection,
-					},
-					context: {
-						database: getDatabase(),
-						schema: this.schema,
-						accountability: this.accountability,
-					},
-				});
-			}
-		}
-
-		return {
-			primaryKeys: postPrepared.map((p) => p.primaryKey),
-			nestedActionEvents,
-		};
 	}
 
 	/**

--- a/api/src/services/notifications.ts
+++ b/api/src/services/notifications.ts
@@ -20,9 +20,6 @@ export class NotificationsService extends ItemsService {
 	override async createMany(data: Partial<Notification>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
 		const primaryKeys = await super.createMany(data, opts);
 
-		// `ItemsService.createMany` is now the single insert path (`createOne` is a
-		// `createMany([data])` wrapper since the batchInsert refactor), so the side
-		// effect lives here — `super.createOne` no longer loops through this class.
 		for (const notification of data) {
 			await this.sendEmail(notification);
 		}

--- a/api/src/services/notifications.ts
+++ b/api/src/services/notifications.ts
@@ -17,12 +17,17 @@ export class NotificationsService extends ItemsService {
 		super('directus_notifications', options);
 	}
 
-	override async createOne(data: Partial<Notification>, opts?: MutationOptions): Promise<PrimaryKey> {
-		const response = await super.createOne(data, opts);
+	override async createMany(data: Partial<Notification>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
+		const primaryKeys = await super.createMany(data, opts);
 
-		await this.sendEmail(data);
+		// `ItemsService.createMany` is now the single insert path (`createOne` is a
+		// `createMany([data])` wrapper since the batchInsert refactor), so the side
+		// effect lives here — `super.createOne` no longer loops through this class.
+		for (const notification of data) {
+			await this.sendEmail(notification);
+		}
 
-		return response;
+		return primaryKeys;
 	}
 
 	async sendEmail(data: Partial<Notification>) {

--- a/api/src/services/operations.ts
+++ b/api/src/services/operations.ts
@@ -7,9 +7,11 @@ export class OperationsService extends ItemsService<OperationRaw> {
 		super('directus_operations', options);
 	}
 
-	override async createOne(data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
-		const result = await super.createOne(data, opts);
+	override async createMany(data: Partial<Item>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
+		const result = await super.createMany(data, opts);
 
+		// `ItemsService.createMany` is the single insert path now (`createOne` wraps
+		// it); reload once after the whole batch — reload is global, not per row.
 		const flowManager = getFlowManager();
 		await flowManager.reload();
 

--- a/api/src/services/operations.ts
+++ b/api/src/services/operations.ts
@@ -10,8 +10,6 @@ export class OperationsService extends ItemsService<OperationRaw> {
 	override async createMany(data: Partial<Item>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
 		const result = await super.createMany(data, opts);
 
-		// `ItemsService.createMany` is the single insert path now (`createOne` wraps
-		// it); reload once after the whole batch — reload is global, not per row.
 		const flowManager = getFlowManager();
 		await flowManager.reload();
 

--- a/api/src/services/permissions.test.ts
+++ b/api/src/services/permissions.test.ts
@@ -1,0 +1,85 @@
+import { SchemaBuilder } from '@directus/schema-builder';
+import type { MutationOptions } from '@directus/types';
+import knex from 'knex';
+import { createTracker, MockClient } from 'knex-mock-client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ItemsService, PermissionsService } from './index.js';
+
+vi.mock('../../src/database/index', () => ({
+	default: vi.fn(),
+	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
+}));
+
+const schema = new SchemaBuilder()
+	.collection('directus_permissions', (c) => {
+		c.field('id').uuid().primary();
+	})
+	.build();
+
+describe('Integration Tests', () => {
+	const db = vi.mocked(knex.default({ client: MockClient }));
+	createTracker(db);
+
+	describe('Services / Permissions', () => {
+		const service = new PermissionsService({
+			knex: db,
+			schema,
+		});
+
+		vi.spyOn(ItemsService.prototype, 'createMany').mockResolvedValue(['perm-id-1']);
+		vi.spyOn(ItemsService.prototype, 'updateMany').mockResolvedValue(['perm-id-2']);
+		vi.spyOn(ItemsService.prototype, 'updateBatch').mockResolvedValue(['perm-id-3']);
+		vi.spyOn(ItemsService.prototype, 'upsertMany').mockResolvedValue(['perm-id-4']);
+		vi.spyOn(ItemsService.prototype, 'deleteMany').mockResolvedValue(['perm-id-5']);
+
+		const clearCacheSpy = vi.spyOn(PermissionsService.prototype as any, 'clearCaches').mockResolvedValue(undefined);
+
+		afterEach(() => {
+			vi.clearAllMocks();
+		});
+
+		it('should clear caches after createOne', async () => {
+			await service.createOne({});
+
+			expect(clearCacheSpy).toHaveBeenCalled();
+		});
+
+		it('should clear caches after createMany', async () => {
+			await service.createMany([{}]);
+
+			expect(clearCacheSpy).toHaveBeenCalled();
+		});
+
+		it('should clear caches after updateMany', async () => {
+			await service.updateMany(['perm-id-6'], {});
+
+			expect(clearCacheSpy).toHaveBeenCalled();
+		});
+
+		it('should clear caches after updateBatch', async () => {
+			await service.updateBatch([{ id: 'perm-id-7' }]);
+
+			expect(clearCacheSpy).toHaveBeenCalled();
+		});
+
+		it('should clear caches after upsertMany', async () => {
+			await service.upsertMany([{}]);
+
+			expect(clearCacheSpy).toHaveBeenCalled();
+		});
+
+		it('should clear caches after deleteMany', async () => {
+			await service.deleteMany(['perm-id-8']);
+
+			expect(clearCacheSpy).toHaveBeenCalled();
+		});
+
+		it('should forward autoPurgeCache option to clearCaches', async () => {
+			const opts: MutationOptions = { autoPurgeCache: false };
+
+			await service.createMany([{}], opts);
+
+			expect(clearCacheSpy).toHaveBeenCalledWith(opts);
+		});
+	});
+});

--- a/api/src/services/permissions.ts
+++ b/api/src/services/permissions.ts
@@ -38,9 +38,6 @@ export class PermissionsService extends ItemsService {
 	}
 
 	override async createMany(data: Partial<Item>[], opts?: MutationOptions) {
-		// `createOne` (now a `createMany([data])` wrapper on `ItemsService`) routes
-		// through here, so a single override covers both paths and the cache only
-		// clears once per batch.
 		const res = await super.createMany(data, opts);
 
 		await this.clearCaches(opts);

--- a/api/src/services/permissions.ts
+++ b/api/src/services/permissions.ts
@@ -37,15 +37,10 @@ export class PermissionsService extends ItemsService {
 		return withAppMinimalPermissions(this.accountability, result, query.filter);
 	}
 
-	override async createOne(data: Partial<Item>, opts?: MutationOptions) {
-		const res = await super.createOne(data, opts);
-
-		await this.clearCaches(opts);
-
-		return res;
-	}
-
 	override async createMany(data: Partial<Item>[], opts?: MutationOptions) {
+		// `createOne` (now a `createMany([data])` wrapper on `ItemsService`) routes
+		// through here, so a single override covers both paths and the cache only
+		// clears once per batch.
 		const res = await super.createMany(data, opts);
 
 		await this.clearCaches(opts);

--- a/api/src/services/policies.ts
+++ b/api/src/services/policies.ts
@@ -47,9 +47,6 @@ export class PoliciesService extends ItemsService<Policy> {
 	}
 
 	override async createMany(data: Partial<Policy>[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
-		// `ItemsService.createMany` is the single insert path now (`createOne` wraps
-		// it); validate every payload up front so a bad row aborts the whole batch
-		// before any insert happens.
 		for (const item of data) {
 			this.assertValidIpAccess(item);
 		}
@@ -60,7 +57,7 @@ export class PoliciesService extends ItemsService<Policy> {
 		const result = await super.createMany(data, opts);
 
 		// TODO is this necessary? Since the attachment should be handled in the AccessService
-		// A new policy has created, clear the permissions cache (once for the batch).
+		// A new policy has created, clear the permissions cache
 		await clearPermissionsCache();
 
 		return result;

--- a/api/src/services/policies.ts
+++ b/api/src/services/policies.ts
@@ -46,16 +46,21 @@ export class PoliciesService extends ItemsService<Policy> {
 		}
 	}
 
-	override async createOne(data: Partial<Policy>, opts: MutationOptions = {}): Promise<PrimaryKey> {
-		this.assertValidIpAccess(data);
+	override async createMany(data: Partial<Policy>[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
+		// `ItemsService.createMany` is the single insert path now (`createOne` wraps
+		// it); validate every payload up front so a bad row aborts the whole batch
+		// before any insert happens.
+		for (const item of data) {
+			this.assertValidIpAccess(item);
+		}
 
 		// A policy has been created, but the attachment to a user/role happens in the AccessService,
 		// so no need to check user integrity
 
-		const result = await super.createOne(data, opts);
+		const result = await super.createMany(data, opts);
 
 		// TODO is this necessary? Since the attachment should be handled in the AccessService
-		// A new policy has created, clear the permissions cache
+		// A new policy has created, clear the permissions cache (once for the batch).
 		await clearPermissionsCache();
 
 		return result;

--- a/api/src/services/revisions.ts
+++ b/api/src/services/revisions.ts
@@ -40,8 +40,6 @@ export class RevisionsService extends ItemsService {
 	}
 
 	override async createMany(data: Partial<Item>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
-		// `createOne` (now a `createMany([data])` wrapper on `ItemsService`) already
-		// routes through here, so we only need the one override.
 		return super.createMany(data, this.setDefaultOptions(opts));
 	}
 

--- a/api/src/services/revisions.ts
+++ b/api/src/services/revisions.ts
@@ -39,11 +39,9 @@ export class RevisionsService extends ItemsService {
 		return opts;
 	}
 
-	override async createOne(data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
-		return super.createOne(data, this.setDefaultOptions(opts));
-	}
-
 	override async createMany(data: Partial<Item>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
+		// `createOne` (now a `createMany([data])` wrapper on `ItemsService`) already
+		// routes through here, so we only need the one override.
 		return super.createMany(data, this.setDefaultOptions(opts));
 	}
 

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -2,6 +2,7 @@ import { ForbiddenError, InvalidInviteError, InvalidPayloadError, RecordNotUniqu
 import { SchemaBuilder } from '@directus/schema-builder';
 import type { Accountability, MutationOptions } from '@directus/types';
 import { UserIntegrityCheckFlag } from '@directus/types';
+import { FailedValidationError } from '@directus/validation';
 import jwt from 'jsonwebtoken';
 import knex from 'knex';
 import { createTracker, MockClient } from 'knex-mock-client';
@@ -129,6 +130,36 @@ describe('Integration Tests', () => {
 
 				expect(opts.userIntegrityCheckFlags).toBe(UserIntegrityCheckFlag.UserLimits);
 			});
+
+			it('should set preMutationError to FailedValidationError when email is null', async () => {
+				const opts: MutationOptions = {};
+
+				await service.createOne({ email: null as any }, opts);
+
+				expect(opts.preMutationError).toBeInstanceOf(FailedValidationError);
+				expect(checkUniqueEmailsSpy).not.toBeCalled();
+			});
+
+			it('should set preMutationError to FailedValidationError when email is empty string', async () => {
+				const opts: MutationOptions = {};
+
+				await service.createOne({ email: '' }, opts);
+
+				expect(opts.preMutationError).toBeInstanceOf(FailedValidationError);
+				expect(checkUniqueEmailsSpy).not.toBeCalled();
+			});
+
+			it('should checkPasswordPolicy when password is null', async () => {
+				await service.createOne({ password: null as any });
+
+				expect(checkPasswordPolicySpy).toBeCalledWith([null]);
+			});
+
+			it('should checkPasswordPolicy when password is empty string', async () => {
+				await service.createOne({ password: '' });
+
+				expect(checkPasswordPolicySpy).toBeCalledWith(['']);
+			});
 		});
 
 		describe('createMany', () => {
@@ -162,6 +193,34 @@ describe('Integration Tests', () => {
 				await service.createMany([{}], opts);
 
 				expect(opts.userIntegrityCheckFlags).toBe(UserIntegrityCheckFlag.UserLimits);
+			});
+
+			it('should set preMutationError to FailedValidationError if any email is null', async () => {
+				const opts: MutationOptions = {};
+
+				await service.createMany([{ email: 'good@example.com' }, { email: null as any }], opts);
+
+				expect(opts.preMutationError).toBeInstanceOf(FailedValidationError);
+			});
+
+			it('should set preMutationError to FailedValidationError if any email is empty string', async () => {
+				const opts: MutationOptions = {};
+
+				await service.createMany([{ email: 'good@example.com' }, { email: '' }], opts);
+
+				expect(opts.preMutationError).toBeInstanceOf(FailedValidationError);
+			});
+
+			it('should checkPasswordPolicy when any password is null', async () => {
+				await service.createMany([{ password: 'testpassword' }, { password: null as any }]);
+
+				expect(checkPasswordPolicySpy).toBeCalledWith(['testpassword', null]);
+			});
+
+			it('should checkPasswordPolicy when any password is empty string', async () => {
+				await service.createMany([{ password: 'testpassword' }, { password: '' }]);
+
+				expect(checkPasswordPolicySpy).toBeCalledWith(['testpassword', '']);
 			});
 		});
 

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -96,40 +96,9 @@ describe('Integration Tests', () => {
 			vi.clearAllMocks();
 		});
 
-		describe('createOne', () => {
-			it('should not checkUniqueEmails', async () => {
-				await service.createOne({});
-
-				expect(checkUniqueEmailsSpy).not.toBeCalled();
-			});
-
-			it('should checkUniqueEmails once', async () => {
-				await service.createOne({ email: 'test@example.com' });
-
-				expect(checkUniqueEmailsSpy).toBeCalledTimes(1);
-			});
-
-			it('should not checkPasswordPolicy', async () => {
-				await service.createOne({});
-
-				expect(checkPasswordPolicySpy).not.toBeCalled();
-			});
-
-			it('should checkPasswordPolicy once', async () => {
-				await service.createOne({ password: 'testpassword' });
-
-				expect(checkPasswordPolicySpy).toBeCalledTimes(1);
-			});
-
-			it('should request user limits checks', async () => {
-				const opts: MutationOptions = {};
-
-				await service.createOne({}, opts);
-
-				expect(opts.userIntegrityCheckFlags).toBe(UserIntegrityCheckFlag.UserLimits);
-			});
-		});
-
+		// NOTE: no `createOne` block — since the batchInsert refactor `createOne` is
+		// a thin `[pk] = await createMany([data])` wrapper, so the createMany tests
+		// below exercise the same per-row validation path.
 		describe('createMany', () => {
 			vi.spyOn(ItemsService.prototype, 'createMany').mockResolvedValue([1]);
 

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -160,6 +160,36 @@ describe('Integration Tests', () => {
 
 				expect(checkPasswordPolicySpy).toBeCalledWith(['']);
 			});
+
+			it('should set UserLimits flag when status is active', async () => {
+				const opts: MutationOptions = {};
+
+				await service.createOne({ status: 'active' }, opts);
+
+				expect(opts.userIntegrityCheckFlags).toBe(UserIntegrityCheckFlag.UserLimits);
+			});
+
+			it('should not set UserLimits flag when status is inactive', async () => {
+				const opts: MutationOptions = {};
+
+				await service.createOne({ status: 'inactive' }, opts);
+
+				expect(opts.userIntegrityCheckFlags).toBeUndefined();
+			});
+
+			it('should OR existing userIntegrityCheckFlags and invoke onRequireUserIntegrityCheck', async () => {
+				const onRequireUserIntegrityCheck = vi.fn();
+
+				const opts: MutationOptions = {
+					userIntegrityCheckFlags: UserIntegrityCheckFlag.RemainingAdmins,
+					onRequireUserIntegrityCheck,
+				};
+
+				await service.createOne({}, opts);
+
+				expect(opts.userIntegrityCheckFlags).toBe(UserIntegrityCheckFlag.All);
+				expect(onRequireUserIntegrityCheck).toHaveBeenCalledWith(UserIntegrityCheckFlag.All);
+			});
 		});
 
 		describe('createMany', () => {
@@ -221,6 +251,44 @@ describe('Integration Tests', () => {
 				await service.createMany([{ password: 'testpassword' }, { password: '' }]);
 
 				expect(checkPasswordPolicySpy).toBeCalledWith(['testpassword', '']);
+			});
+
+			it('should set UserLimits flag if any row is active', async () => {
+				const opts: MutationOptions = {};
+
+				await service.createMany([{ status: 'active' }, { status: 'inactive' }], opts);
+
+				expect(opts.userIntegrityCheckFlags).toBe(UserIntegrityCheckFlag.UserLimits);
+			});
+
+			it('should set UserLimits flag if any row has no status', async () => {
+				const opts: MutationOptions = {};
+
+				await service.createMany([{}, { status: 'inactive' }], opts);
+
+				expect(opts.userIntegrityCheckFlags).toBe(UserIntegrityCheckFlag.UserLimits);
+			});
+
+			it('should not set UserLimits flag if all rows are inactive', async () => {
+				const opts: MutationOptions = {};
+
+				await service.createMany([{ status: 'inactive' }, { status: 'inactive' }], opts);
+
+				expect(opts.userIntegrityCheckFlags).toBeUndefined();
+			});
+
+			it('should OR existing userIntegrityCheckFlags and invoke onRequireUserIntegrityCheck', async () => {
+				const onRequireUserIntegrityCheck = vi.fn();
+
+				const opts: MutationOptions = {
+					userIntegrityCheckFlags: UserIntegrityCheckFlag.RemainingAdmins,
+					onRequireUserIntegrityCheck,
+				};
+
+				await service.createMany([{}, { status: 'active' }], opts);
+
+				expect(opts.userIntegrityCheckFlags).toBe(UserIntegrityCheckFlag.All);
+				expect(onRequireUserIntegrityCheck).toHaveBeenCalledWith(UserIntegrityCheckFlag.All);
 			});
 		});
 

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -65,11 +65,6 @@ describe('Integration Tests', () => {
 			schema,
 		});
 
-		// `createOne` is a thin wrapper around `createMany([data])` since the
-		// batchInsert refactor; spying on it without mocking lets the wrapper
-		// flow through to `UsersService.createMany` (so the email / password /
-		// integrity checks fire), while the spy still records what the caller
-		// passed for the `inviteUser` assertions below.
 		const superCreateOneSpy = vi.spyOn(ItemsService.prototype, 'createOne');
 		const superCreateManySpy = vi.spyOn(ItemsService.prototype, 'createMany').mockResolvedValue(['user-id-1']);
 		const superUpdateOneSpy = vi.spyOn(ItemsService.prototype, 'updateOne').mockResolvedValue('user-id-1');

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -65,7 +65,13 @@ describe('Integration Tests', () => {
 			schema,
 		});
 
-		const superCreateOneSpy = vi.spyOn(ItemsService.prototype, 'createOne').mockResolvedValue('user-id-1');
+		// `createOne` is a thin wrapper around `createMany([data])` since the
+		// batchInsert refactor; spying on it without mocking lets the wrapper
+		// flow through to `UsersService.createMany` (so the email / password /
+		// integrity checks fire), while the spy still records what the caller
+		// passed for the `inviteUser` assertions below.
+		const superCreateOneSpy = vi.spyOn(ItemsService.prototype, 'createOne');
+		const superCreateManySpy = vi.spyOn(ItemsService.prototype, 'createMany').mockResolvedValue(['user-id-1']);
 		const superUpdateOneSpy = vi.spyOn(ItemsService.prototype, 'updateOne').mockResolvedValue('user-id-1');
 		const superUpdateManySpy = vi.spyOn(ItemsService.prototype, 'updateMany').mockResolvedValue(['user-id-2']);
 
@@ -96,12 +102,41 @@ describe('Integration Tests', () => {
 			vi.clearAllMocks();
 		});
 
-		// NOTE: no `createOne` block — since the batchInsert refactor `createOne` is
-		// a thin `[pk] = await createMany([data])` wrapper, so the createMany tests
-		// below exercise the same per-row validation path.
-		describe('createMany', () => {
-			vi.spyOn(ItemsService.prototype, 'createMany').mockResolvedValue([1]);
+		describe('createOne', () => {
+			it('should not checkUniqueEmails', async () => {
+				await service.createOne({});
 
+				expect(checkUniqueEmailsSpy).not.toBeCalled();
+			});
+
+			it('should checkUniqueEmails once', async () => {
+				await service.createOne({ email: 'test@example.com' });
+
+				expect(checkUniqueEmailsSpy).toBeCalledTimes(1);
+			});
+
+			it('should not checkPasswordPolicy', async () => {
+				await service.createOne({});
+
+				expect(checkPasswordPolicySpy).not.toBeCalled();
+			});
+
+			it('should checkPasswordPolicy once', async () => {
+				await service.createOne({ password: 'testpassword' });
+
+				expect(checkPasswordPolicySpy).toBeCalledTimes(1);
+			});
+
+			it('should request user limits checks', async () => {
+				const opts: MutationOptions = {};
+
+				await service.createOne({}, opts);
+
+				expect(opts.userIntegrityCheckFlags).toBe(UserIntegrityCheckFlag.UserLimits);
+			});
+		});
+
+		describe('createMany', () => {
 			it('should not checkUniqueEmails', async () => {
 				await service.createMany([{}]);
 

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -185,12 +185,7 @@ export class UsersService extends ItemsService {
 	}
 
 	/**
-	 * Create a new user
-	 */
-	/**
-	 * Create one or more new users. `createOne` (now a `createMany([data])`
-	 * wrapper on `ItemsService`) routes through here, so per-row validation
-	 * naturally collapses into the array form below.
+	 * Create one or more new users
 	 */
 	override async createMany(data: Partial<Item>[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
 		const emails = data.map((payload) => payload['email']).filter((email) => email);

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -187,33 +187,10 @@ export class UsersService extends ItemsService {
 	/**
 	 * Create a new user
 	 */
-	override async createOne(data: Partial<Item>, opts: MutationOptions = {}): Promise<PrimaryKey> {
-		try {
-			if ('email' in data && data['email'] !== undefined) {
-				this.validateEmail(data['email']);
-				await this.checkUniqueEmails([data['email']]);
-			}
-
-			if ('password' in data) {
-				await this.checkPasswordPolicy([data['password']]);
-			}
-		} catch (err: any) {
-			opts.preMutationError = err;
-		}
-
-		if (!('status' in data) || data['status'] === 'active') {
-			// Creating a user only requires checking user limits if the user is active, no need to care about the role
-			opts.userIntegrityCheckFlags =
-				(opts.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None) | UserIntegrityCheckFlag.UserLimits;
-
-			opts.onRequireUserIntegrityCheck?.(opts.userIntegrityCheckFlags);
-		}
-
-		return await super.createOne(data, opts);
-	}
-
 	/**
-	 * Create multiple new users
+	 * Create one or more new users. `createOne` (now a `createMany([data])`
+	 * wrapper on `ItemsService`) routes through here, so per-row validation
+	 * naturally collapses into the array form below.
 	 */
 	override async createMany(data: Partial<Item>[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
 		const emails = data.map((payload) => payload['email']).filter((email) => email);

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -188,8 +188,8 @@ export class UsersService extends ItemsService {
 	 * Create one or more new users
 	 */
 	override async createMany(data: Partial<Item>[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
-		const emails = data.map((payload) => payload['email']).filter((email) => email);
-		const passwords = data.map((payload) => payload['password']).filter((password) => password);
+		const emails = data.map((payload) => payload['email']).filter((email) => email !== undefined);
+		const passwords = data.map((payload) => payload['password']).filter((password) => password !== undefined);
 		const someActive = data.some((payload) => !('status' in payload) || payload['status'] === 'active');
 
 		try {

--- a/api/src/services/versions.ts
+++ b/api/src/services/versions.ts
@@ -132,16 +132,6 @@ export class VersionsService extends ItemsService<ContentVersion> {
 		return version;
 	}
 
-	override async createOne(data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
-		await this.validateCreateData(data);
-
-		const mainItem = await this.getMainItem(data['collection'], data['item']);
-
-		data['hash'] = objectHash(mainItem);
-
-		return super.createOne(data, opts);
-	}
-
 	override async readOne(key: PrimaryKey, query: Query = {}, opts?: QueryOptions): Promise<ContentVersion> {
 		const version = await super.readOne(key, query, opts);
 
@@ -155,9 +145,17 @@ export class VersionsService extends ItemsService<ContentVersion> {
 			throw new InvalidPayloadError({ reason: 'Input should be an array of items' });
 		}
 
+		// `createOne` (now a `createMany([data])` wrapper on `ItemsService`) routes
+		// through here, so per-row validation + `hash` computation moved into the
+		// loop below — there's no longer a separate single-row override to host them.
 		const keyCombos = new Set();
 
 		for (const item of data) {
+			await this.validateCreateData(item);
+
+			const mainItem = await this.getMainItem(item['collection'], item['item']);
+			item['hash'] = objectHash(mainItem);
+
 			const keyCombo = `${item['key']}-${item['collection']}-${item['item']}`;
 
 			if (keyCombos.has(keyCombo)) {

--- a/api/src/services/versions.ts
+++ b/api/src/services/versions.ts
@@ -145,9 +145,6 @@ export class VersionsService extends ItemsService<ContentVersion> {
 			throw new InvalidPayloadError({ reason: 'Input should be an array of items' });
 		}
 
-		// `createOne` (now a `createMany([data])` wrapper on `ItemsService`) routes
-		// through here, so per-row validation + `hash` computation moved into the
-		// loop below — there's no longer a separate single-row override to host them.
 		const keyCombos = new Set();
 
 		for (const item of data) {

--- a/packages/env/src/constants/defaults.ts
+++ b/packages/env/src/constants/defaults.ts
@@ -21,6 +21,8 @@ export const DEFAULTS: Env = {
 	TEMP_PATH: './node_modules/.directus',
 
 	DB_EXCLUDE_TABLES: 'spatial_ref_sys,sysdiagrams',
+	DB_DEFAULT_ORDER_READS_BY_PK: true,
+	DB_MSSQL_TRUST_BATCH_RETURNING: false,
 
 	STORAGE_LOCATIONS: 'local',
 	STORAGE_LOCAL_DRIVER: 'local',

--- a/packages/env/src/constants/type-map.ts
+++ b/packages/env/src/constants/type-map.ts
@@ -16,6 +16,10 @@ export const TYPE_MAP: Record<string, EnvType> = {
 
 	DB_EXCLUDE_TABLES: 'array',
 
+	DB_BATCH_INSERT_CHUNK_SIZE: 'number',
+	DB_DEFAULT_ORDER_READS_BY_PK: 'boolean',
+	DB_MSSQL_TRUST_BATCH_RETURNING: 'boolean',
+
 	CACHE_SKIP_ALLOWED: 'boolean',
 	CACHE_AUTO_PURGE_IGNORE_LIST: 'array',
 	CACHE_SCHEMA_MAX_ITERATIONS: 'number',

--- a/tests/blackbox/extensions/action-verify-create/index.mjs
+++ b/tests/blackbox/extensions/action-verify-create/index.mjs
@@ -25,7 +25,7 @@ export default function registerHooks({ action }, { services }) {
 		try {
 			const item = await itemService.readOne(data.key);
 
-			if (item.name !== data.payload.name) {
+			if (item.name !== data.payload.name || data.payload.id !== data.key) {
 				throw 'Invalid item';
 			}
 

--- a/tests/blackbox/extensions/env-inject/index.mjs
+++ b/tests/blackbox/extensions/env-inject/index.mjs
@@ -1,0 +1,16 @@
+export default (router, { env }) => {
+	router.post('/set', (req, res) => {
+		if (!env) {
+			return res.status(500).json({ errors: [{ message: 'env not provided in extension context' }] });
+		}
+
+		const { key, value } = req.body ?? {};
+
+		if (typeof key !== 'string' || key.length === 0) {
+			return res.status(400).json({ errors: [{ message: 'missing string "key"' }] });
+		}
+
+		env[key] = value;
+		res.json({ data: { key, value } });
+	});
+};

--- a/tests/blackbox/extensions/env-inject/package.json
+++ b/tests/blackbox/extensions/env-inject/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "env-inject",
+	"version": "0.0.0",
+	"private": true,
+	"directus:extension": {
+		"type": "endpoint",
+		"path": "index.mjs",
+		"source": "index.mjs",
+		"host": "^10.10.0"
+	}
+}

--- a/tests/blackbox/extensions/query-counter/index.mjs
+++ b/tests/blackbox/extensions/query-counter/index.mjs
@@ -1,0 +1,37 @@
+const MAX = 5000;
+const buffer = [];
+
+function recordQuery(q) {
+	const bindings = Array.isArray(q?.bindings) ? q.bindings.map((b) => (b === null ? '' : String(b))).join(' ') : '';
+
+	buffer.push({ sql: q?.sql ?? '', bindings, t: Date.now() });
+
+	if (buffer.length > MAX) {
+		buffer.shift();
+	}
+}
+
+export default (router, { database }) => {
+	if (!database.__queryCounterAttached) {
+		database.on('query', recordQuery);
+		database.__queryCounterAttached = true;
+	}
+
+	router.get('/queries', (req, res) => {
+		const containsBinding = typeof req.query.containsBinding === 'string' ? req.query.containsBinding : '';
+		const containsSql = typeof req.query.containsSql === 'string' ? req.query.containsSql.toLowerCase() : '';
+
+		const matches = buffer.filter((entry) => {
+			if (containsBinding && !entry.bindings.includes(containsBinding)) return false;
+			if (containsSql && !entry.sql.toLowerCase().includes(containsSql)) return false;
+			return true;
+		});
+
+		res.json({ data: matches, total: buffer.length });
+	});
+
+	router.post('/reset', (_req, res) => {
+		buffer.length = 0;
+		res.json({ data: { reset: true } });
+	});
+};

--- a/tests/blackbox/extensions/query-counter/package.json
+++ b/tests/blackbox/extensions/query-counter/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "query-counter",
+	"version": "0.0.0",
+	"private": true,
+	"directus:extension": {
+		"type": "endpoint",
+		"path": "index.mjs",
+		"source": "index.mjs",
+		"host": "^10.10.0"
+	}
+}

--- a/tests/blackbox/tests/db/routes/items/batch-insert.test.ts
+++ b/tests/blackbox/tests/db/routes/items/batch-insert.test.ts
@@ -123,8 +123,13 @@ describe.each(PRIMARY_KEY_TYPES)('/items batch-insert', (pkType) => {
 
 				await resetQueryCounter(vendor);
 
+				// Narrow response to the columns this test owns. The shared `no-relation.seed`
+				// collection carries additional fields (group, date_published) on upstream
+				// that this test doesn't seed and doesn't care about; without fields= the
+				// strict `toEqual` below would tip over on those extra props.
 				const response = await request(getUrl(vendor))
 					.post(`/items/${localCollectionArtists}`)
+					.query({ fields: 'id,name,company' })
 					.send(artists)
 					.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
 
@@ -200,6 +205,7 @@ describe.each(PRIMARY_KEY_TYPES)('/items batch-insert', (pkType) => {
 
 				const response = await request(getUrl(vendor))
 					.post(`/items/${localCollectionArtists}`)
+					.query({ fields: 'id,name,company' })
 					.send(artists)
 					.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
 
@@ -271,6 +277,7 @@ describe.each(PRIMARY_KEY_TYPES)('/items batch-insert', (pkType) => {
 
 				const response = await request(getUrl(vendor))
 					.post(`/items/${localCollectionArtists}`)
+					.query({ fields: 'id,name,company' })
 					.send(artists)
 					.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
 

--- a/tests/blackbox/tests/db/routes/items/batch-insert.test.ts
+++ b/tests/blackbox/tests/db/routes/items/batch-insert.test.ts
@@ -8,15 +8,17 @@ import request from 'supertest';
 import { describe, expect, it } from 'vitest';
 import { collectionArtists } from './no-relation.seed';
 
-// Vendors where ItemsService.createMany emits a single multi-row INSERT … RETURNING (the
-// "reliable batch" path in api/src/services/items.ts). All other vendors fall through the
-// per-row loop and emit one INSERT per item. Both paths must produce the same observable
-// result (count, distinct PKs, fields round-trip, explicit PKs preserved) — only the
-// expected number of INSERT statements differs.
+// Vendors where ItemsService.createMany emits a single multi-row INSERT … RETURNING
+// (the "reliable batch" path in api/src/services/items.ts).
 //
-// sqlite3 is included here because it sits on top of SQLite ≥ 3.35, where INSERT … RETURNING
-// is supported natively; ItemsService probes the version at runtime and falls back to the
-// loop path on older builds. https://www.sqlite.org/lang_returning.html
+// - All other vendors fall through the per-row loop and emit one INSERT per item.
+// - Both paths must produce the same observable result (count, distinct PKs, fields
+//   round-trip, explicit PKs preserved) — only the expected number of INSERT
+//   statements differs.
+// - sqlite3 is included because it sits on top of SQLite ≥ 3.35, where INSERT …
+//   RETURNING is supported natively; ItemsService probes the version at runtime and
+//   falls back to the loop path on older builds
+//   (https://www.sqlite.org/lang_returning.html).
 const RETURNING_VENDORS = [
 	'postgres',
 	'postgres10',
@@ -35,13 +37,17 @@ function isReliableBatchVendor(vendor: Vendor): boolean {
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-// NOTE on response ordering: POST /items returns `data` via `service.readMany(savedKeys)`.
-// As of the DB_DEFAULT_ORDER_READS_BY_PK default in readByQuery, responses for collections
-// with an integer / bigInteger PK are ORDER BY <primary key> ASC (unless the caller passes
-// an explicit `sort`); UUID / string PK collections remain plan-dependent. Tests below sort
-// both `expected` and `got` by `name` before deep-equal: name is a stable semantic key
-// across every pkType, and keeps assertions resilient if the default ordering changes or
-// is turned off (e.g. DB_DEFAULT_ORDER_READS_BY_PK=false).
+// Response ordering note:
+//
+// - POST /items returns `data` via `service.readMany(savedKeys)`.
+// - With the DB_DEFAULT_ORDER_READS_BY_PK default in readByQuery, responses for
+//   collections with an integer / bigInteger PK are `ORDER BY <primary key> ASC`
+//   (unless the caller passes an explicit `sort`); UUID / string PK collections
+//   remain plan-dependent.
+// - Tests below sort both `expected` and `got` by `name` before deep-equal:
+//   - `name` is a stable semantic key across every pkType.
+//   - Keeps assertions resilient if the default ordering changes or is turned off
+//     (e.g. DB_DEFAULT_ORDER_READS_BY_PK=false).
 
 type Artist = {
 	id?: number | string;
@@ -145,10 +151,11 @@ describe.each(PRIMARY_KEY_TYPES)('/items batch-insert', (pkType) => {
 
 				if (pkType === 'integer') {
 					// Integer-PK collections get DB_DEFAULT_ORDER_READS_BY_PK = ORDER BY pk ASC.
-					// Auto-increment IDs are assigned in insertion order, so PK ASC == input
-					// order. Comparing without any sort actively pins that the default
-					// ordering kicked in — if DB_DEFAULT_ORDER_READS_BY_PK gets disabled or
-					// the integer-PK branch in readByQuery regresses, this assertion fails.
+					//
+					// - Auto-increment IDs are assigned in insertion order, so PK ASC == input order.
+					// - Comparing without any sort actively pins that the default ordering kicked in.
+					// - If DB_DEFAULT_ORDER_READS_BY_PK gets disabled or the integer-PK branch in
+					//   readByQuery regresses, this assertion fails.
 					expect(got).toEqual(expected);
 				} else {
 					// UUID / string PKs are intentionally excluded from the default sort, so
@@ -210,11 +217,13 @@ describe.each(PRIMARY_KEY_TYPES)('/items batch-insert', (pkType) => {
 					.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
 
 				// MSSQL: inserting explicit values into an IDENTITY-typed integer PK requires
-				// SET IDENTITY_INSERT ON. Neither knex's mssql querycompiler nor Directus's
-				// createMany emits that toggle, so the INSERT fails with SQL Server error 544
-				// ("Cannot insert explicit value for identity column ... when IDENTITY_INSERT
-				// is set to OFF"). We pin the failure here so a future fix (e.g. an mssql
-				// override in api/src/database/helpers/sequence/dialects/) lights up this test.
+				// SET IDENTITY_INSERT ON.
+				//
+				// - Neither knex's mssql querycompiler nor Directus's createMany emits the toggle.
+				// - The INSERT fails with SQL Server error 544 ("Cannot insert explicit value for
+				//   identity column ... when IDENTITY_INSERT is set to OFF").
+				// - We pin the failure here so a future fix (e.g. an mssql override in
+				//   api/src/database/helpers/sequence/dialects/) lights up this test.
 				if (pkType === 'integer' && vendor === 'mssql') {
 					expect(response.statusCode).toBeGreaterThanOrEqual(400);
 					expect(Array.isArray(response.body.errors)).toBe(true);

--- a/tests/blackbox/tests/db/routes/items/batch-insert.test.ts
+++ b/tests/blackbox/tests/db/routes/items/batch-insert.test.ts
@@ -1,9 +1,9 @@
+import { randomUUID } from 'node:crypto';
 import { getUrl } from '@common/config';
 import vendors, { type Vendor } from '@common/get-dbs-to-test';
 import type { PrimaryKeyType } from '@common/types';
 import { PRIMARY_KEY_TYPES, USER } from '@common/variables';
 import { setDirectusEnv } from '@utils/set-directus-env';
-import { randomUUID } from 'node:crypto';
 import request from 'supertest';
 import { describe, expect, it } from 'vitest';
 import { collectionArtists } from './no-relation.seed';

--- a/tests/blackbox/tests/db/routes/items/batch-insert.test.ts
+++ b/tests/blackbox/tests/db/routes/items/batch-insert.test.ts
@@ -1,0 +1,366 @@
+import { getUrl } from '@common/config';
+import vendors, { type Vendor } from '@common/get-dbs-to-test';
+import type { PrimaryKeyType } from '@common/types';
+import { PRIMARY_KEY_TYPES, USER } from '@common/variables';
+import { setDirectusEnv } from '@utils/set-directus-env';
+import { randomUUID } from 'node:crypto';
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+import { collectionArtists } from './no-relation.seed';
+
+// Vendors where ItemsService.createMany emits a single multi-row INSERT … RETURNING (the
+// "reliable batch" path in api/src/services/items.ts). All other vendors fall through the
+// per-row loop and emit one INSERT per item. Both paths must produce the same observable
+// result (count, distinct PKs, fields round-trip, explicit PKs preserved) — only the
+// expected number of INSERT statements differs.
+//
+// sqlite3 is included here because it sits on top of SQLite ≥ 3.35, where INSERT … RETURNING
+// is supported natively; ItemsService probes the version at runtime and falls back to the
+// loop path on older builds. https://www.sqlite.org/lang_returning.html
+const RETURNING_VENDORS = [
+	'postgres',
+	'postgres10',
+	'cockroachdb',
+	'oracle',
+	'sqlite3',
+	// mssql is opt-in only via DB_MSSQL_TRUST_BATCH_RETURNING (see
+	// api/src/database/helpers/capabilities/dialects/mssql.ts). When the env var
+	// isn't set — which is the case in CI by default — mssql falls through the
+	// per-row loop bucket and emits N INSERTs.
+] as const satisfies readonly Vendor[];
+
+function isReliableBatchVendor(vendor: Vendor): boolean {
+	return (RETURNING_VENDORS as readonly Vendor[]).includes(vendor);
+}
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// NOTE on response ordering: POST /items returns `data` via `service.readMany(savedKeys)`.
+// As of the DB_DEFAULT_ORDER_READS_BY_PK default in readByQuery, responses for collections
+// with an integer / bigInteger PK are ORDER BY <primary key> ASC (unless the caller passes
+// an explicit `sort`); UUID / string PK collections remain plan-dependent. Tests below sort
+// both `expected` and `got` by `name` before deep-equal: name is a stable semantic key
+// across every pkType, and keeps assertions resilient if the default ordering changes or
+// is turned off (e.g. DB_DEFAULT_ORDER_READS_BY_PK=false).
+
+type Artist = {
+	id?: number | string;
+	name: string;
+	company: string;
+};
+
+function buildArtist(
+	pkType: PrimaryKeyType,
+	index: number,
+	nonce: string,
+	opts: { explicitId?: boolean } = {},
+): Artist {
+	const artist: Artist = {
+		name: `batch-${index}-${nonce}`,
+		company: `co-${index}-${nonce}`,
+	};
+
+	if (pkType === 'string') {
+		artist.id = `artist-${nonce}-${index}`;
+	} else if (opts.explicitId) {
+		if (pkType === 'uuid') {
+			artist.id = randomUUID();
+		} else if (pkType === 'integer') {
+			// 1B+ offset stays above per-table AUTO_INCREMENT in fresh test DBs;
+			// nonce hash makes consecutive runs use disjoint ranges.
+			const nonceNum = parseInt(nonce.replace(/-/g, '').slice(0, 8), 16);
+			artist.id = 1_000_000_000 + (nonceNum % 100_000_000) + index;
+		}
+	}
+
+	return artist;
+}
+
+async function resetQueryCounter(vendor: Vendor) {
+	await request(getUrl(vendor)).post('/query-counter/reset').set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+}
+
+const sortByName = (x: { name: string }, y: { name: string }) => x.name.localeCompare(y.name);
+
+async function fetchInsertQueriesForNonce(vendor: Vendor, nonce: string, collection: string) {
+	const response = await request(getUrl(vendor))
+		.get(`/query-counter/queries`)
+		.query({ containsBinding: nonce, containsSql: `insert into` })
+		.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+	const data = (response.body.data ?? []) as Array<{ sql: string; bindings: string }>;
+	return data.filter((q) => q.sql.toLowerCase().includes(collection.toLowerCase()));
+}
+
+describe.each(PRIMARY_KEY_TYPES)('/items batch-insert', (pkType) => {
+	const localCollectionArtists = `${collectionArtists}_${pkType}`;
+
+	describe(`pkType: ${pkType}`, () => {
+		describe('createMany short-circuits on empty input', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const nonce = randomUUID();
+
+				await resetQueryCounter(vendor);
+
+				const response = await request(getUrl(vendor))
+					.post(`/items/${localCollectionArtists}`)
+					.send([])
+					.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+				expect(response.statusCode).toBe(200);
+				expect(response.body.data).toEqual([]);
+
+				const inserts = await fetchInsertQueriesForNonce(vendor, nonce, localCollectionArtists);
+				expect(inserts).toHaveLength(0);
+			});
+		});
+
+		describe('createMany returns N items with distinct PKs, fields round-trip', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const N = 5;
+				const nonce = randomUUID();
+				const artists = Array.from({ length: N }, (_, i) => buildArtist(pkType, i, nonce));
+
+				await resetQueryCounter(vendor);
+
+				const response = await request(getUrl(vendor))
+					.post(`/items/${localCollectionArtists}`)
+					.send(artists)
+					.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+				expect(response.statusCode).toBe(200);
+
+				const expected = artists.map((a) => ({
+					id: a.id ?? (pkType === 'integer' ? expect.any(Number) : expect.stringMatching(UUID_REGEX)),
+					name: a.name,
+					company: a.company,
+				}));
+
+				const got = response.body.data as Array<{ id: number | string; name: string; company: string }>;
+
+				if (pkType === 'integer') {
+					// Integer-PK collections get DB_DEFAULT_ORDER_READS_BY_PK = ORDER BY pk ASC.
+					// Auto-increment IDs are assigned in insertion order, so PK ASC == input
+					// order. Comparing without any sort actively pins that the default
+					// ordering kicked in — if DB_DEFAULT_ORDER_READS_BY_PK gets disabled or
+					// the integer-PK branch in readByQuery regresses, this assertion fails.
+					expect(got).toEqual(expected);
+				} else {
+					// UUID / string PKs are intentionally excluded from the default sort, so
+					// the response is in plan-dependent order. Sort both sides by `name` to
+					// compare order-independently.
+					expect([...got].sort(sortByName)).toEqual([...expected].sort(sortByName));
+				}
+
+				// Engine UNIQUE prevents row-level PK dups; this pins that createMany's
+				// PK reassignment reports them back distinctly — catches off-by-one or
+				// shuffle regressions in the insertedRows → itemsToInsert mapping at
+				// items.ts:430-449.
+				expect(new Set(got.map((g) => g.id)).size).toBe(N);
+
+				// Query-count is the only branch: reliable vendors emit one multi-row INSERT,
+				// loop-bucket vendors emit one INSERT per row.
+				const inserts = await fetchInsertQueriesForNonce(vendor, nonce, localCollectionArtists);
+				expect(inserts).toHaveLength(isReliableBatchVendor(vendor) ? 1 : N);
+			});
+		});
+
+		describe('createOne (single-object POST) returns one item via createMany([one])', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const nonce = randomUUID();
+				const artist = buildArtist(pkType, 0, nonce);
+
+				await resetQueryCounter(vendor);
+
+				const response = await request(getUrl(vendor))
+					.post(`/items/${localCollectionArtists}`)
+					.send(artist)
+					.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+				expect(response.statusCode).toBe(200);
+				expect(response.body.data).toMatchObject({ name: artist.name, company: artist.company });
+
+				const inserts = await fetchInsertQueriesForNonce(vendor, nonce, localCollectionArtists);
+				expect(inserts).toHaveLength(1);
+			});
+		});
+
+		if (pkType === 'string') {
+			return;
+		}
+
+		describe('createMany preserves explicit PKs (homogeneous-explicit batch)', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const N = 3;
+				const nonce = randomUUID();
+
+				const artists = Array.from({ length: N }, (_, i) => buildArtist(pkType, i, nonce, { explicitId: true }));
+
+				await resetQueryCounter(vendor);
+
+				const response = await request(getUrl(vendor))
+					.post(`/items/${localCollectionArtists}`)
+					.send(artists)
+					.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+				// MSSQL: inserting explicit values into an IDENTITY-typed integer PK requires
+				// SET IDENTITY_INSERT ON. Neither knex's mssql querycompiler nor Directus's
+				// createMany emits that toggle, so the INSERT fails with SQL Server error 544
+				// ("Cannot insert explicit value for identity column ... when IDENTITY_INSERT
+				// is set to OFF"). We pin the failure here so a future fix (e.g. an mssql
+				// override in api/src/database/helpers/sequence/dialects/) lights up this test.
+				if (pkType === 'integer' && vendor === 'mssql') {
+					expect(response.statusCode).toBeGreaterThanOrEqual(400);
+					expect(Array.isArray(response.body.errors)).toBe(true);
+					expect(response.body.errors.length).toBeGreaterThan(0);
+					return;
+				}
+
+				expect(response.statusCode).toBe(200);
+
+				const expected = artists.map((a) => ({
+					// MSSQL's UNIQUEIDENTIFIER column round-trips UUIDs uppercase
+					// (Directus's mssql schema helper does .toUpperCase() in formatUUID);
+					// our explicit randomUUID() values are lowercase, so adjust expected
+					// to match.
+					id: pkType === 'uuid' && vendor === 'mssql' ? (a.id as string).toUpperCase() : a.id,
+					name: a.name,
+					company: a.company,
+				}));
+
+				const got = response.body.data as Array<{ id: string | number; name: string; company: string }>;
+
+				if (pkType === 'integer') {
+					// Explicit integer IDs are monotonically ascending (1B + nonceHash + index),
+					// so PK ASC (DB_DEFAULT_ORDER_READS_BY_PK) puts `got` in the same order as
+					// `expected` (input order). Comparing without any sort actively pins that
+					// the default ordering kicked in.
+					expect(got).toEqual(expected);
+				} else {
+					// UUID PKs are intentionally excluded from the default sort; response
+					// order is plan-dependent. Sort both sides by `name` to compare
+					// order-independently.
+					expect([...got].sort(sortByName)).toEqual([...expected].sort(sortByName));
+				}
+
+				const inserts = await fetchInsertQueriesForNonce(vendor, nonce, localCollectionArtists);
+				expect(inserts).toHaveLength(isReliableBatchVendor(vendor) ? 1 : N);
+			});
+		});
+
+		describe('createMany preserves explicit PKs and auto-generates the rest (mixed batch)', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const N = 5;
+				const nonce = randomUUID();
+				const explicitIndices = new Set([0, 2, 4]);
+
+				const artists: Artist[] = Array.from({ length: N }, (_, i) =>
+					buildArtist(pkType, i, nonce, { explicitId: explicitIndices.has(i) }),
+				);
+
+				// MSSQL's UNIQUEIDENTIFIER round-trips UUIDs uppercase (Directus's mssql
+				// formatUUID does .toUpperCase()); our explicit randomUUID() values are
+				// lowercase. Normalize both `expected` and `explicitIds` through this
+				// helper so the assertions below match what the server returns.
+				const explicitIdFor = (a: Artist) =>
+					pkType === 'uuid' && vendor === 'mssql' ? (a.id as string).toUpperCase() : a.id;
+
+				const explicitIds = new Set([...explicitIndices].map((i) => explicitIdFor(artists[i]!)!));
+
+				await resetQueryCounter(vendor);
+
+				const response = await request(getUrl(vendor))
+					.post(`/items/${localCollectionArtists}`)
+					.send(artists)
+					.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+				// Same IDENTITY_INSERT limitation as the homogeneous-explicit block —
+				// mssql + integer PK can't accept explicit values without the toggle
+				// that Directus doesn't emit. Pin the failure.
+				if (pkType === 'integer' && vendor === 'mssql') {
+					expect(response.statusCode).toBeGreaterThanOrEqual(400);
+					expect(Array.isArray(response.body.errors)).toBe(true);
+					expect(response.body.errors.length).toBeGreaterThan(0);
+					return;
+				}
+
+				expect(response.statusCode).toBe(200);
+
+				const autoIdMatcher = pkType === 'integer' ? expect.any(Number) : expect.stringMatching(UUID_REGEX);
+
+				const expected = artists
+					.map((a, i) => ({
+						id: explicitIndices.has(i) ? explicitIdFor(a) : autoIdMatcher,
+						name: a.name,
+						company: a.company,
+					}))
+					.sort(sortByName);
+
+				// PK ASC is dialect-dependent for a mixed-integer batch (postgres/oracle
+				// put auto-row small IDs before explicit 1B+ IDs; mysql/maria/sqlite bump
+				// AUTO_INCREMENT past explicits so the auto IDs interleave). UUID mixed
+				// has random PK order. Either way response order isn't a meaningful
+				// invariant to pin here — sort by `name` and compare order-independently.
+				const got = [...(response.body.data as Array<{ id: string | number; name: string; company: string }>)].sort(
+					sortByName,
+				);
+
+				expect(got).toEqual(expected);
+
+				// Engine UNIQUE prevents row-level PK dups; these pin that createMany's
+				// PK reassignment reports them back distinctly AND keeps explicit IDs
+				// disjoint from auto-gen ones — catches off-by-one or shuffle regressions
+				// in the insertedRows → itemsToInsert mapping at items.ts:430-449.
+				const allIds = new Set(got.map((g) => g.id));
+				expect(allIds.size).toBe(N);
+				expect([...allIds].filter((id) => explicitIds.has(id))).toHaveLength(explicitIndices.size);
+
+				const inserts = await fetchInsertQueriesForNonce(vendor, nonce, localCollectionArtists);
+				expect(inserts).toHaveLength(isReliableBatchVendor(vendor) ? 1 : N);
+			});
+		});
+	});
+});
+
+// MSSQL is opt-in for the batch bucket (see DB_MSSQL_TRUST_BATCH_RETURNING in
+// api/src/database/helpers/capabilities/dialects/mssql.ts). The blocks above
+// cover the default (loop-bucket) behavior; this block flips the env var via
+// the `env-inject` test extension to verify the opt-in path emits one
+// multi-row INSERT instead of N per-row ones — on the SAME spawned Directus
+// instance, without a restart. See setDirectusEnv() for how that works.
+if ((vendors as readonly Vendor[]).includes('mssql')) {
+	describe('/items batch-insert: mssql DB_MSSQL_TRUST_BATCH_RETURNING=true (opt-in batch bucket)', () => {
+		const vendor: Vendor = 'mssql';
+		const localCollectionArtists = `${collectionArtists}_integer`;
+
+		it('createMany emits one multi-row INSERT', async () => {
+			// Scope the env flip tightly to this test: setting it in beforeAll keeps
+			// trust-batch=true on the shared mssql Directus instance for the entire
+			// describe lifecycle, which races against any other test file running
+			// concurrently against the same instance (they'd unexpectedly hit the
+			// batch path). try/finally narrows the window to this test's body only.
+			await setDirectusEnv(vendor, 'DB_MSSQL_TRUST_BATCH_RETURNING', 'true');
+
+			try {
+				const N = 5;
+				const nonce = randomUUID();
+				const artists = Array.from({ length: N }, (_, i) => buildArtist('integer', i, nonce));
+
+				await resetQueryCounter(vendor);
+
+				const response = await request(getUrl(vendor))
+					.post(`/items/${localCollectionArtists}`)
+					.send(artists)
+					.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+				expect(response.statusCode).toBe(200);
+				expect(response.body.data).toHaveLength(N);
+
+				const inserts = await fetchInsertQueriesForNonce(vendor, nonce, localCollectionArtists);
+				expect(inserts).toHaveLength(1);
+			} finally {
+				await setDirectusEnv(vendor, 'DB_MSSQL_TRUST_BATCH_RETURNING', '');
+			}
+		});
+	});
+}

--- a/tests/blackbox/utils/set-directus-env.ts
+++ b/tests/blackbox/utils/set-directus-env.ts
@@ -1,0 +1,25 @@
+import { getUrl } from '@common/config';
+import type { Vendor } from '@common/get-dbs-to-test';
+import { USER } from '@common/variables';
+import request from 'supertest';
+
+/**
+ * Mutates a single key on the running Directus's cached env object via the
+ * `env-inject` test extension. Lets a test flip a runtime-checked env var
+ * (e.g. DB_MSSQL_TRUST_BATCH_RETURNING) on the SAME spawned Directus
+ * instance, without restarting it.
+ *
+ * Only effective for env vars that are re-read on each access via the `env`
+ * reference returned by useEnv() — env vars captured into a const at module
+ * load are unaffected.
+ */
+export async function setDirectusEnv(vendor: Vendor, key: string, value: string): Promise<void> {
+	const response = await request(getUrl(vendor))
+		.post('/env-inject/set')
+		.send({ key, value })
+		.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+	if (response.statusCode !== 200) {
+		throw new Error(`env-inject set ${key} failed (${response.statusCode}): ${JSON.stringify(response.body)}`);
+	}
+}


### PR DESCRIPTION
Last September I encountered performances issues when my users needed to insert several items (upon 100).

- I realized Directus doesn't use `batchInsert` even for dbms supporting it like Postgres.
- I implemented a WIP version in my fork to support it and it made my app usable for my users
- Glad to LLMs, I can now extract this patch (as it is merged with several other perf tweaks I need) and gather the required information for the dbms I don't use 

## Architecture
- To achieve this, the main point is to base `createOne` on `createMany` instead of basing `createMany` on `createOne`
- This required to switch extending `createOne` by extending `createMany` in `UsersService`, `FilesService`, `CommentsService`, `NotificationsService`, `PermissionsService`, `OperationsService`, `PoliciesService`, `RevisionsService`, `VersionsService`. 
    - IMHO using hooks may match the ItemsService pattern more but I considered it out of scope.
    - I added quite a lot of tests to ensure the upstream behavior is preserved
- `batchInsert` will create rows with the same `NOW()` value so ordering by `date_created` doesn't work always as before. I added a default order by pk (controlled by DB_DEFAULT_ORDER_READS_BY_PK env var) to reduce regression risk for Directus users
- There was an inconsistency regarding `actionHookPayload[primaryKeyField] = primaryKey;` which was set only when the dbms didn't return the pk (MySQL/Sqlite). I patched the tests to check it in blackbox tests but this may create retrocompatibility issues.
- The same pattern flip should be applied on `updateOne` / `updateMany` for better perf but Knex does support `batchUpdate` and it is obviously out-of-scope
- Most per dbms specific cases have been moved to the database layer (e.g. `{ includeTriggerModifications: true }` for MSSQL)
- Open question: 
    - Should I fully remove the use of `Knex.insert` branch to reduce the code size?
    - I guess the `Durus` project won't handle silently so flipping the `insertOne`/`insertMany` dependency seems to make sense


## DBMS support
Gated by a new `CapabilitiesHelper.preservesInsertOrderInReturning()` (default `false`). Per-dialect overrides:

- **postgres / cockroachdb / redshift** — `true` (contractual).
- **oracle** — `true` (knex emits per-row `RETURNING … INTO` inside `BEGIN…END`, collected via positional OUT binds).
- **sqlite** — `true` when runtime `sqlite_version()` ≥ 3.35 (when RETURNING landed).
- **mssql** — opt-in via `DB_MSSQL_TRUST_BATCH_RETURNING`. Microsoft says OUTPUT row order isn't preserved; empirically the OUTPUT-into-temp-table path stays insertion-ordered.
    - Should it be enabled by default to follow Knex behavior?
    - Also `{ includeTriggerModifications: true }` is not supported by Knex with `batchInsert`  so it would fail on tables having triggers. A per collection `DB_MSSQL_TRUST_BATCH_RETURNING` or listing tables with triggers may fix it but it seems out-of-scope to me.
- **mysql / maria** — `false`. MariaDB supports it since 10.5 but it is not enabled in Knex 

More: https://github.com/knex/knex/issues/6254

## New env vars

- `DB_BATCH_INSERT_CHUNK_SIZE` — knex passthrough, default 1000.
- `DB_MSSQL_TRUST_BATCH_RETURNING` — default `false`.
- `DB_DEFAULT_ORDER_READS_BY_PK` — default `true`.


## Known limitation
- The `order by date_created` issue
- Should be handled at the Knex layer IMHO
    - Some MSSQL niche cases (triggers / not contractual)
    - MariaDB support >= 10.5
- I heavily used Claude Code to extract my manual patch so
    - As I am not a native English speaker, I relied on it concerning 
        - some functions naming 
        - comments phrasing
    - So please tell me if some aren't accurate
    - Obviously, I carefully reviewed the generated code

## Checklist

- [x] Added or updated tests
- [ ] Documentation PR created [here](https://github.com/directus/docs) or not required
    - The specific points seems very technical compared to the rest of the docs but plz, tell if you think it is required.
    - The env vars need to be documented
    - The `order by date_created` seems to be the most important nuance for Directus users 
- [ ] ~OpenAPI package PR created [here](https://github.com/directus/openapi) or not required~

---

Related 
- https://github.com/directus/directus/discussions/16018

Fixes #24338
Fixes #27603

