### PR TITLE
upstream-draft: perf(items): narrow single-key updateMany to an exact `where`

### DIFF
--- a/.changeset/single-key-update-where.md
+++ b/.changeset/single-key-update-where.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Narrow a single-key `updateMany` to an exact `WHERE pk = ?` instead of `WHERE pk IN (?)`. The single-row form lets the database take a precise record lock rather than the wider range lock an `IN (...)` predicate can acquire, reducing lock contention under concurrent single-item updates (the common `updateOne` path). Behaviour is unchanged; only the emitted SQL and lock granularity differ.

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -20,6 +20,7 @@ vi.mock('../utils/versioning/handle-version.js', { spy: true });
 const schema = new SchemaBuilder()
 	.collection('test', (c) => {
 		c.field('id').id();
+		c.field('name').string();
 	})
 	.collection('directus_versions', (c) => {
 		c.field('id').id();
@@ -193,6 +194,25 @@ describe('Integration Tests', () => {
 				await service.updateMany([1], {}, { userIntegrityCheckFlags: UserIntegrityCheckFlag.All });
 
 				expect(validateUserCountIntegrity).toHaveBeenCalled();
+			});
+
+			it('should match a single key with an exact `where` instead of `whereIn`', async () => {
+				await service.updateMany([1], { name: 'Test' });
+
+				const update = tracker.history.all.find((query) => query.method === 'update');
+
+				expect(update?.sql).toMatch(/where .*=/i);
+				expect(update?.sql).not.toMatch(/ in \(/i);
+				expect(update?.bindings).toContain(1);
+			});
+
+			it('should match several keys with `whereIn`', async () => {
+				await service.updateMany([1, 2], { name: 'Test' });
+
+				const update = tracker.history.all.find((query) => query.method === 'update');
+
+				expect(update?.sql).toMatch(/ in \(/i);
+				expect(update?.bindings).toEqual(expect.arrayContaining([1, 2]));
 			});
 		});
 

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -845,7 +845,15 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 			if (Object.keys(payloadWithTypeCasting).length > 0) {
 				try {
-					await trx(this.collection).update(payloadWithTypeCasting).whereIn(primaryKeyField, keys);
+					const query = trx(this.collection).update(payloadWithTypeCasting);
+
+					// A single-key update narrows to an exact `WHERE pk = ?` so the database takes a
+					// precise record lock instead of the wider range lock an `IN (...)` can acquire.
+					if (keys.length === 1) {
+						await query.where(primaryKeyField, keys[0]);
+					} else {
+						await query.whereIn(primaryKeyField, keys);
+					}
 				} catch (err: any) {
 					throw await translateDatabaseError(err, data);
 				}


### PR DESCRIPTION
When a single item is updated (the common `updateOne` → `updateMany([key])` path), the batch update still matched its row with `WHERE pk IN (?)`. This narrows the single-key case to `WHERE pk = ?`. The same rows are affected either way; only the emitted SQL and the lock granularity change. Multi-key updates keep `whereIn`. Delete/create paths are left untouched (out of scope here — `deleteMany` could get the symmetric treatment in a follow-up if you want it).

Extracted from my `hhh-dev` fork where we're shaving lock contention off the items service layer.

## Where the gain actually lands (per engine)

I dug through the docs to scope the claim honestly. The lock-contention benefit is **InnoDB-specific** (so MySQL + MariaDB, the two InnoDB dialects in the matrix). It's a **no-op on the other engines** — they have no gap/next-key locking concept, so there's nothing to narrow:

- **MySQL InnoDB / MariaDB** — the only place it matters. A unique-index *unique search* locks just the index record (no gap lock), but `IN (...)` is fed through the range optimizer and can be planned as a range, so InnoDB may decline to treat it as a unique search and take next-key/gap locks on the scanned range. Bites hardest on a **no-match** (it gap-locks the searched key's gap → classic insert-into-gap deadlock, [bug #107958](https://bugs.mysql.com/bug.php?id=107958)) and under concurrent insert/update load. `WHERE pk = ?` is an unambiguous unique search → record lock only.
- **PostgreSQL** — no-op. No gap/next-key locks (no predicate locking outside SERIALIZABLE SSI); row locks are tuple-level on touched rows. `IN (single)` plans as `= ANY('{v}')`, usually the same Index Scan.
- **SQLite** — no-op. Database-level / single-writer locking, no row locks.
- **Oracle** — no-op for locks. Row locks only on modified rows, no range locks; same one row locked. Plan differs (`INLIST ITERATOR` vs unique scan) = micro-CPU only.
- **CockroachDB** — ~no-op. `IN (single)` resolves to a point-get like `=`.

So on PG/SQLite/Oracle/CRDB the only residual effect is a marginally simpler plan (point-get vs in-list iterator), sub-microsecond. No public benchmark nails this exact `=` vs `IN(single)` micro-difference — it's documentation-grade reasoning. A real number would need a sysbench-style concurrent `UPDATE ... WHERE pk=?` on hot InnoDB rows measuring lock-waits/deadlocks/p99.

Refs: [InnoDB Locking 17.7.1](https://dev.mysql.com/doc/refman/8.0/en/innodb-locking.html), [Locks Set by SQL Statements 17.7.3](https://dev.mysql.com/doc/refman/8.0/en/innodb-locks-set.html), [bug #107958](https://bugs.mysql.com/bug.php?id=107958).

## Open questions for review

- Given the gain is InnoDB-only, is this still worth carrying upstream as a small correctness-neutral tidy, or would you rather see a benchmark witness first?
- Worth extending the same single-key narrowing to `deleteMany`?

The two added unit tests pin the emitted SQL per branch (single key → `where pk =`, several keys → `in (...)`) so the optimization can't silently regress.