### PR TITLE
upstream-draft: feat(items): optionally await action hooks in mutations

### DIFF
--- a/.changeset/async-emit-action.md
+++ b/.changeset/async-emit-action.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+'@directus/types': patch
+---
+
+Made `emitter.emitAction()` async so an items-service mutation can optionally wait for its action hooks to finish before resolving. Action hooks remain **fire-and-forget by default** (unchanged behaviour); pass the new `awaitActionHooks` mutation option to block a create/update/delete until its action handlers have settled — useful when a client immediately reads back a side effect a handler produces (e.g. an aggregate recompute) and would otherwise race it. A mutation's action events — the item's own plus any nested ones, and the `items`/`<collection>`-scoped variants — run in parallel, so a slow handler on one event doesn't serialize the rest. `bypassEmitAction` now also accepts an async handler. Errors thrown by action handlers are still caught and logged, not propagated.

--- a/api/src/emitter.ts
+++ b/api/src/emitter.ts
@@ -59,16 +59,24 @@ export class Emitter {
 		return updatedPayload;
 	}
 
-	public emitAction(event: string | string[], meta: Record<string, any>, context: EventContext | null = null): void {
+	public async emitAction(
+		event: string | string[],
+		meta: Record<string, any>,
+		context: EventContext | null = null,
+	): Promise<void> {
 		const logger = useLogger();
 		const events = Array.isArray(event) ? event : [event];
 
-		for (const event of events) {
-			this.actionEmitter.emitAsync(event, { event, ...meta }, context ?? this.getDefaultContext()).catch((err) => {
-				logger.warn(`An error was thrown while executing action "${event}"`);
-				logger.warn(err);
-			});
-		}
+		// Run every event's listeners in parallel and await them together, so a slow
+		// handler on one event doesn't serialize behind the others.
+		await Promise.all(
+			events.map((event) =>
+				this.actionEmitter.emitAsync(event, { event, ...meta }, context ?? this.getDefaultContext()).catch((err) => {
+					logger.warn(`An error was thrown while executing action "${event}"`);
+					logger.warn(err);
+				}),
+			),
+		);
 	}
 
 	public async emitInit(event: string, meta: Record<string, any>): Promise<void> {

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -5,6 +5,7 @@ import knex, { type Knex } from 'knex';
 import { createTracker, MockClient, Tracker } from 'knex-mock-client';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, type MockedFunction, test, vi } from 'vitest';
 import { getDatabaseClient } from '../database/index.js';
+import emitter from '../emitter.js';
 import { validateUserCountIntegrity } from '../utils/validate-user-count-integrity.js';
 import { handleVersion } from '../utils/versioning/handle-version.js';
 import { ItemsService } from './index.js';
@@ -169,6 +170,74 @@ describe('Integration Tests', () => {
 				expect(mockReturning).toHaveBeenCalledWith('id', undefined);
 
 				transactionSpy.mockRestore();
+			});
+
+			it('awaits async action handlers before resolving when awaitActionHooks is set', async () => {
+				let actionCompleted = false;
+
+				// Resolve on a macrotask: a fire-and-forget emitAction would let createOne
+				// return before this runs, leaving actionCompleted false.
+				const handler = () =>
+					new Promise<void>((resolve) => {
+						setTimeout(() => {
+							actionCompleted = true;
+							resolve();
+						}, 0);
+					});
+
+				emitter.onAction('test.items.create', handler);
+
+				try {
+					await service.createOne({ name: 'Test' }, { awaitActionHooks: true });
+					expect(actionCompleted).toBe(true);
+				} finally {
+					emitter.offAction('test.items.create', handler);
+				}
+			});
+
+			it('does not await action handlers by default (fire-and-forget)', async () => {
+				let actionCompleted = false;
+
+				const handler = () =>
+					new Promise<void>((resolve) => {
+						setTimeout(() => {
+							actionCompleted = true;
+							resolve();
+						}, 0);
+					});
+
+				emitter.onAction('test.items.create', handler);
+
+				try {
+					await service.createOne({ name: 'Test' });
+					// Without awaitActionHooks, createOne resolves without waiting for the macrotask handler.
+					expect(actionCompleted).toBe(false);
+				} finally {
+					emitter.offAction('test.items.create', handler);
+				}
+			});
+
+			it('runs the scoped action events in parallel when awaited', async () => {
+				let signalSecondStarted!: () => void;
+				const secondStarted = new Promise<void>((resolve) => (signalSecondStarted = resolve));
+
+				// The first handler only finishes once the second has started. Run sequentially
+				// this deadlocks (the second never starts), so the test only passes when parallel.
+				const firstHandler = () => secondStarted;
+
+				const secondHandler = () => {
+					signalSecondStarted();
+				};
+
+				emitter.onAction('items.create', firstHandler);
+				emitter.onAction('test.items.create', secondHandler);
+
+				try {
+					await service.createOne({ name: 'Test' }, { awaitActionHooks: true });
+				} finally {
+					emitter.offAction('items.create', firstHandler);
+					emitter.offAction('test.items.create', secondHandler);
+				}
 			});
 		});
 

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -272,5 +272,73 @@ describe('Integration Tests', () => {
 				expect(validateUserCountIntegrity).toHaveBeenCalled();
 			});
 		});
+
+		describe('action hook emission (await / bypass)', () => {
+			const macrotaskHandler = (onDone: () => void) => () =>
+				new Promise<void>((resolve) => {
+					setTimeout(() => {
+						onDone();
+						resolve();
+					}, 0);
+				});
+
+			it('still resolves when an awaited action handler throws (error caught and logged)', async () => {
+				const handler = () => Promise.reject(new Error('boom'));
+
+				emitter.onAction('test.items.create', handler);
+
+				try {
+					// emitter.emitAction swallows per-event errors, so the mutation must not reject
+					const outcome = await service.createOne({ name: 'Test' }, { awaitActionHooks: true }).then(
+						() => 'resolved',
+						() => 'rejected',
+					);
+
+					expect(outcome).toBe('resolved');
+				} finally {
+					emitter.offAction('test.items.create', handler);
+				}
+			});
+
+			it('routes action events to bypassEmitAction and skips the emitter', async () => {
+				const emitActionSpy = vi.spyOn(emitter, 'emitAction');
+				const bypassEmitAction = vi.fn().mockResolvedValue(undefined);
+
+				await service.createOne({ name: 'Test' }, { bypassEmitAction, awaitActionHooks: true });
+
+				expect(bypassEmitAction).toHaveBeenCalled();
+				expect(emitActionSpy).not.toHaveBeenCalled();
+
+				emitActionSpy.mockRestore();
+			});
+
+			it('awaits async action handlers on update when awaitActionHooks is set', async () => {
+				let actionCompleted = false;
+				const handler = macrotaskHandler(() => (actionCompleted = true));
+
+				emitter.onAction('test.items.update', handler);
+
+				try {
+					await service.updateMany([1], {}, { awaitActionHooks: true });
+					expect(actionCompleted).toBe(true);
+				} finally {
+					emitter.offAction('test.items.update', handler);
+				}
+			});
+
+			it('awaits async action handlers on delete when awaitActionHooks is set', async () => {
+				let actionCompleted = false;
+				const handler = macrotaskHandler(() => (actionCompleted = true));
+
+				emitter.onAction('test.items.delete', handler);
+
+				try {
+					await service.deleteMany([1], { awaitActionHooks: true });
+					expect(actionCompleted).toBe(true);
+				} finally {
+					emitter.offAction('test.items.delete', handler);
+				}
+			});
+		});
 	});
 });

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -39,6 +39,30 @@ import { PayloadService } from './payload.js';
 
 const env = useEnv();
 
+/**
+ * Emit a mutation's action events (the item's own event plus any queued nested ones) in parallel.
+ * They run together, so a slow handler on one event doesn't serialize the rest. By default the
+ * mutation does not wait for them (Directus' historical fire-and-forget behaviour); pass
+ * `awaitActionHooks` to block until every handler has settled.
+ */
+async function emitActionEvents(actionEvents: ActionEventParams[], opts: MutationOptions): Promise<void> {
+	const emitting = Promise.all(
+		actionEvents.map((actionEvent) =>
+			opts.bypassEmitAction
+				? opts.bypassEmitAction(actionEvent)
+				: emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context),
+		),
+	);
+
+	if (opts.awaitActionHooks) {
+		await emitting;
+	} else {
+		// Per-event errors are already caught and logged inside emitter.emitAction; swallow here so
+		// an un-awaited rejection (e.g. from a bypassEmitAction handler) doesn't go unhandled.
+		emitting.catch(() => {});
+	}
+}
+
 export class ItemsService<Item extends AnyItem = AnyItem, Collection extends string = string>
 	implements AbstractService<Item>
 {
@@ -414,19 +438,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				},
 			};
 
-			if (opts.bypassEmitAction) {
-				opts.bypassEmitAction(actionEvent);
-			} else {
-				emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context);
-			}
-
-			for (const nestedActionEvent of nestedActionEvents) {
-				if (opts.bypassEmitAction) {
-					opts.bypassEmitAction(nestedActionEvent);
-				} else {
-					emitter.emitAction(nestedActionEvent.event, nestedActionEvent.meta, nestedActionEvent.context);
-				}
-			}
+			await emitActionEvents([actionEvent, ...nestedActionEvents], opts);
 		}
 
 		if (shouldClearCache(this.cache, opts, this.collection)) {
@@ -499,13 +511,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		});
 
 		if (opts.emitEvents !== false) {
-			for (const nestedActionEvent of nestedActionEvents) {
-				if (opts.bypassEmitAction) {
-					opts.bypassEmitAction(nestedActionEvent);
-				} else {
-					emitter.emitAction(nestedActionEvent.event, nestedActionEvent.meta, nestedActionEvent.context);
-				}
-			}
+			await emitActionEvents(nestedActionEvents, opts);
 		}
 
 		if (shouldClearCache(this.cache, opts, this.collection)) {
@@ -587,7 +593,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				: records;
 
 		if (opts?.emitEvents !== false) {
-			emitter.emitAction(
+			// Read action hooks stay fire-and-forget; the await opt-in (`awaitActionHooks`) is for mutations.
+			void emitter.emitAction(
 				this.eventScope === 'items' ? ['items.read', `${this.collection}.items.read`] : `${this.eventScope}.read`,
 				{
 					payload: filteredRecords,
@@ -991,19 +998,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				},
 			};
 
-			if (opts.bypassEmitAction) {
-				opts.bypassEmitAction(actionEvent);
-			} else {
-				emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context);
-			}
-
-			for (const nestedActionEvent of nestedActionEvents) {
-				if (opts.bypassEmitAction) {
-					opts.bypassEmitAction(nestedActionEvent);
-				} else {
-					emitter.emitAction(nestedActionEvent.event, nestedActionEvent.meta, nestedActionEvent.context);
-				}
-			}
+			await emitActionEvents([actionEvent, ...nestedActionEvents], opts);
 		}
 
 		return keys;
@@ -1216,11 +1211,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				},
 			};
 
-			if (opts.bypassEmitAction) {
-				opts.bypassEmitAction(actionEvent);
-			} else {
-				emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context);
-			}
+			await emitActionEvents([actionEvent], opts);
 		}
 
 		return keysAfterHooks;

--- a/packages/types/src/items.ts
+++ b/packages/types/src/items.ts
@@ -67,7 +67,14 @@ export type MutationOptions = {
 	 * To bypass the emitting of action events if emitEvents is enabled
 	 * Can be used to queue up the nested events from item service's create, update and delete
 	 */
-	bypassEmitAction?: ((params: ActionEventParams) => void) | undefined;
+	bypassEmitAction?: ((params: ActionEventParams) => void) | ((params: ActionEventParams) => Promise<void>) | undefined;
+
+	/**
+	 * Await the mutation's action hooks before resolving, instead of firing them and forgetting.
+	 * Off by default (action hooks stay fire-and-forget); opt in when a client reads back a side
+	 * effect an action handler produces and would otherwise race it.
+	 */
+	awaitActionHooks?: boolean | undefined;
 
 	/**
 	 * To bypass limits so that functions would work as intended


### PR DESCRIPTION
## Why

`emitter.emitAction()` is fire-and-forget: the items service kicks off action hooks without awaiting them (`emitAsync(...).catch(warn)`), so a `create`/`update`/`delete` resolves — and the API responds — before any action handler finishes. If a handler has a side effect that a client then reads back (e.g. recomputing an aggregate table on `items.create`), there's a race.

Directus action hooks are **deliberately non-blocking**, so this keeps that default and makes the awaiting **opt-in**.

## What

- **`emitAction` becomes async** and runs an event's listeners in parallel (`Promise.all`), so a slow handler on one event doesn't serialize the rest.
- **New `awaitActionHooks` mutation option** (default `false`). When set, the items-service mutation awaits its action events before resolving; when unset, the events stay fire-and-forget — **identical to today's behaviour**. The repeated per-site emit logic folds into a small `emitActionEvents()` helper.
- A mutation's action events — the item's own plus any nested ones, and the `items.*` / `<collection>.*` scoped variants — are awaited together under the opt-in.
- **Read action hooks stay fire-and-forget** — the opt-in is for mutations only, so read latency is unchanged.
- `bypassEmitAction` gains an async signature. Handler errors are still caught and logged — **not** propagated — so the only semantic change (under the opt-in) is timing, not error behaviour.

## Retrocompat

- `awaitActionHooks` defaults off; every existing mutation keeps fire-and-forget action hooks. No caller sees a timing change unless it opts in.

## Out of scope

- Making the await the _default_ (the original fork commit did this unconditionally) — deliberately gated behind the option so the blast radius is opt-in.
- Other services that emit actions (collections, relations, etc.) still fire-and-forget — kept to the items layer.

## Questions

- Is `awaitActionHooks` on `MutationOptions` the right surface, or would you prefer it per-event / an env default?
- Should a cancelled/awaited mutation still parallelise across the scoped event variants as it does here, or is per-event ordering ever expected?
