### PR TITLE
upstream-draft: feat(filters): typed filter output (TIn/TOut) and items.create take-over (#32)

### DIFF
--- a/.changeset/filter-cancel-create.md
+++ b/.changeset/filter-cancel-create.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': minor
+---
+
+Let an `items.create` filter take over the creation by returning a primary key. When a `*.items.create` filter returns a `string`/`number` instead of a payload, `ItemsService.createOne` short-circuits the insert and surfaces that key (e.g. dedupe to an existing row, or hand off to an external store). Builds on the typed filter output (`FilterHandler<TIn, TOut>`); a filter returning a normal payload object inserts exactly as before.

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -188,6 +188,58 @@ describe('Integration Tests', () => {
 
 				transactionSpy.mockRestore();
 			});
+
+			it('should short-circuit and return the key when a create filter returns a string primary key', async () => {
+				const emitFilterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue('abc');
+
+				const insert = vi.fn().mockReturnThis();
+
+				const transactionSpy = vi.spyOn(db, 'transaction').mockImplementation(async (callback) => {
+					return await callback({ ...db, insert } as any);
+				});
+
+				const result = await service.createOne({ name: 'Test' });
+
+				expect(result).toBe('abc');
+				expect(insert).not.toHaveBeenCalled();
+
+				transactionSpy.mockRestore();
+				emitFilterSpy.mockRestore();
+			});
+
+			it('should NOT emit an items.create action when a filter takes over the create', async () => {
+				const emitFilterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(5);
+				const emitActionSpy = vi.spyOn(emitter, 'emitAction');
+
+				const transactionSpy = vi.spyOn(db, 'transaction').mockImplementation(async (callback) => {
+					return await callback({ ...db } as any);
+				});
+
+				await service.createOne({ name: 'Test' });
+
+				// the row was never created through this service, so the action must not fire
+				expect(emitActionSpy).not.toHaveBeenCalled();
+
+				transactionSpy.mockRestore();
+				emitActionSpy.mockRestore();
+				emitFilterSpy.mockRestore();
+			});
+
+			it('should insert and emit the action normally when a filter returns a payload object (no take-over)', async () => {
+				// control case: a filter that returns the payload (not a key) leaves creation to the service
+				const emitFilterSpy = vi
+					.spyOn(emitter, 'emitFilter')
+					.mockImplementation(async (_event: any, payload: any) => payload);
+
+				const emitActionSpy = vi.spyOn(emitter, 'emitAction');
+
+				await service.createOne({ name: 'Test' });
+
+				expect(emitActionSpy).toHaveBeenCalled();
+
+				emitActionSpy.mockRestore();
+				emitFilterSpy.mockRestore();
+			});
 		});
 
 		describe('createMany', () => {

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -5,6 +5,7 @@ import knex, { type Knex } from 'knex';
 import { createTracker, MockClient, Tracker } from 'knex-mock-client';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, type MockedFunction, test, vi } from 'vitest';
 import { getDatabaseClient } from '../database/index.js';
+import emitter from '../emitter.js';
 import { validateUserCountIntegrity } from '../utils/validate-user-count-integrity.js';
 import { handleVersion } from '../utils/versioning/handle-version.js';
 import { ItemsService } from './index.js';
@@ -167,6 +168,23 @@ describe('Integration Tests', () => {
 				await service.createOne({ name: 'Test' });
 
 				expect(mockReturning).toHaveBeenCalledWith('id', undefined);
+
+				transactionSpy.mockRestore();
+			});
+
+			it('should short-circuit and return the key when a create filter returns a primary key', async () => {
+				vi.spyOn(emitter, 'emitFilter').mockResolvedValue(5);
+
+				const insert = vi.fn().mockReturnThis();
+
+				const transactionSpy = vi.spyOn(db, 'transaction').mockImplementation(async (callback) => {
+					return await callback({ ...db, insert } as any);
+				});
+
+				const result = await service.createOne({ name: 'Test' });
+
+				expect(result).toBe(5);
+				expect(insert).not.toHaveBeenCalled();
 
 				transactionSpy.mockRestore();
 			});

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -145,6 +145,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 		const payload: AnyItem = cloneDeep(data);
 		let actionHookPayload = payload;
+		let createWasTakenOver = false;
 		const nestedActionEvents: ActionEventParams[] = [];
 
 		/**
@@ -178,7 +179,10 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 			if (typeof payloadAfterHooks === 'string' || typeof payloadAfterHooks === 'number') {
 				// A filter hook returned a primary key instead of a payload: it has taken over the
-				// creation, so short-circuit and surface that key.
+				// creation, so short-circuit and surface that key. No row was created through this
+				// service, so the items.create action must not fire with the original payload — the
+				// hook that took over owns any events.
+				createWasTakenOver = true;
 				return payloadAfterHooks;
 			}
 
@@ -402,7 +406,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			return primaryKey;
 		});
 
-		if (opts.emitEvents !== false) {
+		if (opts.emitEvents !== false && !createWasTakenOver) {
 			const actionEvent = {
 				event:
 					this.eventScope === 'items'

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -160,7 +160,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			// item that is about to be saved
 			const payloadAfterHooks =
 				opts.emitEvents !== false
-					? await emitter.emitFilter(
+					? await emitter.emitFilter<AnyItem, PrimaryKey>(
 							this.eventScope === 'items'
 								? ['items.create', `${this.collection}.items.create`]
 								: `${this.eventScope}.create`,
@@ -175,6 +175,12 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 							},
 						)
 					: payload;
+
+			if (typeof payloadAfterHooks === 'string' || typeof payloadAfterHooks === 'number') {
+				// A filter hook returned a primary key instead of a payload: it has taken over the
+				// creation, so short-circuit and surface that key.
+				return payloadAfterHooks;
+			}
 
 			const payloadWithPresets = this.accountability
 				? await processPayload(


### PR DESCRIPTION
## Why

A filter hook can only ever return *the same shape it was handed* — `FilterHandler<T>` types input and output as one `T`. That blocks two things I want:

1. A filter that **transforms** a payload into a different type.
2. A `*.items.create` filter that wants to **take over** the creation entirely (e.g. dedupe → return the existing row's key, or hand off to an external store) instead of letting the service insert.

Today there's no way to express either without `as`-casting through the type system. This is fork issue #32 ("filtering filters").

## What

- **`@directus/types`** — `FilterHandler<TIn, TOut = TIn>` now carries a separate output type and returns `TIn | TOut`. `TOut` defaults to `TIn`, so every existing filter keeps its exact signature — no caller changes.
- **`@directus/api` `emitFilter<TIn, TOut>`** — threads the output type. Listeners still receive the **chained** payload (each sees the prior listener's output, unchanged from today's behavior) and additionally get the untouched input as **`meta.originalPayload`**.
- **`ItemsService.createOne`** — right after the `items.create` filter hook, if the returned payload is a **primary key** (`string | number`), the service short-circuits: it skips the insert and returns that key. The filter has taken over the creation.

## Retrocompat

- `TOut` defaults to `TIn` — existing `FilterHandler<T>` / `onFilter<T>` / `emitFilter<T>` usages are unchanged.
- A filter that returns a normal payload object inserts exactly as before — the short-circuit only triggers on a bare `string`/`number`.
- `meta.originalPayload` is purely additive; verified no existing caller passes that meta key.

## Out of scope

- **`null`-as-cancel**: not in this PR. A `null` return is only meaningful as a cancel signal, which is delivered in the stacked follow-up #52 (uniform `allowFilterCancel` for create/update/delete). This PR only adds the PK take-over; on its own a `null` return is not special-cased here.
- **`items.db.insert` / `items.db.inserted` filter events**: a separate, heavier fork feature — its own future PR, not this one.
- **Filter-chain trace logging**: proposed as a small follow-up PR (debug-level per-listener before/after), kept out of this type patch.

## Questions

- Comfortable with `meta.originalPayload` as the way to expose the untouched input, or would you rather not widen the filter `meta` contract here?
- The create-cancel contract is "return a PK to take over." Happy with `string | number` as the signal, or would you prefer an explicit sentinel?
- Should a create filter that takes over still emit the `items.create` **action** event, or is silent take-over right?