### PR TITLE
upstream-draft: feat(items): cancel any mutation (create/update/delete) from a filter hook (#32)

### DIFF
--- a/.changeset/filter-cancel-create.md
+++ b/.changeset/filter-cancel-create.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': minor
+---
+
+Let an `items.create` filter take over the creation by returning a primary key. When a `*.items.create` filter returns a `string`/`number` instead of a payload, `ItemsService.createOne` short-circuits the insert and surfaces that key (e.g. dedupe to an existing row, or hand off to an external store). Builds on the typed filter output (`FilterHandler<TIn, TOut>`); a filter returning a normal payload object inserts exactly as before.

--- a/.changeset/filter-cancel-mutations.md
+++ b/.changeset/filter-cancel-mutations.md
@@ -5,7 +5,7 @@
 
 Let a filter hook cancel a create, update or delete by returning `null`, gated by a new `allowFilterCancel` mutation option.
 
-- When a `*.items.create` / `*.items.update` / `*.items.delete` filter returns `null` and the caller passed `{ allowFilterCancel: true }`, the service skips the mutation: `createOne` resolves to `null`, `updateMany`/`deleteMany` resolve to `[]`. Without the opt-in, a `null` return throws `InvalidPayloadError`, so the default signatures (and all existing callers) are unchanged.
+- When a `*.items.create` / `*.items.update` / `*.items.delete` filter returns `null` and the caller passed `{ allowFilterCancel: true }`, the service skips the mutation. `createOne` resolves to `null`; the batch variants keep the cancelled slots as `null` so the result stays index-aligned with the input (`createMany` returns a `null` per cancelled item, `updateMany`/`deleteMany` return a `null` per key on a batch cancel) — `(PrimaryKey | null)[]` under the opt-in overload. Without the opt-in, a `null` return throws `InvalidPayloadError`, so the default signatures (and all existing callers) are unchanged.
 - The public endpoints opt in, so an extension hook can cancel a create/update/delete for any user collection through REST, GraphQL and WebSocket. A cancelled single create responds with `{ data: null }`; a cancelled update reads back the unchanged item; a cancelled delete leaves the item in place.
 
 Builds on the `FilterHandler<TIn, TOut>` output type. Internal/system mutations keep the strict default. Upsert-create cancellation is out of scope.

--- a/.changeset/filter-cancel-mutations.md
+++ b/.changeset/filter-cancel-mutations.md
@@ -1,0 +1,11 @@
+---
+'@directus/types': minor
+'@directus/api': minor
+---
+
+Let a filter hook cancel a create, update or delete by returning `null`, gated by a new `allowFilterCancel` mutation option.
+
+- When a `*.items.create` / `*.items.update` / `*.items.delete` filter returns `null` and the caller passed `{ allowFilterCancel: true }`, the service skips the mutation: `createOne` resolves to `null`, `updateMany`/`deleteMany` resolve to `[]`. Without the opt-in, a `null` return throws `InvalidPayloadError`, so the default signatures (and all existing callers) are unchanged.
+- The public endpoints opt in, so an extension hook can cancel a create/update/delete for any user collection through REST, GraphQL and WebSocket. A cancelled single create responds with `{ data: null }`; a cancelled update reads back the unchanged item; a cancelled delete leaves the item in place.
+
+Builds on the `FilterHandler<TIn, TOut>` output type. Internal/system mutations keep the strict default. Upsert-create cancellation is out of scope.

--- a/api/src/controllers/items.ts
+++ b/api/src/controllers/items.ts
@@ -34,7 +34,8 @@ router.post(
 
 		if (Array.isArray(req.body)) {
 			const keys = await service.createMany(req.body, { allowFilterCancel: true });
-			savedKeys.push(...keys);
+			// Cancelled creates come back as null; drop them before reading the created items.
+			savedKeys.push(...keys.filter((key): key is PrimaryKey => key !== null));
 		} else {
 			const key = await service.createOne(req.body, { allowFilterCancel: true });
 
@@ -146,7 +147,7 @@ router.patch(
 			return next();
 		}
 
-		let keys: PrimaryKey[] = [];
+		let keys: (PrimaryKey | null)[] = [];
 
 		if (Array.isArray(req.body)) {
 			keys = await service.updateBatch(req.body, { allowFilterCancel: true });
@@ -158,7 +159,12 @@ router.patch(
 		}
 
 		try {
-			const result = await service.readMany(keys, req.sanitizedQuery);
+			// Cancelled updates come back as null; drop them before reading the affected items.
+			const result = await service.readMany(
+				keys.filter((key): key is PrimaryKey => key !== null),
+				req.sanitizedQuery,
+			);
+
 			res.locals['payload'] = { data: result };
 		} catch (error: any) {
 			if (isDirectusError(error, ErrorCode.Forbidden)) {

--- a/api/src/controllers/items.ts
+++ b/api/src/controllers/items.ts
@@ -149,12 +149,12 @@ router.patch(
 		let keys: PrimaryKey[] = [];
 
 		if (Array.isArray(req.body)) {
-			keys = await service.updateBatch(req.body);
+			keys = await service.updateBatch(req.body, { allowFilterCancel: true });
 		} else if (req.body.keys) {
-			keys = await service.updateMany(req.body.keys, req.body.data);
+			keys = await service.updateMany(req.body.keys, req.body.data, { allowFilterCancel: true });
 		} else {
 			const sanitizedQuery = await sanitizeQuery(req.body.query, req.schema, req.accountability);
-			keys = await service.updateByQuery(sanitizedQuery, req.body.data);
+			keys = await service.updateByQuery(sanitizedQuery, req.body.data, { allowFilterCancel: true });
 		}
 
 		try {
@@ -188,7 +188,7 @@ router.patch(
 			schema: req.schema,
 		});
 
-		const updatedPrimaryKey = await service.updateOne(req.params['pk']!, req.body);
+		const updatedPrimaryKey = await service.updateOne(req.params['pk']!, req.body, { allowFilterCancel: true });
 
 		try {
 			const result = await service.readOne(updatedPrimaryKey, req.sanitizedQuery);
@@ -219,12 +219,12 @@ router.delete(
 		});
 
 		if (Array.isArray(req.body)) {
-			await service.deleteMany(req.body);
+			await service.deleteMany(req.body, { allowFilterCancel: true });
 		} else if (req.body.keys) {
-			await service.deleteMany(req.body.keys);
+			await service.deleteMany(req.body.keys, { allowFilterCancel: true });
 		} else {
 			const sanitizedQuery = await sanitizeQuery(req.body.query, req.schema, req.accountability);
-			await service.deleteByQuery(sanitizedQuery);
+			await service.deleteByQuery(sanitizedQuery, { allowFilterCancel: true });
 		}
 
 		return next();
@@ -243,7 +243,7 @@ router.delete(
 			schema: req.schema,
 		});
 
-		await service.deleteOne(req.params['pk']!);
+		await service.deleteOne(req.params['pk']!, { allowFilterCancel: true });
 		return next();
 	}),
 	respond,

--- a/api/src/controllers/items.ts
+++ b/api/src/controllers/items.ts
@@ -33,20 +33,27 @@ router.post(
 		const savedKeys: PrimaryKey[] = [];
 
 		if (Array.isArray(req.body)) {
-			const keys = await service.createMany(req.body);
+			const keys = await service.createMany(req.body, { allowFilterCancel: true });
 			savedKeys.push(...keys);
 		} else {
-			const key = await service.createOne(req.body);
-			savedKeys.push(key);
+			const key = await service.createOne(req.body, { allowFilterCancel: true });
+
+			if (key !== null) {
+				// A filter hook may cancel the creation by returning null; nothing to read back then.
+				savedKeys.push(key);
+			}
 		}
 
 		try {
 			if (Array.isArray(req.body)) {
 				const result = await service.readMany(savedKeys, req.sanitizedQuery);
 				res.locals['payload'] = { data: result || null };
-			} else {
+			} else if (savedKeys.length > 0) {
 				const result = await service.readOne(savedKeys[0]!, req.sanitizedQuery);
 				res.locals['payload'] = { data: result || null };
+			} else {
+				// The single create was cancelled by a filter hook: no item to return.
+				res.locals['payload'] = { data: null };
 			}
 		} catch (error: any) {
 			if (isDirectusError(error, ErrorCode.Forbidden)) {

--- a/api/src/services/deployment.ts
+++ b/api/src/services/deployment.ts
@@ -5,6 +5,7 @@ import type {
 	CachedResult,
 	Credentials,
 	DeploymentConfig,
+	MutationOptions,
 	Options,
 	PrimaryKey,
 	Project,
@@ -34,7 +35,7 @@ export class DeploymentService extends ItemsService<DeploymentConfig> {
 		super('directus_deployments', options);
 	}
 
-	override async createOne(data: Partial<DeploymentConfig>, opts?: any): Promise<PrimaryKey> {
+	override async createOne(data: Partial<DeploymentConfig>, opts?: MutationOptions): Promise<PrimaryKey> {
 		const provider = data.provider as ProviderType | undefined;
 
 		if (!provider) {

--- a/api/src/services/graphql/resolvers/mutation.ts
+++ b/api/src/services/graphql/resolvers/mutation.ts
@@ -52,12 +52,12 @@ export async function resolveMutation(
 			}
 
 			if (action === 'update') {
-				const key = await service.updateOne(args['id'], args['data']);
+				const key = await service.updateOne(args['id'], args['data'], { allowFilterCancel: true });
 				return hasQuery ? await service.readOne(key, query) : true;
 			}
 
 			if (action === 'delete') {
-				await service.deleteOne(args['id']);
+				await service.deleteOne(args['id'], { allowFilterCancel: true });
 				return { id: args['id'] };
 			}
 
@@ -74,14 +74,14 @@ export async function resolveMutation(
 				if (batchUpdate) {
 					keys.push(...(await service.updateBatch(args['data'])));
 				} else {
-					keys.push(...(await service.updateMany(args['ids'], args['data'])));
+					keys.push(...(await service.updateMany(args['ids'], args['data'], { allowFilterCancel: true })));
 				}
 
 				return hasQuery ? await service.readMany(keys, query) : true;
 			}
 
 			if (action === 'delete') {
-				const keys = await service.deleteMany(args['ids']);
+				const keys = await service.deleteMany(args['ids'], { allowFilterCancel: true });
 				return { ids: keys };
 			}
 

--- a/api/src/services/graphql/resolvers/mutation.ts
+++ b/api/src/services/graphql/resolvers/mutation.ts
@@ -74,7 +74,11 @@ export async function resolveMutation(
 				if (batchUpdate) {
 					keys.push(...(await service.updateBatch(args['data'])));
 				} else {
-					keys.push(...(await service.updateMany(args['ids'], args['data'], { allowFilterCancel: true })));
+					keys.push(
+						...(await service.updateMany(args['ids'], args['data'], { allowFilterCancel: true })).filter(
+							(key): key is PrimaryKey => key !== null,
+						),
+					);
 				}
 
 				return hasQuery ? await service.readMany(keys, query) : true;

--- a/api/src/services/graphql/resolvers/mutation.ts
+++ b/api/src/services/graphql/resolvers/mutation.ts
@@ -46,8 +46,9 @@ export async function resolveMutation(
 	try {
 		if (single) {
 			if (action === 'create') {
-				const key = await service.createOne(args['data']);
-				return hasQuery ? await service.readOne(key, query) : true;
+				const key = await service.createOne(args['data'], { allowFilterCancel: true });
+				// A filter hook may cancel the create (null key); there is then no item to read back.
+				return hasQuery && key !== null ? await service.readOne(key, query) : true;
 			}
 
 			if (action === 'update') {

--- a/api/src/services/items.test-d.ts
+++ b/api/src/services/items.test-d.ts
@@ -1,0 +1,13 @@
+import type { PrimaryKey } from '@directus/types';
+import { expectTypeOf, test } from 'vitest';
+import { ItemsService } from './items.js';
+
+const service = {} as ItemsService;
+
+test('createOne resolves to a primary key by default', () => {
+	expectTypeOf(service.createOne({})).toEqualTypeOf<Promise<PrimaryKey>>();
+});
+
+test('createOne may resolve to null when filter cancel is opted in', () => {
+	expectTypeOf(service.createOne({}, { allowFilterCancel: true })).toEqualTypeOf<Promise<PrimaryKey | null>>();
+});

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -228,6 +228,16 @@ describe('Integration Tests', () => {
 
 				expect(validateUserCountIntegrity).toHaveBeenCalled();
 			});
+
+			it('should keep cancelled creates as null to stay index-aligned with the input', async () => {
+				const filterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(null);
+
+				const result = await service.createMany([{ name: 'A' }, { name: 'B' }], { allowFilterCancel: true });
+
+				expect(result).toEqual([null, null]);
+
+				filterSpy.mockRestore();
+			});
 		});
 
 		describe('updateBatch', () => {
@@ -251,7 +261,7 @@ describe('Integration Tests', () => {
 
 				const result = await service.updateMany([1], { name: 'Test' }, { allowFilterCancel: true });
 
-				expect(result).toEqual([]);
+				expect(result).toEqual([null]);
 				expect(transactionSpy).not.toHaveBeenCalled();
 
 				filterSpy.mockRestore();
@@ -279,7 +289,7 @@ describe('Integration Tests', () => {
 
 				const result = await service.deleteMany([1], { allowFilterCancel: true });
 
-				expect(result).toEqual([]);
+				expect(result).toEqual([null]);
 				expect(transactionSpy).not.toHaveBeenCalled();
 
 				filterSpy.mockRestore();

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -255,7 +255,7 @@ describe('Integration Tests', () => {
 				expect(validateUserCountIntegrity).toHaveBeenCalled();
 			});
 
-			it('should cancel the update and return [] when a filter returns null and cancel is allowed', async () => {
+			it('should cancel the update and return a null per key when a filter returns null and cancel is allowed', async () => {
 				const filterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(null);
 				const transactionSpy = vi.spyOn(db, 'transaction');
 
@@ -283,7 +283,7 @@ describe('Integration Tests', () => {
 				expect(validateUserCountIntegrity).toHaveBeenCalled();
 			});
 
-			it('should cancel the deletion and return [] when a filter returns null and cancel is allowed', async () => {
+			it('should cancel the deletion and return a null per key when a filter returns null and cancel is allowed', async () => {
 				const filterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(null);
 				const transactionSpy = vi.spyOn(db, 'transaction');
 

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -244,6 +244,26 @@ describe('Integration Tests', () => {
 
 				expect(validateUserCountIntegrity).toHaveBeenCalled();
 			});
+
+			it('should cancel the update and return [] when a filter returns null and cancel is allowed', async () => {
+				const filterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(null);
+				const transactionSpy = vi.spyOn(db, 'transaction');
+
+				const result = await service.updateMany([1], { name: 'Test' }, { allowFilterCancel: true });
+
+				expect(result).toEqual([]);
+				expect(transactionSpy).not.toHaveBeenCalled();
+
+				filterSpy.mockRestore();
+			});
+
+			it('should throw when a filter returns null but cancel is not allowed', async () => {
+				const filterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(null);
+
+				await expect(service.updateMany([1], { name: 'Test' })).rejects.toThrow(InvalidPayloadError);
+
+				filterSpy.mockRestore();
+			});
 		});
 
 		describe('deleteMany', () => {
@@ -251,6 +271,26 @@ describe('Integration Tests', () => {
 				await service.deleteMany([1], { userIntegrityCheckFlags: UserIntegrityCheckFlag.All });
 
 				expect(validateUserCountIntegrity).toHaveBeenCalled();
+			});
+
+			it('should cancel the deletion and return [] when a filter returns null and cancel is allowed', async () => {
+				const filterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(null);
+				const transactionSpy = vi.spyOn(db, 'transaction');
+
+				const result = await service.deleteMany([1], { allowFilterCancel: true });
+
+				expect(result).toEqual([]);
+				expect(transactionSpy).not.toHaveBeenCalled();
+
+				filterSpy.mockRestore();
+			});
+
+			it('should throw when a filter returns null but cancel is not allowed', async () => {
+				const filterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(null);
+
+				await expect(service.deleteMany([1])).rejects.toThrow(InvalidPayloadError);
+
+				filterSpy.mockRestore();
 			});
 		});
 	});

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -220,6 +220,33 @@ describe('Integration Tests', () => {
 				transactionSpy.mockRestore();
 				filterSpy.mockRestore();
 			});
+
+			it('should create normally when a filter returns the payload (cancel allowed but not triggered)', async () => {
+				// control: the cancel/take-over guards must only fire on null / a key, never on a payload
+				const filterSpy = vi
+					.spyOn(emitter, 'emitFilter')
+					.mockImplementation(async (_event: any, payload: any) => payload);
+
+				const mockReturning = vi.fn().mockResolvedValue([{ id: 1 }]);
+
+				const mockQuery = {
+					insert: vi.fn().mockReturnThis(),
+					into: vi.fn().mockReturnThis(),
+					returning: mockReturning,
+				};
+
+				const transactionSpy = vi
+					.spyOn(db, 'transaction')
+					.mockImplementation(async (callback) => callback({ ...db, ...mockQuery } as any));
+
+				const result = await service.createOne({ name: 'Test' }, { allowFilterCancel: true });
+
+				expect(mockQuery.insert).toHaveBeenCalled();
+				expect(result).not.toBeNull();
+
+				transactionSpy.mockRestore();
+				filterSpy.mockRestore();
+			});
 		});
 
 		describe('createMany', () => {
@@ -274,6 +301,22 @@ describe('Integration Tests', () => {
 
 				filterSpy.mockRestore();
 			});
+
+			it('should run the update normally when a filter returns a non-null payload', async () => {
+				const filterSpy = vi
+					.spyOn(emitter, 'emitFilter')
+					.mockImplementation(async (_event: any, payload: any) => payload);
+
+				const transactionSpy = vi.spyOn(db, 'transaction');
+
+				const result = await service.updateMany([1], { name: 'Test' }, { allowFilterCancel: true });
+
+				expect(transactionSpy).toHaveBeenCalled();
+				expect(result).toEqual([1]);
+
+				transactionSpy.mockRestore();
+				filterSpy.mockRestore();
+			});
 		});
 
 		describe('deleteMany', () => {
@@ -300,6 +343,22 @@ describe('Integration Tests', () => {
 
 				await expect(service.deleteMany([1])).rejects.toThrow(InvalidPayloadError);
 
+				filterSpy.mockRestore();
+			});
+
+			it('should run the deletion normally when a filter returns a non-null payload', async () => {
+				const filterSpy = vi
+					.spyOn(emitter, 'emitFilter')
+					.mockImplementation(async (_event: any, payload: any) => payload);
+
+				const transactionSpy = vi.spyOn(db, 'transaction');
+
+				const result = await service.deleteMany([1], { allowFilterCancel: true });
+
+				expect(transactionSpy).toHaveBeenCalled();
+				expect(result).toEqual([1]);
+
+				transactionSpy.mockRestore();
 				filterSpy.mockRestore();
 			});
 		});

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -5,6 +5,7 @@ import knex, { type Knex } from 'knex';
 import { createTracker, MockClient, Tracker } from 'knex-mock-client';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, type MockedFunction, test, vi } from 'vitest';
 import { getDatabaseClient } from '../database/index.js';
+import emitter from '../emitter.js';
 import { validateUserCountIntegrity } from '../utils/validate-user-count-integrity.js';
 import { handleVersion } from '../utils/versioning/handle-version.js';
 import { ItemsService } from './index.js';
@@ -167,6 +168,23 @@ describe('Integration Tests', () => {
 				await service.createOne({ name: 'Test' });
 
 				expect(mockReturning).toHaveBeenCalledWith('id', undefined);
+
+				transactionSpy.mockRestore();
+			});
+
+			it('should short-circuit and return the key when a create filter returns a primary key', async () => {
+				vi.spyOn(emitter, 'emitFilter').mockResolvedValue(5);
+
+				const insert = vi.fn().mockReturnThis();
+
+				const transactionSpy = vi.spyOn(db, 'transaction').mockImplementation(async (callback) => {
+					return await callback({ ...db, insert } as any);
+				});
+
+				const result = await service.createOne({ name: 'Test' });
+
+				expect(result).toBe(5);
+				expect(insert).not.toHaveBeenCalled();
 
 				transactionSpy.mockRestore();
 			});

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -1,4 +1,5 @@
 import { VERSION_KEY_PUBLISHED, VERSION_KEY_PUBLISHED_LEGACY } from '@directus/constants';
+import { InvalidPayloadError } from '@directus/errors';
 import { SchemaBuilder } from '@directus/schema-builder';
 import { UserIntegrityCheckFlag } from '@directus/types';
 import knex, { type Knex } from 'knex';
@@ -187,6 +188,37 @@ describe('Integration Tests', () => {
 				expect(insert).not.toHaveBeenCalled();
 
 				transactionSpy.mockRestore();
+			});
+
+			it('should cancel the create and return null when a filter returns null and cancel is allowed', async () => {
+				const filterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(null);
+
+				const insert = vi.fn().mockReturnThis();
+
+				const transactionSpy = vi.spyOn(db, 'transaction').mockImplementation(async (callback) => {
+					return await callback({ ...db, insert } as any);
+				});
+
+				const result = await service.createOne({ name: 'Test' }, { allowFilterCancel: true });
+
+				expect(result).toBeNull();
+				expect(insert).not.toHaveBeenCalled();
+
+				transactionSpy.mockRestore();
+				filterSpy.mockRestore();
+			});
+
+			it('should throw when a filter returns null but cancel is not allowed', async () => {
+				const filterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(null);
+
+				const transactionSpy = vi.spyOn(db, 'transaction').mockImplementation(async (callback) => {
+					return await callback({ ...db } as any);
+				});
+
+				await expect(service.createOne({ name: 'Test' })).rejects.toThrow(InvalidPayloadError);
+
+				transactionSpy.mockRestore();
+				filterSpy.mockRestore();
 			});
 		});
 

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -788,7 +788,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		// item that is about to be saved
 		const payloadAfterHooks =
 			opts.emitEvents !== false
-				? await emitter.emitFilter(
+				? await emitter.emitFilter<Partial<AnyItem>, null>(
 						this.eventScope === 'items'
 							? ['items.update', `${this.collection}.items.update`]
 							: `${this.eventScope}.update`,
@@ -804,6 +804,17 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 						},
 					)
 				: payload;
+
+		if (payloadAfterHooks === null) {
+			if (!opts.allowFilterCancel) {
+				throw new InvalidPayloadError({
+					reason: `A filter hook cancelled the update, but this operation requires it`,
+				});
+			}
+
+			// The filter cancelled the update: nothing is written and no keys are returned.
+			return [];
+		}
 
 		// Sort keys to ensure that the order is maintained
 		keys.sort();
@@ -1144,7 +1155,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 		const keysAfterHooks =
 			opts.emitEvents !== false
-				? await emitter.emitFilter(
+				? await emitter.emitFilter<PrimaryKey[], null>(
 						this.eventScope === 'items'
 							? ['items.delete', `${this.collection}.items.delete`]
 							: `${this.eventScope}.delete`,
@@ -1159,6 +1170,17 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 						},
 					)
 				: keys;
+
+		if (keysAfterHooks === null) {
+			if (!opts.allowFilterCancel) {
+				throw new InvalidPayloadError({
+					reason: `A filter hook cancelled the deletion, but this operation requires it`,
+				});
+			}
+
+			// The filter cancelled the deletion: nothing is deleted and no keys are returned.
+			return [];
+		}
 
 		if (this.accountability) {
 			await validateAccess(

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -124,7 +124,9 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	/**
 	 * Create a single new item.
 	 */
-	async createOne(data: Partial<Item>, opts: MutationOptions = {}): Promise<PrimaryKey> {
+	async createOne(data: Partial<Item>, opts: MutationOptions & { allowFilterCancel: true }): Promise<PrimaryKey | null>;
+	async createOne(data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey>;
+	async createOne(data: Partial<Item>, opts: MutationOptions = {}): Promise<PrimaryKey | null> {
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
 
 		if (!opts.bypassLimits) {
@@ -153,14 +155,14 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		 * that any errors thrown in any nested relational changes will bubble up and cancel the whole
 		 * update tree
 		 */
-		const primaryKey: PrimaryKey = await transaction(this.knex, async (trx) => {
+		const primaryKey: PrimaryKey | null = await transaction(this.knex, async (trx) => {
 			const previousSeatCount = await captureSeatCount(trx, opts.userIntegrityCheckFlags);
 
 			// Run all hooks that are attached to this event so the end user has the chance to augment the
 			// item that is about to be saved
 			const payloadAfterHooks =
 				opts.emitEvents !== false
-					? await emitter.emitFilter<AnyItem, PrimaryKey>(
+					? await emitter.emitFilter<AnyItem, PrimaryKey | null>(
 							this.eventScope === 'items'
 								? ['items.create', `${this.collection}.items.create`]
 								: `${this.eventScope}.create`,
@@ -180,6 +182,17 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				// A filter hook returned a primary key instead of a payload: it has taken over the
 				// creation, so short-circuit and surface that key.
 				return payloadAfterHooks;
+			}
+
+			if (payloadAfterHooks === null) {
+				if (!opts.allowFilterCancel) {
+					throw new InvalidPayloadError({
+						reason: `A filter hook cancelled the creation, but this operation requires a created item`,
+					});
+				}
+
+				// The filter cancelled the creation: no item is inserted and no key is produced.
+				return null;
 			}
 
 			const payloadWithPresets = this.accountability
@@ -401,6 +414,11 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 			return primaryKey;
 		});
+
+		// A filter hook cancelled the creation: nothing was inserted, so skip the action hooks entirely.
+		if (primaryKey === null) {
+			return null;
+		}
 
 		if (opts.emitEvents !== false) {
 			const actionEvent = {

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -494,7 +494,9 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					bypassAutoIncrementSequenceReset = false;
 				}
 
-				const primaryKey = await service.createOne(payload, {
+				// `allowFilterCancel` is propagated via `opts`; the overload resolves to the non-null
+				// signature, but a cancelling filter can still return null at runtime — hence the guard.
+				const primaryKey: PrimaryKey | null = await service.createOne(payload, {
 					...(opts || {}),
 					autoPurgeCache: false,
 					onRequireUserIntegrityCheck: (flags) => (userIntegrityCheckFlags |= flags),
@@ -504,7 +506,10 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					bypassAutoIncrementSequenceReset,
 				});
 
-				primaryKeys.push(primaryKey);
+				// A filter hook may cancel an individual create (null); a cancelled item yields no key.
+				if (primaryKey !== null) {
+					primaryKeys.push(primaryKey);
+				}
 			}
 
 			if (userIntegrityCheckFlags) {

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -465,7 +465,13 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	 *
 	 * Uses `this.createOne` under the hood.
 	 */
-	async createMany(data: Partial<Item>[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
+	async createMany(
+		data: Partial<Item>[],
+		opts: MutationOptions & { allowFilterCancel: true },
+	): Promise<(PrimaryKey | null)[]>;
+
+	async createMany(data: Partial<Item>[], opts?: MutationOptions): Promise<PrimaryKey[]>;
+	async createMany(data: Partial<Item>[], opts: MutationOptions = {}): Promise<(PrimaryKey | null)[]> {
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
 
 		if (this.collection === 'directus_users') {
@@ -480,7 +486,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 			let userIntegrityCheckFlags = opts.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None;
 
-			const primaryKeys: PrimaryKey[] = [];
+			const primaryKeys: (PrimaryKey | null)[] = [];
 			const nestedActionEvents: ActionEventParams[] = [];
 
 			const pkField = this.schema.collections[this.collection]!.primary;
@@ -506,10 +512,9 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					bypassAutoIncrementSequenceReset,
 				});
 
-				// A filter hook may cancel an individual create (null); a cancelled item yields no key.
-				if (primaryKey !== null) {
-					primaryKeys.push(primaryKey);
-				}
+				// A filter hook may cancel an individual create by returning null; the null is kept in
+				// place so the result stays index-aligned with the input (mirrors createOne).
+				primaryKeys.push(primaryKey);
 			}
 
 			if (userIntegrityCheckFlags) {
@@ -760,7 +765,18 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	/**
 	 * Update many items by primary key, setting all items to the same change.
 	 */
-	async updateMany(keys: PrimaryKey[], data: Partial<Item>, opts: MutationOptions = {}): Promise<PrimaryKey[]> {
+	async updateMany(
+		keys: PrimaryKey[],
+		data: Partial<Item>,
+		opts: MutationOptions & { allowFilterCancel: true },
+	): Promise<(PrimaryKey | null)[]>;
+
+	async updateMany(keys: PrimaryKey[], data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey[]>;
+	async updateMany(
+		keys: PrimaryKey[],
+		data: Partial<Item>,
+		opts: MutationOptions = {},
+	): Promise<(PrimaryKey | null)[]> {
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
 
 		if (!opts.bypassLimits) {
@@ -812,8 +828,9 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				});
 			}
 
-			// The filter cancelled the update: nothing is written and no keys are returned.
-			return [];
+			// The filter cancelled the update: nothing is written; return a null per key so the
+			// result stays index-aligned with the input keys.
+			return keys.map(() => null);
 		}
 
 		// Sort keys to ensure that the order is maintained
@@ -1143,7 +1160,13 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	/**
 	 * Delete multiple items by primary key.
 	 */
-	async deleteMany(keys: PrimaryKey[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
+	async deleteMany(
+		keys: PrimaryKey[],
+		opts: MutationOptions & { allowFilterCancel: true },
+	): Promise<(PrimaryKey | null)[]>;
+
+	async deleteMany(keys: PrimaryKey[], opts?: MutationOptions): Promise<PrimaryKey[]>;
+	async deleteMany(keys: PrimaryKey[], opts: MutationOptions = {}): Promise<(PrimaryKey | null)[]> {
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
 
 		if (!opts.bypassLimits) {
@@ -1178,8 +1201,9 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				});
 			}
 
-			// The filter cancelled the deletion: nothing is deleted and no keys are returned.
-			return [];
+			// The filter cancelled the deletion: nothing is deleted; return a null per key so the
+			// result stays index-aligned with the input keys.
+			return keys.map(() => null);
 		}
 
 		if (this.accountability) {

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -160,7 +160,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			// item that is about to be saved
 			const payloadAfterHooks =
 				opts.emitEvents !== false
-					? await emitter.emitFilter(
+					? await emitter.emitFilter<AnyItem, PrimaryKey>(
 							this.eventScope === 'items'
 								? ['items.create', `${this.collection}.items.create`]
 								: `${this.eventScope}.create`,
@@ -175,6 +175,12 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 							},
 						)
 					: payload;
+
+			if (typeof payloadAfterHooks === 'string' || typeof payloadAfterHooks === 'number') {
+				// A filter hook returned a primary key instead of a payload: it has taken over the
+				// creation, so short-circuit and surface that key.
+				return payloadAfterHooks;
+			}
 
 			const payloadWithPresets = this.accountability
 				? await processPayload(

--- a/api/src/websocket/handlers/items.test.ts
+++ b/api/src/websocket/handlers/items.test.ts
@@ -118,7 +118,9 @@ describe('WebSocket heartbeat handler', () => {
 		// do mocking
 		(getSchema as Mock).mockImplementation(() => ({ collections: { test: [] } }));
 
-		const createMany = vi.fn(),
+		// A filter hook may cancel an individual create, leaving a null in place; the handler
+		// must drop those before reading back, so the read only sees the surviving key.
+		const createMany = vi.fn().mockResolvedValue([1, null]),
 			readMany = vi.fn();
 
 		(ItemsService as Mock).mockImplementation(() => ({ createMany, readMany }));
@@ -137,7 +139,7 @@ describe('WebSocket heartbeat handler', () => {
 		await vi.runAllTimersAsync(); // flush promises to make sure the event is handled
 		// expect service functions
 		expect(createMany).toBeCalled();
-		expect(readMany).toBeCalled();
+		expect(readMany).toBeCalledWith([1], expect.anything());
 		expect(fakeClient.send).toBeCalled();
 	});
 
@@ -198,7 +200,9 @@ describe('WebSocket heartbeat handler', () => {
 		// do mocking
 		(getSchema as Mock).mockImplementation(() => ({ collections: { test: [] } }));
 
-		const updateMany = vi.fn(),
+		// A filter hook may cancel an individual update, leaving a null in place; the handler
+		// must drop those before reading back, so the read only sees the surviving key.
+		const updateMany = vi.fn().mockResolvedValue([1, null]),
 			readMany = vi.fn();
 
 		(ItemsService as Mock).mockImplementation(() => ({ updateMany, readMany }));
@@ -220,7 +224,7 @@ describe('WebSocket heartbeat handler', () => {
 		// expect service functions
 		expect(updateMany).toBeCalled();
 		expect(getMetaForQuery).toBeCalled();
-		expect(readMany).toBeCalled();
+		expect(readMany).toBeCalledWith([1], expect.anything());
 		expect(fakeClient.send).toBeCalled();
 	});
 

--- a/api/src/websocket/handlers/items.ts
+++ b/api/src/websocket/handlers/items.ts
@@ -78,10 +78,10 @@ export class ItemsHandler {
 			const query = await sanitizeQuery(message.query ?? {}, schema, accountability);
 
 			if (message.id) {
-				const key = await service.updateOne(message.id, message.data);
+				const key = await service.updateOne(message.id, message.data, { allowFilterCancel: true });
 				result = await service.readOne(key);
 			} else if (message.ids) {
-				const keys = await service.updateMany(message.ids, message.data);
+				const keys = await service.updateMany(message.ids, message.data, { allowFilterCancel: true });
 				meta = await metaService.getMetaForQuery(message.collection, query);
 				result = await service.readMany(keys, query);
 			} else if (isSingleton) {
@@ -92,7 +92,7 @@ export class ItemsHandler {
 				meta = await metaService.getMetaForQuery(message.collection, query);
 				result = await service.readMany(keys, query);
 			} else {
-				const keys = await service.updateByQuery(query, message.data);
+				const keys = await service.updateByQuery(query, message.data, { allowFilterCancel: true });
 				meta = await metaService.getMetaForQuery(message.collection, query);
 				result = await service.readMany(keys, query);
 			}
@@ -100,14 +100,14 @@ export class ItemsHandler {
 
 		if (message.action === 'delete') {
 			if (message.id) {
-				await service.deleteOne(message.id);
+				await service.deleteOne(message.id, { allowFilterCancel: true });
 				result = message.id;
 			} else if (message.ids) {
-				await service.deleteMany(message.ids);
+				await service.deleteMany(message.ids, { allowFilterCancel: true });
 				result = message.ids;
 			} else if (message.query) {
 				const query = await sanitizeQuery(message.query, schema, accountability);
-				result = await service.deleteByQuery(query);
+				result = await service.deleteByQuery(query, { allowFilterCancel: true });
 			} else {
 				throw new WebSocketError(
 					'items',

--- a/api/src/websocket/handlers/items.ts
+++ b/api/src/websocket/handlers/items.ts
@@ -1,4 +1,5 @@
 import { isSystemCollection } from '@directus/system-data';
+import type { PrimaryKey } from '@directus/types';
 import emitter from '../../emitter.js';
 import { ItemsService, MetaService } from '../../services/index.js';
 import { getSchema } from '../../utils/get-schema.js';
@@ -50,7 +51,11 @@ export class ItemsHandler {
 
 			if (Array.isArray(message.data)) {
 				const keys = await service.createMany(message.data, { allowFilterCancel: true });
-				result = await service.readMany(keys, query);
+
+				result = await service.readMany(
+					keys.filter((key): key is PrimaryKey => key !== null),
+					query,
+				);
 			} else {
 				const key = await service.createOne(message.data, { allowFilterCancel: true });
 				// A filter hook may cancel the create (null key); there is then no item to read back.
@@ -83,7 +88,11 @@ export class ItemsHandler {
 			} else if (message.ids) {
 				const keys = await service.updateMany(message.ids, message.data, { allowFilterCancel: true });
 				meta = await metaService.getMetaForQuery(message.collection, query);
-				result = await service.readMany(keys, query);
+
+				result = await service.readMany(
+					keys.filter((key): key is PrimaryKey => key !== null),
+					query,
+				);
 			} else if (isSingleton) {
 				await service.upsertSingleton(message.data);
 				result = await service.readSingleton(query);

--- a/api/src/websocket/handlers/items.ts
+++ b/api/src/websocket/handlers/items.ts
@@ -49,11 +49,12 @@ export class ItemsHandler {
 			const query = await sanitizeQuery(message?.query ?? {}, schema, accountability);
 
 			if (Array.isArray(message.data)) {
-				const keys = await service.createMany(message.data);
+				const keys = await service.createMany(message.data, { allowFilterCancel: true });
 				result = await service.readMany(keys, query);
 			} else {
-				const key = await service.createOne(message.data);
-				result = await service.readOne(key, query);
+				const key = await service.createOne(message.data, { allowFilterCancel: true });
+				// A filter hook may cancel the create (null key); there is then no item to read back.
+				result = key !== null ? await service.readOne(key, query) : null;
 			}
 		}
 

--- a/packages/types/src/items.ts
+++ b/packages/types/src/items.ts
@@ -107,6 +107,12 @@ export type MutationOptions = {
 	 * Callback function that is called whenever a mutation requires a user integrity check to be made
 	 */
 	onRequireUserIntegrityCheck?: ((flags: UserIntegrityCheckFlag) => void) | undefined;
+
+	/**
+	 * Allow an `items.create` filter hook to cancel the creation by returning `null`. When set,
+	 * `createOne` resolves to `null` instead of a primary key; otherwise a `null` return throws.
+	 */
+	allowFilterCancel?: boolean | undefined;
 };
 
 export type FieldMutationOptions = MutationOptions & {


### PR DESCRIPTION
## Why

Stacked on #51 (filter output types + create take-over). That PR lets an `items.create` filter take over a creation; this one gives extension authors the symmetric, **uniform** ability to **cancel** any mutation — create, update or delete — by returning `null` from the corresponding filter hook.

A filter registers against `items.create` / `items.update` / `items.delete` but doesn't control the service call site, so cancellation has to be reachable through the normal API for it to be useful "for any model". This wires that up.

## What

- **Opt-in, uniform gate.** A new `allowFilterCancel` mutation option. When set and the filter returns `null`:
  - `createOne` resolves to `null`; the batch variants keep cancelled slots as `null` so the result stays index-aligned with the input — `createMany` returns a `null` per cancelled item, `updateMany` / `deleteMany` return a `null` per key on a batch cancel. The mutation is skipped (no transaction, no action hooks).
  - Without the opt-in, a `null` return throws `InvalidPayloadError`, so the default signatures and every existing caller are unchanged.
- **Reachable through the API.** REST, GraphQL and WebSocket create/update/delete endpoints opt in, so a hook can cancel for any user collection:
  - cancelled single **create** → `{ data: null }`;
  - cancelled **update** → reads back the unchanged item;
  - cancelled **delete** → leaves the item in place (204).
- Single variants (`updateOne`/`deleteOne`) return the targeted key unchanged on cancel. The batch variants widen to `(PrimaryKey | null)[]` only under the `allowFilterCancel` opt-in overload, so existing callers (and the base `AbstractService`) keep their `PrimaryKey[]` signatures — no cascade. The public batch endpoints filter the `null`s out before reading the affected rows back.

## Retrocompat

- `allowFilterCancel` defaults off; internal/system mutations (settings, bootstrap, license, …) stay strict — a stray `null` there throws rather than silently cancelling.
- Existing filters that return a payload/keys are byte-identical to before.

## Out of scope

- **Upsert-create cancellation** — `upsertOne`/`upsertSingleton` keep the strict create path; cancelling the create half of an upsert re-introduces the single-key widening and is deferred.
- Folding #51's create take-over into this PR — kept separate so "filter changes output type" and "filter cancels mutation" review independently.

## Questions

- Is `allowFilterCancel` the right name/shape, or would you prefer the gate per-event (e.g. only `items.create`)?
- Cancelled-mutation responses: single create → `{ data: null }`, update → unchanged item, delete → 204. Happy with those, or should a cancelled create/update signal more explicitly (e.g. 204)?
- Should a cancelled mutation still emit its action hook, or is silent cancellation correct (current behaviour: no action emitted)?

## Relationship to the no-op-skip PR (#36)

`upstream-draft: feat(items): skip no-op item updates (#36)` and this PR both touch the `null`-from-`items.update`-filter case, so the ownership is split deliberately:

- **That PR** owns the no-op **skip** (`{}` / PK-only / all-empty alterations → `[]`) and makes a `null` payload raise `InvalidPayloadError` — it does **not** give `null` a cancel meaning.
- **This PR** owns **cancellation**: the same `null` check gains the `allowFilterCancel` opt-in (cancel → index-aligned `null`; without opt-in it throws, exactly as the no-op-skip PR does). So whichever lands first, the other rebases cleanly — this PR's `null` block is a superset of that PR's throw.
