### PR TITLE
upstream-diff: compose-hhh-main excludes experiments/superseded PRs

### DIFF
--- a/.github/workflows/compose-hhh-main.yml
+++ b/.github/workflows/compose-hhh-main.yml
@@ -73,10 +73,14 @@ jobs:
         run: |
           # Only integrate PRs titled `upstream-draft: …` — work staged for an
           # upstream proposal that we soak-test in hhh-main first. Other PRs into
-          # main are left out.
+          # main are left out. `experiments` (held WIP) and `superseded`
+          # (replaced) labels exclude an otherwise-matching PR.
           gh pr list --repo "$GITHUB_REPOSITORY" --base main --state open \
-            --json number,headRefName,isDraft,title \
-            --jq '[.[] | select(.isDraft | not) | select(.title | startswith("upstream-draft: "))]' \
+            --json number,headRefName,isDraft,title,labels \
+            --jq '[.[]
+              | select(.isDraft | not)
+              | select(.title | startswith("upstream-draft: "))
+              | select(any(.labels[].name; . == "experiments" or . == "superseded") | not)]' \
             > prs.json
           echo "Discovered PRs:"; jq -r '.[] | "  #\(.number) \(.title)"' prs.json
           echo "count=$(jq length prs.json)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Narrow the `hhh-main` integration to PRs we actually want soaking: discovery now skips open `upstream-draft:` PRs labelled **`experiments`** (held WIP) or **`superseded`** (replaced).

Single-file change to `compose-hhh-main.yml` discovery jq.

## Scope note

This is now **compose-only**. The dist machinery (`release-fork.yml`, the `hhh-main-dist` dispatch, `.gitattributes` export-ignore) was pulled out — `hhh-main` (v12) isn't deployed (Hippocast runs the license-free v11 line), so it needs no `-dist`. Dist lands with the v11 deployment phase.

## Heads-up

- The `compose` check on this PR runs the **base** copy of the workflow — the jq change only really exercises post-merge. `Changeset Check` red is a false-gate (CI-infra change, no package touched).