### PR TITLE
upstream-draft: feat(items): db.select / db.selected filter hooks on the read path (#32)

### DIFF
--- a/.changeset/items-db-read-filter-events.md
+++ b/.changeset/items-db-read-filter-events.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Added `items.db.select` / `items.db.selected` filter hooks (and their collection-scoped `<collection>.db.select` / `<collection>.db.selected` variants) around the read query in `runAst`. `db.select` receives the pending knex query builder so a hook can adjust it before it runs; `db.selected` receives the raw rows straight off the database so a hook can inspect or replace them before any transform. With no listeners registered both are a no-op.

--- a/api/src/database/run-ast/run-ast.test.ts
+++ b/api/src/database/run-ast/run-ast.test.ts
@@ -1,0 +1,94 @@
+import { SchemaBuilder } from '@directus/schema-builder';
+import type { Accountability, Item } from '@directus/types';
+import knex, { type Knex } from 'knex';
+import { createTracker, MockClient, type Tracker } from 'knex-mock-client';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, type MockedFunction, vi } from 'vitest';
+import emitter from '../../emitter.js';
+import type { AST } from '../../types/ast.js';
+import { runAst } from './run-ast.js';
+
+vi.mock('../index.js', () => ({
+	default: vi.fn(),
+	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
+}));
+
+const schema = new SchemaBuilder()
+	.collection('test', (c) => {
+		c.field('id').id();
+		c.field('name').string();
+	})
+	.build();
+
+const accountability = { admin: true } as Accountability;
+
+function buildAst(): AST {
+	return {
+		type: 'root',
+		name: 'test',
+		query: { fields: ['id', 'name'] },
+		children: [
+			{ type: 'field', name: 'id', fieldKey: 'id', alias: false, whenCase: [] },
+			{ type: 'field', name: 'name', fieldKey: 'name', alias: false, whenCase: [] },
+		],
+		cases: [],
+	};
+}
+
+describe('runAst filter events', () => {
+	let db: MockedFunction<Knex>;
+	let tracker: Tracker;
+
+	beforeAll(() => {
+		db = vi.mocked(knex.default({ client: MockClient }));
+		tracker = createTracker(db);
+	});
+
+	beforeEach(() => {
+		tracker.on.select('test').response([{ id: 1, name: 'Original' }]);
+	});
+
+	afterEach(() => {
+		tracker.reset();
+		emitter.offAll();
+		vi.clearAllMocks();
+	});
+
+	it('emits items.db.select with the pending query builder before it runs', async () => {
+		const handler = vi.fn((payload) => payload);
+		emitter.onFilter('items.db.select', handler);
+
+		await runAst(buildAst(), schema, accountability, { knex: db });
+
+		expect(handler).toHaveBeenCalledTimes(1);
+		const [payload, meta, context] = handler.mock.calls[0]!;
+		// The payload is the un-awaited knex query builder, so a hook can still mutate it.
+		expect(typeof (payload as { then?: unknown }).then).toBe('function');
+		expect(meta).toMatchObject({ event: 'items.db.select', collection: 'test' });
+		expect(context).toMatchObject({ schema });
+	});
+
+	it('emits items.db.selected with the raw rows and lets a hook replace them', async () => {
+		const selectedHandler = vi.fn(() => [{ id: 1, name: 'Replaced' }]);
+		emitter.onFilter('items.db.selected', selectedHandler);
+
+		const result = await runAst(buildAst(), schema, accountability, { knex: db });
+
+		expect(selectedHandler).toHaveBeenCalledTimes(1);
+		const [payload, meta] = selectedHandler.mock.calls[0]!;
+		expect(payload).toEqual([{ id: 1, name: 'Original' }]);
+		expect(meta).toMatchObject({ event: 'items.db.selected', collection: 'test' });
+		expect((result as Item[])[0]).toMatchObject({ id: 1, name: 'Replaced' });
+	});
+
+	it('also emits the collection-scoped event names', async () => {
+		const scopedSelect = vi.fn((payload) => payload);
+		const scopedSelected = vi.fn((payload) => payload);
+		emitter.onFilter('test.db.select', scopedSelect);
+		emitter.onFilter('test.db.selected', scopedSelected);
+
+		await runAst(buildAst(), schema, accountability, { knex: db });
+
+		expect(scopedSelect).toHaveBeenCalledTimes(1);
+		expect(scopedSelected).toHaveBeenCalledTimes(1);
+	});
+});

--- a/api/src/database/run-ast/run-ast.ts
+++ b/api/src/database/run-ast/run-ast.ts
@@ -1,6 +1,7 @@
 import { useEnv } from '@directus/env';
 import type { Accountability, Filter, Item, Permission, Query, SchemaOverview } from '@directus/types';
 import { cloneDeep, merge } from 'lodash-es';
+import emitter from '../../emitter.js';
 import { fetchPermissions } from '../../permissions/lib/fetch-permissions.js';
 import { fetchPolicies } from '../../permissions/lib/fetch-policies.js';
 import { PayloadService } from '../../services/payload.js';
@@ -85,7 +86,23 @@ export async function runAst(
 			{ schema, knex },
 		);
 
-		const rawItems: Item | Item[] = await dbQuery;
+		// Let hooks rewrite the query builder before it runs (e.g. add a hint or extra clause).
+		const filteredQuery = await emitter.emitFilter(
+			['items.db.select', `${collection}.db.select`],
+			dbQuery,
+			{ collection, query },
+			{ database: knex, schema, accountability },
+		);
+
+		let rawItems: Item | Item[] = await filteredQuery;
+
+		// Let hooks inspect or replace the raw rows straight off the database, before any transform.
+		rawItems = await emitter.emitFilter(
+			['items.db.selected', `${collection}.db.selected`],
+			rawItems,
+			{ collection, query },
+			{ database: knex, schema, accountability },
+		);
 
 		if (!rawItems) return null;
 


### PR DESCRIPTION
Part of #32. Extensions can hook the items write path (`items.create`, etc.) but there's no filter seam on the read path — once `runAst` builds and runs the query you can't touch it. This adds two:

- `items.db.select` / `<collection>.db.select` — receives the **pending knex query builder** (before it's awaited), so a hook can rewrite the query (add a hint, an extra clause, swap it out).
- `items.db.selected` / `<collection>.db.selected` — receives the **raw rows straight off the database**, before the payload transforms, so a hook can inspect or replace them.

Both fire inside `run()`, which is recursive — so they also fire on nested relational sub-reads, not just the top-level query. That's deliberate (a hook can intercept *any* read), but it does mean they fire multiple times on deep reads. With no listener registered `emitFilter` is a no-op, so the hot-path cost is two `listeners()` lookups per level.

Tests: there was no `runAst` test in the repo, so this adds one (`run-ast.test.ts`) — knex-mock-client + SchemaBuilder, real filter handlers registered on the emitter singleton. It asserts `db.select` gets the un-awaited builder, `db.selected` gets the raw rows and its return value replaces them, and the collection-scoped event names fire.

Open questions:
- Per-level firing vs top-level only — I went with per-level to match the fork's intent, but I can gate it to the root AST if you'd rather not fire on every relational sub-read.
- Naming: `db.select`/`db.selected` mirror the existing `db.insert` direction in #32. Happy to rename if you have a convention in mind.

Out of scope: the `items.db.insert` / `db.inserted` write-path events from the same fork branch — they're entangled with the batch-insert createMany work (separate PR) and still WIP-quality, so I've held them back rather than ship them half-baked here.