### PR TITLE
upstream-draft: fix(items): normalize nested filters with sibling relational keys (#37)

### DIFF
--- a/.changeset/normalize-nested-filters.md
+++ b/.changeset/normalize-nested-filters.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed deeply nested relational filters silently dropping sibling keys. `getFilterPath` only follows `Object.keys(value)[0]`, so a filter like `{ rel: { a: {...}, b: {...} } }` only applied the first branch's WHERE/JOIN conditions. A `normalizeFilter()` pass now splits multi-key relational objects into `_and` arrays before joins and where clauses are built, so every relational path is applied.

--- a/api/src/database/run-ast/lib/apply-query/filter/index.test.ts
+++ b/api/src/database/run-ast/lib/apply-query/filter/index.test.ts
@@ -330,6 +330,87 @@ for (const quantifier of ['_some', '_none']) {
 	});
 }
 
+test(`filtering o2m relation with sibling relational keys`, async () => {
+	const schema = new SchemaBuilder()
+		.collection('article', (c) => {
+			c.field('id').id();
+			c.field('links').o2m('links_list', 'article_id');
+		})
+		.collection('links_list', (c) => {
+			c.field('id').id();
+			c.field('name').string();
+			c.field('status').string();
+		})
+		.build();
+
+	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
+	const queryBuilder = db.queryBuilder();
+
+	applyFilter(
+		db,
+		schema,
+		queryBuilder,
+		{
+			links: {
+				name: { _eq: 'a' },
+				status: { _eq: 'b' },
+			},
+		},
+		'article',
+		{},
+		[],
+		[],
+	);
+
+	const rawQuery = queryBuilder.toSQL();
+
+	// without normalization getFilterPath would drop one sibling; both must survive
+	expect(rawQuery.bindings).toContain('a');
+	expect(rawQuery.bindings).toContain('b');
+});
+
+test(`filtering o2m relation with sibling keys inside _some`, async () => {
+	const schema = new SchemaBuilder()
+		.collection('article', (c) => {
+			c.field('id').id();
+			c.field('links').o2m('links_list', 'article_id');
+		})
+		.collection('links_list', (c) => {
+			c.field('id').id();
+			c.field('name').string();
+			c.field('status').string();
+		})
+		.build();
+
+	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
+	const queryBuilder = db.queryBuilder();
+
+	applyFilter(
+		db,
+		schema,
+		queryBuilder,
+		{
+			links: {
+				_some: {
+					name: { _eq: 'a' },
+					status: { _eq: 'b' },
+				},
+			},
+		},
+		'article',
+		{},
+		[],
+		[],
+	);
+
+	const rawQuery = queryBuilder.toSQL();
+
+	// the quantifier still produces a subquery, and both siblings survive inside it
+	expect(rawQuery.sql).toContain('select');
+	expect(rawQuery.bindings).toContain('a');
+	expect(rawQuery.bindings).toContain('b');
+});
+
 test(`filtering a2o relation`, async () => {
 	const schema = new SchemaBuilder()
 		.collection('article', (c) => {

--- a/api/src/database/run-ast/lib/apply-query/filter/index.test.ts
+++ b/api/src/database/run-ast/lib/apply-query/filter/index.test.ts
@@ -186,6 +186,69 @@ test(`filtering m2o relation`, async () => {
 	expect(rawQuery.bindings).toEqual(['username']);
 });
 
+test(`filtering nested m2o with sibling relational keys`, async () => {
+	const schema = new SchemaBuilder()
+		.collection('root', (c) => {
+			c.field('id').id();
+			c.field('rel_1').m2o('table_1');
+		})
+		.collection('table_1', (c) => {
+			c.field('id').id();
+			c.field('rel_2').m2o('table_2');
+		})
+		.collection('table_2', (c) => {
+			c.field('id').id();
+			c.field('status').string();
+			c.field('rel_3').m2o('table_3');
+		})
+		.collection('table_3', (c) => {
+			c.field('id').id();
+			c.field('status').string();
+			c.field('rel_4').m2o('table_4');
+		})
+		.collection('table_4', (c) => {
+			c.field('id').id();
+			c.field('status').string();
+		})
+		.build();
+
+	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
+	const queryBuilder = db.queryBuilder();
+
+	applyFilter(
+		db,
+		schema,
+		queryBuilder,
+		{
+			rel_1: {
+				rel_2: {
+					rel_3: {
+						status: { _eq: 'active' },
+						rel_4: {
+							status: { _eq: 'active' },
+						},
+					},
+					status: { _eq: 'active' },
+				},
+			},
+		},
+		'root',
+		{},
+		[],
+		[],
+	);
+
+	const rawQuery = queryBuilder.toSQL();
+
+	// All three conditions should appear in the WHERE clause
+	expect(rawQuery.sql).toContain('where');
+	expect(rawQuery.bindings).toContain('active');
+
+	// Should be 3: one for each sibling filter (table_3.status, table_4.status, table_2.status)
+	const activeBindings = rawQuery.bindings.filter((b: unknown) => b === 'active');
+	expect(activeBindings).toHaveLength(3);
+});
+
 const o2m_schema = new SchemaBuilder()
 	.collection('article', (c) => {
 		c.field('id').id();

--- a/api/src/database/run-ast/lib/apply-query/filter/index.ts
+++ b/api/src/database/run-ast/lib/apply-query/filter/index.ts
@@ -10,6 +10,7 @@ import { addJoin } from '../add-join.js';
 import { getFilterPath } from '../get-filter-path.js';
 import { getOperation } from '../get-operation.js';
 import applyQuery from '../index.js';
+import { normalizeFilter } from '../normalize-filter.js';
 import { getFilterType } from './get-filter-type.js';
 import { applyOperator } from './operator.js';
 import { validateOperator } from './validate-operator.js';
@@ -28,8 +29,10 @@ export function applyFilter(
 	let hasJoins = false;
 	let hasMultiRelationalFilter = false;
 
-	addJoins(rootQuery, rootFilter, collection);
-	addWhereClauses(knex, rootQuery, rootFilter, collection);
+	const normalizedFilter = normalizeFilter(rootFilter);
+
+	addJoins(rootQuery, normalizedFilter, collection);
+	addWhereClauses(knex, rootQuery, normalizedFilter, collection);
 
 	return { query: rootQuery, hasJoins, hasMultiRelationalFilter };
 

--- a/api/src/database/run-ast/lib/apply-query/normalize-filter.test.ts
+++ b/api/src/database/run-ast/lib/apply-query/normalize-filter.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from 'vitest';
+import { normalizeFilter } from './normalize-filter.js';
+
+describe('normalizeFilter', () => {
+	test('returns empty filter unchanged', () => {
+		expect(normalizeFilter({})).toEqual({});
+	});
+
+	test('returns simple operator filter unchanged', () => {
+		const filter = { field: { _eq: 'value' } };
+		expect(normalizeFilter(filter)).toEqual(filter);
+	});
+
+	test('returns single relational path unchanged', () => {
+		const filter = { rel: { sub: { _eq: 'value' } } };
+		expect(normalizeFilter(filter)).toEqual(filter);
+	});
+
+	test('returns deep single relational path unchanged', () => {
+		const filter = { a: { b: { c: { d: { _eq: 1 } } } } };
+		expect(normalizeFilter(filter)).toEqual(filter);
+	});
+
+	test('splits sibling relational keys into _and', () => {
+		const filter = {
+			rel: {
+				field_a: { _eq: 1 },
+				field_b: { _eq: 2 },
+			},
+		};
+
+		expect(normalizeFilter(filter)).toEqual({
+			_and: [{ rel: { field_a: { _eq: 1 } } }, { rel: { field_b: { _eq: 2 } } }],
+		});
+	});
+
+	test('splits deeply nested sibling keys', () => {
+		const filter = {
+			a: {
+				b: {
+					c: { _eq: 1 },
+					d: { _eq: 2 },
+				},
+			},
+		};
+
+		expect(normalizeFilter(filter)).toEqual({
+			_and: [{ a: { b: { c: { _eq: 1 } } } }, { a: { b: { d: { _eq: 2 } } } }],
+		});
+	});
+
+	test('splits at multiple nesting levels', () => {
+		const filter = {
+			a: {
+				b: {
+					x: { _eq: 1 },
+					y: { _eq: 2 },
+				},
+				c: { _eq: 3 },
+			},
+		};
+
+		expect(normalizeFilter(filter)).toEqual({
+			_and: [{ a: { b: { x: { _eq: 1 } } } }, { a: { b: { y: { _eq: 2 } } } }, { a: { c: { _eq: 3 } } }],
+		});
+	});
+
+	test('preserves _and arrays and normalizes their contents', () => {
+		const filter = {
+			_and: [
+				{
+					rel: {
+						a: { _eq: 1 },
+						b: { _eq: 2 },
+					},
+				},
+			],
+		};
+
+		expect(normalizeFilter(filter)).toEqual({
+			_and: [
+				{
+					_and: [{ rel: { a: { _eq: 1 } } }, { rel: { b: { _eq: 2 } } }],
+				},
+			],
+		});
+	});
+
+	test('preserves _or arrays and normalizes their contents', () => {
+		const filter = {
+			_or: [
+				{
+					rel: {
+						a: { _eq: 1 },
+						b: { _eq: 2 },
+					},
+				},
+			],
+		};
+
+		expect(normalizeFilter(filter)).toEqual({
+			_or: [
+				{
+					_and: [{ rel: { a: { _eq: 1 } } }, { rel: { b: { _eq: 2 } } }],
+				},
+			],
+		});
+	});
+
+	test('handles mixed operator and relational keys', () => {
+		const filter = {
+			field: {
+				_eq: 'direct',
+				sub: { _eq: 'nested' },
+			},
+		};
+
+		expect(normalizeFilter(filter)).toEqual({
+			_and: [{ field: { sub: { _eq: 'nested' } } }, { field: { _eq: 'direct' } }],
+		});
+	});
+
+	test('keeps multiple operator keys on same field together', () => {
+		const filter = { field: { _gte: 1, _lte: 10 } };
+		expect(normalizeFilter(filter)).toEqual(filter);
+	});
+
+	test('handles _some as relational key', () => {
+		const filter = {
+			rel: {
+				_some: { field: { _eq: 1 } },
+				other: { _eq: 2 },
+			},
+		};
+
+		expect(normalizeFilter(filter)).toEqual({
+			_and: [{ rel: { _some: { field: { _eq: 1 } } } }, { rel: { other: { _eq: 2 } } }],
+		});
+	});
+
+	test('handles _none as relational key', () => {
+		const filter = {
+			rel: {
+				_none: { field: { _eq: 1 } },
+				other: { _eq: 2 },
+			},
+		};
+
+		expect(normalizeFilter(filter)).toEqual({
+			_and: [{ rel: { _none: { field: { _eq: 1 } } } }, { rel: { other: { _eq: 2 } } }],
+		});
+	});
+
+	test('preserves flat structure when top-level keys are unique', () => {
+		const filter = {
+			field_a: { _eq: 1 },
+			field_b: { _eq: 2 },
+			rel: { sub: { _eq: 3 } },
+		};
+
+		expect(normalizeFilter(filter)).toEqual(filter);
+	});
+
+	test('handles non-object filter values', () => {
+		const filter = { field: 'direct-value' };
+		expect(normalizeFilter(filter as any)).toEqual({ field: 'direct-value' });
+	});
+
+	test('deeply nested m2o chain with sibling filters at multiple levels', () => {
+		const filter = {
+			field_a: { _eq: 'value-a' },
+			field_b: { _in: ['x', 'y'] },
+			rel_1: {
+				rel_2: {
+					rel_3: {
+						status: { _eq: 'active' },
+						rel_4: {
+							status: { _eq: 'active' },
+							rel_5: {
+								status: { _eq: 'active' },
+							},
+						},
+					},
+					status: { _eq: 'active' },
+				},
+			},
+		};
+
+		const normalized = normalizeFilter(filter);
+
+		// All paths should be fully separated - each with a single relational chain
+		expect(normalized).toEqual({
+			_and: [
+				{ field_a: { _eq: 'value-a' } },
+				{ field_b: { _in: ['x', 'y'] } },
+				{ rel_1: { rel_2: { rel_3: { status: { _eq: 'active' } } } } },
+				{ rel_1: { rel_2: { rel_3: { rel_4: { status: { _eq: 'active' } } } } } },
+				{ rel_1: { rel_2: { rel_3: { rel_4: { rel_5: { status: { _eq: 'active' } } } } } } },
+				{ rel_1: { rel_2: { status: { _eq: 'active' } } } },
+			],
+		});
+	});
+});

--- a/api/src/database/run-ast/lib/apply-query/normalize-filter.test.ts
+++ b/api/src/database/run-ast/lib/apply-query/normalize-filter.test.ts
@@ -65,6 +65,42 @@ describe('normalizeFilter', () => {
 		});
 	});
 
+	test('never nests _and/_or inside a relational value (the getFilterPath invariant)', () => {
+		// liftAndPush must keep the logical wrapper at the top, not buried in a relational value
+		// where getFilterPath (which only follows Object.keys(value)[0]) would mishandle it.
+		const filter = {
+			a: {
+				b: {
+					c: { _eq: 1 },
+					d: { _eq: 2 },
+				},
+				e: { _eq: 3 },
+			},
+		};
+
+		const isPlainObject = (node: unknown): node is Record<string, unknown> =>
+			typeof node === 'object' && node !== null && !Array.isArray(node);
+
+		const relationalValueContainsLogical = (node: unknown): boolean => {
+			if (!isPlainObject(node)) return false;
+
+			for (const [key, value] of Object.entries(node)) {
+				if (key === '_and' || key === '_or') {
+					// a top-level logical wrapper is fine; recurse into its sub-filters
+					if ((value as unknown[]).some(relationalValueContainsLogical)) return true;
+				} else if (isPlainObject(value)) {
+					// `value` is a relational/operator object: it must not introduce a logical wrapper
+					if ('_and' in value || '_or' in value) return true;
+					if (relationalValueContainsLogical(value)) return true;
+				}
+			}
+
+			return false;
+		};
+
+		expect(relationalValueContainsLogical(normalizeFilter(filter))).toBe(false);
+	});
+
 	test('preserves _and arrays and normalizes their contents', () => {
 		const filter = {
 			_and: [

--- a/api/src/database/run-ast/lib/apply-query/normalize-filter.ts
+++ b/api/src/database/run-ast/lib/apply-query/normalize-filter.ts
@@ -1,0 +1,84 @@
+import type { Filter } from '@directus/types';
+import { isObject } from '@directus/utils';
+
+/**
+ * Normalizes a filter so that each relational path segment has at most one
+ * non-operator child key. When a relational object has multiple sibling
+ * children (e.g. `{ parent: { field_a: { _eq: 'value' }, nested: { ... } } }`),
+ * they are split into separate entries wrapped in `_and`.
+ *
+ * This is necessary because `getFilterPath` only follows `Object.keys(value)[0]`,
+ * silently dropping any sibling keys at the same nesting level.
+ */
+export function normalizeFilter(filter: Filter): Filter {
+	const entries = Object.entries(filter);
+	const parts: Filter[] = [];
+
+	for (const [key, value] of entries) {
+		if (key === '_and' || key === '_or') {
+			parts.push({ [key]: (value as Filter[]).map((f) => normalizeFilter(f)) } as Filter);
+			continue;
+		}
+
+		if (!isObject(value)) {
+			parts.push({ [key]: value } as Filter);
+			continue;
+		}
+
+		const val = value as Record<string, any>;
+		const childKeys = Object.keys(val);
+		const relKeys = childKeys.filter((k) => !k.startsWith('_') || k === '_none' || k === '_some');
+		const opKeys = childKeys.filter((k) => k.startsWith('_') && k !== '_none' && k !== '_some');
+
+		if (relKeys.length > 1 || (relKeys.length >= 1 && opKeys.length >= 1)) {
+			// Multiple relational children or mix of relational + operator keys: split each
+			for (const rk of relKeys) {
+				const normalized = normalizeFilter({ [rk]: val[rk] } as Filter);
+				liftAndPush(parts, key, normalized);
+			}
+
+			if (opKeys.length > 0) {
+				const ops: Record<string, any> = {};
+				for (const ok of opKeys) ops[ok] = val[ok];
+				parts.push({ [key]: ops } as Filter);
+			}
+		} else if (relKeys.length === 1) {
+			// Single relational child, recurse to normalize deeper levels
+			const normalized = normalizeFilter(val as Filter);
+			liftAndPush(parts, key, normalized);
+		} else {
+			// Only operator keys (leaf node)
+			parts.push({ [key]: val } as Filter);
+		}
+	}
+
+	if (parts.length === 0) return {} as Filter;
+	if (parts.length === 1) return parts[0]!;
+
+	// Merge into a flat object when all keys are unique (preserves original structure)
+	const allKeys = parts.flatMap((p) => Object.keys(p));
+
+	if (new Set(allKeys).size === allKeys.length) {
+		return Object.assign({}, ...parts) as Filter;
+	}
+
+	return { _and: parts } as Filter;
+}
+
+/**
+ * If the normalized result is a pure `_and` wrapper, lift each sub-filter
+ * and wrap it with the parent key individually. This prevents `_and` from
+ * appearing inside a relational value object where `getFilterPath` can't
+ * handle it.
+ */
+function liftAndPush(parts: Filter[], key: string, normalized: Filter): void {
+	const normKeys = Object.keys(normalized);
+
+	if (normKeys.length === 1 && normKeys[0] === '_and') {
+		for (const sub of (normalized as any)._and) {
+			parts.push({ [key]: sub } as Filter);
+		}
+	} else {
+		parts.push({ [key]: normalized } as Filter);
+	}
+}


### PR DESCRIPTION
`getFilterPath` walks a relational filter by following `Object.keys(value)[0]` — only the **first** key at each nesting level. So a filter with sibling relational keys at the same level silently drops all but the first branch:

```js
{ rel_1: { rel_2: { a: { _eq: 1 }, b: { _eq: 2 } } } }
// only `a` produced a WHERE/JOIN; `b` was dropped
```

This bites any deeply-nested relational filter with more than one child per level. Our hooks currently work around it app-side with a `parseHookNestedFields()` shim before handing filters to Directus — this removes the need for that.

Fix: a `normalizeFilter()` pass in `applyFilter`, before `addJoins` / `addWhereClauses`, that splits multi-key relational objects into `_and` arrays so every relational path gets its own entry. Operator keys (`_eq`, `_none`, `_some`, …) and `_and`/`_or` are preserved; single-key paths and leaves pass through unchanged (merged flat when keys don't collide, so the common case keeps its original shape).

Tests: `normalize-filter.test.ts` covers the transform in isolation (16 cases — leaves, operators, `_and`/`_or`, single vs multi sibling, deep nesting); `filter/index.test.ts` adds an end-to-end case asserting all three sibling conditions reach the WHERE clause (3 `active` bindings) — that case fails without the fix, so it's a real regression guard.

Open questions:
- `normalizeFilter` runs on **every** `applyFilter` call. It's a shallow structural walk and a no-op for single-key filters, but it does allocate on multi-key ones — flag if you want it gated behind a "has sibling relational keys" cheap check first.
- Edge: I treat `_none`/`_some` as relational (they introduce a sub-path), everything else `_`-prefixed as an operator. Want to confirm that's the full set for your filter grammar.

Out of scope: `getFilterPath` itself is left untouched — normalizing upstream of it is the minimal, lower-risk fix vs. teaching the walker to fan out.