### PR TITLE
ci(compose-hhh-main): fix 'main matched multiple remote tracking branches' in sync step

### DIFF
--- a/.github/workflows/compose-hhh-main.yml
+++ b/.github/workflows/compose-hhh-main.yml
@@ -56,7 +56,10 @@ jobs:
         run: |
           git remote add upstream https://github.com/directus/directus.git
           git fetch upstream main
-          git checkout main
+          # checkout lands on the PR merge ref (detached HEAD), and fetching
+          # upstream/main makes a bare `git checkout main` ambiguous (two remotes
+          # carry main). Pin the source explicitly so git's DWIM never guesses.
+          git checkout -B main origin/main
           # main = upstream + our thin overlay (this workflow), so it is ahead
           # of upstream and cannot fast-forward. Merge keeps the overlay; stays
           # clean unless upstream edits the same file.


### PR DESCRIPTION
Every `compose-hhh-main` run triggered by a `pull_request` has been dying in the **Sync fork main from upstream** step — `compose` shows red on every feature PR (e.g. #48), which is noise that hides real integration conflicts.

The cause isn't a merge conflict. `actions/checkout` lands on the PR *merge ref* in detached HEAD; the step then adds the `upstream` remote and fetches `upstream/main`, so two remote-tracking refs are now named `main`. The bare `git checkout main` that follows asks git to DWIM-create a local `main` from a remote — and with two candidates it refuses:

```
fatal: 'main' matched multiple (2) remote tracking branches
##[error]Process completed with exit code 128.
```

The job never reaches the PR-integration loop, so the "Skipped (merge conflict)" reporting downstream is never even exercised on these runs.

Fix is one line: pin the source explicitly — `git checkout -B main origin/main` — so DWIM never has to guess.

I scoped this to the checkout only. I did **not** touch the `git merge upstream/main` / `git push origin main` that follow, nor the integration loop — those run fine once the checkout resolves. Open question: do you want `checkout.defaultRemote=origin` set globally in the job too as a belt-and-suspenders, or is the explicit `-B` enough? I lean explicit-only.