### PR TITLE
upstream-draft: fix(items): malformed primary key → InvalidPayloadError (400) not Forbidden (403)

### DIFF
--- a/.changeset/invalid-payload-on-bad-key.md
+++ b/.changeset/invalid-payload-on-bad-key.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+A malformed primary key on a by-key item operation — a non-uuid value for a `uuid` primary key, or a non-integer for an `integer` primary key — now raises `InvalidPayloadError` (400) instead of `ForbiddenError` (403). The key shape is validated before any access check, so a malformed key is a bad request, not an authorization failure.

--- a/api/src/utils/validate-keys.test.ts
+++ b/api/src/utils/validate-keys.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { InvalidPayloadError } from '@directus/errors';
 import { SchemaBuilder } from '@directus/schema-builder';
 import { describe, expect, it } from 'vitest';
 import { validateKeys } from './validate-keys.js';
@@ -15,13 +16,13 @@ const schema = new SchemaBuilder()
 describe('validate keys', () => {
 	describe('of integer type', () => {
 		it('Throws an error when provided with an invalid integer key', () => {
-			expect(() => validateKeys(schema, 'pk_integer', 'id', 'invalid')).toThrowError();
-			expect(() => validateKeys(schema, 'pk_integer', 'id', NaN)).toThrowError();
+			expect(() => validateKeys(schema, 'pk_integer', 'id', 'invalid')).toThrowError(InvalidPayloadError);
+			expect(() => validateKeys(schema, 'pk_integer', 'id', NaN)).toThrowError(InvalidPayloadError);
 		});
 
 		it('Throws an error when provided with an array containing an invalid integer key', () => {
-			expect(() => validateKeys(schema, 'pk_integer', 'id', [111, 'invalid', 222])).toThrowError();
-			expect(() => validateKeys(schema, 'pk_integer', 'id', [555, NaN, 666])).toThrowError();
+			expect(() => validateKeys(schema, 'pk_integer', 'id', [111, 'invalid', 222])).toThrowError(InvalidPayloadError);
+			expect(() => validateKeys(schema, 'pk_integer', 'id', [555, NaN, 666])).toThrowError(InvalidPayloadError);
 		});
 
 		it('Does not throw an error when provided with a valid integer key', () => {
@@ -37,20 +38,31 @@ describe('validate keys', () => {
 
 	describe('of uuid type', () => {
 		it('Throws an error when provided with an invalid uuid key', () => {
-			expect(() => validateKeys(schema, 'pk_uuid', 'id', 'fakeuuid-62d9-434d-a7c7-878c8376782e')).toThrowError();
-			expect(() => validateKeys(schema, 'pk_uuid', 'id', 'invalid')).toThrowError();
-			expect(() => validateKeys(schema, 'pk_uuid', 'id', NaN)).toThrowError();
-			expect(() => validateKeys(schema, 'pk_uuid', 'id', 111)).toThrowError();
+			expect(() => validateKeys(schema, 'pk_uuid', 'id', 'fakeuuid-62d9-434d-a7c7-878c8376782e')).toThrowError(
+				InvalidPayloadError,
+			);
+
+			expect(() => validateKeys(schema, 'pk_uuid', 'id', 'invalid')).toThrowError(InvalidPayloadError);
+			expect(() => validateKeys(schema, 'pk_uuid', 'id', NaN)).toThrowError(InvalidPayloadError);
+			expect(() => validateKeys(schema, 'pk_uuid', 'id', 111)).toThrowError(InvalidPayloadError);
 		});
 
 		it('Throws an error when provided with an array containing an invalid uuid key', () => {
 			expect(() =>
 				validateKeys(schema, 'pk_uuid', 'id', [randomUUID(), 'fakeuuid-62d9-434d-a7c7-878c8376782e', randomUUID()]),
-			).toThrowError();
+			).toThrowError(InvalidPayloadError);
 
-			expect(() => validateKeys(schema, 'pk_uuid', 'id', [randomUUID(), 'invalid', randomUUID()])).toThrowError();
-			expect(() => validateKeys(schema, 'pk_uuid', 'id', [randomUUID(), NaN, randomUUID()])).toThrowError();
-			expect(() => validateKeys(schema, 'pk_uuid', 'id', [randomUUID(), 111, randomUUID()])).toThrowError();
+			expect(() => validateKeys(schema, 'pk_uuid', 'id', [randomUUID(), 'invalid', randomUUID()])).toThrowError(
+				InvalidPayloadError,
+			);
+
+			expect(() => validateKeys(schema, 'pk_uuid', 'id', [randomUUID(), NaN, randomUUID()])).toThrowError(
+				InvalidPayloadError,
+			);
+
+			expect(() => validateKeys(schema, 'pk_uuid', 'id', [randomUUID(), 111, randomUUID()])).toThrowError(
+				InvalidPayloadError,
+			);
 		});
 
 		it('Does not throw an error when provided with a valid uuid key', () => {

--- a/api/src/utils/validate-keys.ts
+++ b/api/src/utils/validate-keys.ts
@@ -1,4 +1,4 @@
-import { ForbiddenError } from '@directus/errors';
+import { InvalidPayloadError } from '@directus/errors';
 import type { PrimaryKey, SchemaOverview } from '@directus/types';
 import { isValidUuid } from './is-valid-uuid.js';
 
@@ -19,12 +19,11 @@ export function validateKeys(
 		const primaryKeyFieldType = schema.collections[collection]?.fields[keyField]?.type;
 
 		if (primaryKeyFieldType === 'uuid' && !isValidUuid(String(keys))) {
-			throw new ForbiddenError({
+			throw new InvalidPayloadError({
 				reason: `Primary key of ${collection} must be a uuid instead of ${JSON.stringify(keys, null, 2)}`,
 			});
 		} else if (primaryKeyFieldType === 'integer' && !Number.isInteger(Number(keys))) {
-			// Should this be a forbidden error? InvalidPayload?
-			throw new ForbiddenError({
+			throw new InvalidPayloadError({
 				reason: `Primary key of ${collection} must be an integer instead of ${JSON.stringify(keys, null, 2)}`,
 			});
 		}


### PR DESCRIPTION
## Why

`validateKeys` rejects a malformed primary key — a non-uuid value for a `uuid` PK, or a non-integer for an `integer` PK — by throwing `ForbiddenError` (403). But it runs **before any access or permission check** (it's the first thing each by-key item op does), so a malformed key is a **bad request**, not an authorization failure. The fork even flagged it inline: `// Should this be a forbidden error? InvalidPayload?`.

A 403 here is also misleading for clients: nothing was looked up, so there's no existence to protect (the anti-enumeration rationale that justifies 403-for-missing-item doesn't apply pre-lookup).

## What

- `api/src/utils/validate-keys.ts` — the two throws switch from `ForbiddenError` (403) to `InvalidPayloadError` (400). Reason text unchanged.
- Unit test strengthened to assert `InvalidPayloadError` specifically (it previously only asserted "throws").

## Impact

- 8 call sites, all `ItemsService` (by-key read/update/delete). A malformed key now returns **400** instead of **403**.
- This is a deliberate status-contract change — kept **separate** from the `ForbiddenError`-reasons work so it can be reviewed (and accepted/rejected) on its own.

## Stacked on

`upstream-draft: feat(errors): give reasons to ForbiddenErrors` — that PR added the reason strings to these throws; this one flips the error type on top, so the diff here is just the `ForbiddenError → InvalidPayloadError` swap. Rebases to `main` when the base merges.

## Questions

- Comfortable with the 403→400 change for malformed keys, or do you prefer to keep 403 for consistency with the missing-item case?
