### PR TITLE
upstream-draft: feat(migrations): name the colliding version + files on duplicate migration keys

### DIFF
--- a/.changeset/migration-collision-detail.md
+++ b/.changeset/migration-collision-detail.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Improved the "Migration keys collide" startup error to list which version collides and the exact files sharing it, instead of a generic message that left you to hunt for the duplicate by hand.

--- a/api/src/database/migrations/run.test.ts
+++ b/api/src/database/migrations/run.test.ts
@@ -107,4 +107,34 @@ describe('run', () => {
 			});
 		});
 	});
+
+	describe('when migration keys collide', () => {
+		afterEach(() => {
+			vi.doUnmock('fs-extra');
+			vi.resetModules();
+		});
+
+		it('throws an error listing the colliding version and its files', async () => {
+			vi.resetModules();
+
+			vi.doMock('fs-extra', () => ({
+				default: {
+					readdir: vi.fn().mockResolvedValue(['20201028A-first.js', '20201028A-second.js']),
+					pathExists: vi.fn().mockResolvedValue(false),
+				},
+			}));
+
+			const { default: runWithCollision } = await import('./run.js');
+
+			tracker.on.select('directus_migrations').response([]);
+
+			const error = await runWithCollision(db, 'up').catch((e: Error) => e);
+
+			expect(error).toBeInstanceOf(Error);
+			expect((error as Error).message).toContain('Migration keys collide!');
+			expect((error as Error).message).toContain('"20201028A"');
+			expect((error as Error).message).toContain('first.js');
+			expect((error as Error).message).toContain('second.js');
+		});
+	});
 });

--- a/api/src/database/migrations/run.test.ts
+++ b/api/src/database/migrations/run.test.ts
@@ -136,5 +136,78 @@ describe('run', () => {
 			expect((error as Error).message).toContain('first.js');
 			expect((error as Error).message).toContain('second.js');
 		});
+
+		it('formats each collision as a tab-dashed line listing comma-separated files', async () => {
+			vi.resetModules();
+
+			vi.doMock('fs-extra', () => ({
+				default: {
+					readdir: vi.fn().mockResolvedValue(['20201028A-first.js', '20201028A-second.js']),
+					pathExists: vi.fn().mockResolvedValue(false),
+				},
+			}));
+
+			const { default: runWithCollision } = await import('./run.js');
+
+			tracker.on.select('directus_migrations').response([]);
+
+			const error = await runWithCollision(db, 'up').catch((e: Error) => e);
+
+			expect((error as Error).message).toMatch(
+				/\n\t- "20201028A": [^\n]*20201028A-[a-z]+\.js, [^\n]*20201028A-[a-z]+\.js/,
+			);
+		});
+
+		it('lists every colliding version when several versions collide', async () => {
+			vi.resetModules();
+
+			vi.doMock('fs-extra', () => ({
+				default: {
+					readdir: vi
+						.fn()
+						.mockResolvedValue([
+							'20201028A-first.js',
+							'20201028A-second.js',
+							'20201029B-third.js',
+							'20201029B-fourth.js',
+						]),
+					pathExists: vi.fn().mockResolvedValue(false),
+				},
+			}));
+
+			const { default: runWithCollision } = await import('./run.js');
+
+			tracker.on.select('directus_migrations').response([]);
+
+			const error = await runWithCollision(db, 'up').catch((e: Error) => e);
+
+			const message = (error as Error).message;
+
+			expect(message).toContain('"20201028A"');
+			expect(message).toContain('"20201029B"');
+			// one line per colliding version
+			expect(message.match(/\n\t- "/g)).toHaveLength(2);
+		});
+
+		it('does not report a collision when every version is unique', async () => {
+			vi.resetModules();
+
+			vi.doMock('fs-extra', () => ({
+				default: {
+					readdir: vi.fn().mockResolvedValue(['20201028A-first.js', '20201029B-second.js']),
+					pathExists: vi.fn().mockResolvedValue(false),
+				},
+			}));
+
+			const { default: runWithCollision } = await import('./run.js');
+
+			tracker.on.select('directus_migrations').response([]);
+
+			const result = await runWithCollision(db, 'up').catch((e: Error) => e);
+
+			if (result instanceof Error) {
+				expect(result.message).not.toContain('Migration keys collide!');
+			}
+		});
 	});
 });

--- a/api/src/database/migrations/run.ts
+++ b/api/src/database/migrations/run.ts
@@ -38,7 +38,20 @@ export default async function run(database: Knex, direction: 'up' | 'down' | 'la
 	const migrationKeys = new Set(migrations.map((m) => m.version));
 
 	if (migrations.length > migrationKeys.size) {
-		throw new Error('Migration keys collide! Please ensure that every migration uses a unique key.');
+		const filesByVersion = new Map<string, string[]>();
+
+		for (const migration of migrations) {
+			const files = filesByVersion.get(migration.version!) ?? [];
+			files.push(migration.file);
+			filesByVersion.set(migration.version!, files);
+		}
+
+		const collisions = [...filesByVersion]
+			.filter(([, files]) => files.length > 1)
+			.map(([version, files]) => `\t- "${version}": ${files.join(', ')}`)
+			.join('\n');
+
+		throw new Error(`Migration keys collide! Please ensure that every migration uses a unique key:\n${collisions}`);
 	}
 
 	function parseFilePath(filePath: string, custom = false) {


### PR DESCRIPTION
When two migrations end up with the same version key (easy to do when cherry-picking or maintaining a fork alongside upstream), Directus refuses to boot with `Migration keys collide! Please ensure that every migration uses a unique key.` — but it doesn't say *which* key or *which* files. You're left grepping the migrations directory by hand.

This collects the migration files grouped by version and lists each colliding version with the exact files that share it, e.g.:

```
Migration keys collide! Please ensure that every migration uses a unique key:
	- "20201028A": .../20201028A-first.js, .../20201028A-second.js
```

Behaviour is otherwise unchanged — it still throws on collision, just with enough detail to fix it.

Open question: I kept the `migration.version!` non-null assertions consistent with the rest of `run.ts` (the filename regex guarantees a version prefix). Let me know if you'd rather harden that instead.

Out of scope: the migration loading / ordering logic itself — only the error message changed.