### PR TITLE
upstream-diff: track fork agent context (.agents/)

### DIFF
--- a/.agents/auto-memory/MEMORY.md
+++ b/.agents/auto-memory/MEMORY.md
@@ -10,6 +10,9 @@
 - [Directus v12 license → dual-target compose](project_directus_v12_license_dual_compose.md) — v12+ needs a license key;
   v11.9.2 = last license-free release Hippocast runs; fork keeps last-v11 + main lines; compose infra (#64/#65) targets
   main only for now, last-v11 is a deferred phase; `upstream-diff:` = fork-permanent, lands on main, never upstream
+- [Compose stack order rubric](project_directus_compose_stack_order_rubric.md) — hhh-main rebased-copy tree: roots =
+  only isolated PRs; order root→leaf bugfix → perf → light contract consistency (payload/reasons) → contract changes
+  (light→heavy) → refused-upstream; deps override rank only when a branch carries another's code
 - [knex >=3.2 breaks Directus deep sort](project_directus_knex_deepsort_regression.md) — knex 3.2.10 #6392 wraps window
   aliases; Directus pre-wraps directus_row_number → double-escape → 500 on every o2m/m2m/m2a sort; pin knex 3.1.0
 - [Codecov per-package flags; blackbox not in api unit flag](project_directus_codecov_flags.md) — codecov/patch/<pkg>

--- a/.agents/auto-memory/MEMORY.md
+++ b/.agents/auto-memory/MEMORY.md
@@ -7,6 +7,9 @@
 - [Fork integration branches (main overlay + hhh-main)](project_directus_fork_integration_branches.md) — main =
   upstream + compose-hhh-main.yml overlay; hhh-main auto-composed from open PRs; blackbox/e2e label-gated;
   blackbox-pr.yml is name:Check; CI gates = build+eslint+stylelint (no tsc); mssql dropped (fork-runner saturation)
+- [Directus v12 license → dual-target compose](project_directus_v12_license_dual_compose.md) — v12+ needs a license key;
+  v11.9.2 = last license-free release Hippocast runs; fork keeps last-v11 + main lines; compose infra (#64/#65) targets
+  main only for now, last-v11 is a deferred phase; `upstream-diff:` = fork-permanent, lands on main, never upstream
 - [knex >=3.2 breaks Directus deep sort](project_directus_knex_deepsort_regression.md) — knex 3.2.10 #6392 wraps window
   aliases; Directus pre-wraps directus_row_number → double-escape → 500 on every o2m/m2m/m2a sort; pin knex 3.1.0
 - [Codecov per-package flags; blackbox not in api unit flag](project_directus_codecov_flags.md) — codecov/patch/<pkg>

--- a/.agents/auto-memory/MEMORY.md
+++ b/.agents/auto-memory/MEMORY.md
@@ -4,9 +4,17 @@
   `git commit --amend` + `git push --force-with-lease` over layered fix-up commits
 - [Don't ask before pnpm install / build in this repo](feedback_no_ask_for_build_install.md) — project override of the
   global ask-before-install rule; routine install/build steps run silently, dep-modifying commands still ask
-- [Fork integration branches (main overlay + hhh-main)](project_directus_fork_integration_branches.md) — main =
-  upstream + compose-hhh-main.yml overlay; hhh-main auto-composed from open PRs; blackbox/e2e label-gated;
-  blackbox-pr.yml is name:Check; CI gates = build+eslint+stylelint (no tsc); mssql dropped (fork-runner saturation)
+- [Fork integration branches (pr-controle topology)](project_directus_fork_integration_branches.md) — pr-controle =
+  default/trunk (all fork CI); main = clean upstream base; hhh-main = derived from the copy stack; supersedes old
+  main-overlay model; blackbox/e2e label-gated; blackbox-pr.yml is name:Check; CI gates = build+eslint+stylelint (no
+  tsc)
+- [Compose copy-stack architecture](project_directus_compose_copy_stack.md) — upstream-draft PRs isolated for upstream;
+  parallel hhh-main-root/stacked copies resolve overlaps once; compose consumes the copies; SSH deploy key for
+  workflow-file pushes; cla-bot reads contributors.yml from head ref → inject hhh-bot
+- [Stacked copy rebuild gotchas](project_directus_stacked_rebuild_gotchas.md) — cherry-pick branches independent (fix
+  low → rebuild above); divergent stacked history ≠ rebase (#52); merge-tree forced-base lies when behind main;
+  test-file two-block merge must close the first block; semantic interactions (#50 vs #58) only surface in the full api
+  test
 - [Directus v12 license → dual-target compose](project_directus_v12_license_dual_compose.md) — v12+ needs a license key;
   v11.9.2 = last license-free release Hippocast runs; fork keeps last-v11 + main lines; compose infra (#64/#65) targets
   main only for now, last-v11 is a deferred phase; `upstream-diff:` = fork-permanent, lands on main, never upstream

--- a/.agents/auto-memory/MEMORY.md
+++ b/.agents/auto-memory/MEMORY.md
@@ -1,0 +1,20 @@
+- [Directus DB clients & batch-insert RETURNING support](project_directus_db_clients.md) — canonical list in
+  `api/src/types/database.ts`; MariaDB rides under `mysql`; mysql/mariadb/sqlite hit the fallback loop
+- [Amending the prior commit is OK on this feature branch](feedback_amend_ok.md) — for upstream-bound PR work, prefer
+  `git commit --amend` + `git push --force-with-lease` over layered fix-up commits
+- [Don't ask before pnpm install / build in this repo](feedback_no_ask_for_build_install.md) — project override of the
+  global ask-before-install rule; routine install/build steps run silently, dep-modifying commands still ask
+- [Fork integration branches (main overlay + hhh-main)](project_directus_fork_integration_branches.md) — main =
+  upstream + compose-hhh-main.yml overlay; hhh-main auto-composed from open PRs; blackbox/e2e label-gated;
+  blackbox-pr.yml is name:Check; CI gates = build+eslint+stylelint (no tsc); mssql dropped (fork-runner saturation)
+- [knex >=3.2 breaks Directus deep sort](project_directus_knex_deepsort_regression.md) — knex 3.2.10 #6392 wraps window
+  aliases; Directus pre-wraps directus_row_number → double-escape → 500 on every o2m/m2m/m2a sort; pin knex 3.1.0
+- [Codecov per-package flags; blackbox not in api unit flag](project_directus_codecov_flags.md) — codecov/patch/<pkg>
+  target=auto≈project; blackbox-only api code fails patch/api → needs knex-mock-client unit tests; constants barrel line
+  needs import-through-index
+- [Directus ForbiddenError conventions](project_directus_forbidden_error_conventions.md) — 403 for missing items
+  (anti-enumeration), pre-access validation → 400, ForbiddenError({reason}) is upstream + always-visible, status never
+  env-gated; PRs #61/#62
+- [api vitest typecheck blocked by pre-existing debt](reference_api_typecheck_blocked.md) — \*.test-d.ts never run;
+  enabling typecheck surfaces ~203 src type errors (and emitter graph pulls in untyped pino-http-print) → needs a
+  dedicated cleanup PR

--- a/.agents/auto-memory/feedback_amend_ok.md
+++ b/.agents/auto-memory/feedback_amend_ok.md
@@ -1,0 +1,22 @@
+---
+name: feedback-amend-ok-in-directus-pr-flow
+description:
+  Amending the prior commit is acceptable in this Directus PR-flow context without asking; force-with-lease push
+  afterwards is fine.
+metadata:
+  type: feedback
+---
+
+When iterating on a not-yet-merged feature branch in this repo, amending the previous commit (instead of layering a
+follow-up commit) is fine — don't ask first, don't apologize after. Force-with-lease push is the expected follow-up.
+
+**Why:** Reviewers on the upstream-bound PRs care about a tight, scoped diff per logical change; layered "fix-up"
+commits add noise. The user explicitly OK'd amending after I flagged it.
+
+**How to apply:**
+
+- Default to `git commit --amend --no-edit` (or `--amend` with an updated message when scope shifts) when extending the
+  most recent commit's scope.
+- Follow up with `git push --force-with-lease` — never plain `--force`.
+- This override is scoped to this project's feature branches (the upstream-bound PR work). On `main`/published shared
+  branches, fall back to the global default of creating new commits.

--- a/.agents/auto-memory/feedback_no_ask_for_build_install.md
+++ b/.agents/auto-memory/feedback_no_ask_for_build_install.md
@@ -1,0 +1,27 @@
+---
+name: feedback-no-ask-for-build-install-in-pr-flow
+description:
+  In the Directus PR-flow context on this fork, do NOT ask before running pnpm install / pnpm build / workspace builds.
+  The global ask-before-install rule is overridden here.
+metadata:
+  type: feedback
+---
+
+For this repo's upstream-bound PR work, `pnpm install`, `pnpm --filter <pkg> build`, and `pnpm -r build` should be run
+without first asking. The friction of asking every time outweighs the safety win when the build/install steps are
+routine prerequisites to running tests.
+
+**Why:** User feedback explicit in this session: _"do not ask for building any package nor calling pnpm install"_. The
+global default ([[feedback-ask-before-build-install]]) still applies in other contexts; this is a project-scoped
+override.
+
+**How to apply:**
+
+- `pnpm install` (after pulling, after adding/removing deps): run without asking.
+- `pnpm --filter <pkg> build` (for a single workspace package): run without asking.
+- `pnpm -r build` / `pnpm -r --filter '@directus/*' build` (workspace-wide): run without asking.
+- The exception: anything that _modifies_ dependencies (e.g. `pnpm add`, `pnpm update`, `pnpm remove`) still requires
+  explicit user confirmation. The override is for build/install steps that are reproducing a known state, not for
+  changing dependency versions.
+- Docker builds (`docker compose build`, `docker build`) still ask per the global rule — they're slower and
+  side-effecty.

--- a/.agents/auto-memory/project_directus_codecov_flags.md
+++ b/.agents/auto-memory/project_directus_codecov_flags.md
@@ -1,0 +1,25 @@
+---
+name: project_directus_codecov_flags
+description:
+  This fork's codecov runs per-package patch flags; blackbox coverage is NOT in the api unit flag, so blackbox-only code
+  fails codecov/patch/api
+metadata:
+  type: project
+---
+
+Codecov on jclaveau/directus PRs posts a `codecov/patch/<pkg>` + `codecov/project/<pkg>` per workspace package. Patch
+target = auto ≈ project% (~68%), not 100% (no `codecov.yml` in repo). `compose`/`compose-hhh-main` always fails
+(App-token lacks `workflows`) — ignore.
+
+- **Blackbox coverage is NOT uploaded to the `api` (unit) flag.** Code exercised only by `tests/blackbox` shows as
+  uncovered patch under `codecov/patch/api`. New api logic needs real **unit** tests (knex-mock-client) to clear patch.
+- Seen on #46 (batch-insert): the per-dialect `CapabilitiesHelper` overrides
+  (`api/src/database/helpers/capabilities/dialects/*`) and the `createMany` batchInsert/per-row dispatch were
+  blackbox-only → patch/api red. Fixed with `capabilities.test.ts` (all dialect methods) + `createMany` unit tests
+  (batch vs per-row vs empty).
+- #50 (skip-noop): a new `@directus/constants` barrel line `export * from './items.js'` was the uncovered patch line
+  until the test imported `ALTERATIONS_KEYS` _through_ `./index.js` instead of the leaf.
+
+**How to apply:** before pushing an api/constants PR here, run the changed package's coverage locally and intersect
+uncovered lines with the diff; expect blackbox-covered paths to still need unit tests. General mechanics in
+[[reference_codecov_patch_coverage]]. CI gate context in [[project_directus_fork_integration_branches]].

--- a/.agents/auto-memory/project_directus_compose_copy_stack.md
+++ b/.agents/auto-memory/project_directus_compose_copy_stack.md
@@ -1,0 +1,41 @@
+---
+name: directus-compose-copy-stack
+description:
+  How hhh-main is composed conflict-free — isolated upstream-draft PRs stay clean for upstream; a parallel
+  hhh-main-root/stacked copy tree resolves overlaps once; compose consumes the copies. SSH deploy key + CLA inject.
+metadata:
+  type: project
+---
+
+The open `upstream-draft:` PRs collide when composed (several edit `api/src/services/items.ts`/`items.test.ts`).
+Resolution (2026-06-16, jclaveau/directus): keep upstream-draft PRs **isolated off `main`** for upstream submission, and
+maintain a parallel **copy tree** that compose consumes.
+
+## The copy tree
+
+- **`hhh-main-root:` <title>** — isolated PR (no file overlap with any other), base `main`, unchanged content.
+- **`hhh-main-stacked:` <title>** — rebased onto its **parent copy** (not the upstream-draft branch → decoupled from
+  upstream churn). Every member of a conflict-connected component is stacked; only truly-isolated PRs are roots.
+- Built by **cherry-picking each PR's own commit range** onto the advancing tip (NOT merging heads — a stacked
+  upstream-draft head contains its parent, which would double-apply). Order = the mergeability rubric
+  [[directus-compose-stack-order-rubric]].
+- Always open. Each PR description records: copy-of #, parent, exact resolution, and a **re-rebase recipe** so a refresh
+  after a `main` sync is mechanical.
+
+## Compose consumes the copies
+
+`compose-hhh-main.yml` discovers `hhh-main-root:`/`hhh-main-stacked:` titles (not `upstream-draft:`), topo-merges them
+(clean by construction), CLA-signs, builds, api-tests, force-pushes hhh-main. A merge conflict now means the **stack is
+stale vs main → re-rebase** (not raw inter-PR conflict). Verified green end-to-end.
+
+## Two infra mechanics that are load-bearing
+
+- **SSH deploy key, not GITHUB_TOKEN, for pushes** — App tokens are forbidden from pushing `.github/workflows/*` changes
+  (both the main sync and the hhh-main force-push carry them). Deploy key `compose-bot` (write) + secret
+  `COMPOSE_SSH_KEY`; checkout `with: ssh-key: ${{ secrets.COMPOSE_SSH_KEY }}`. Repo-scoped, non-expiring.
+- **CLA auto-sign** — compose's merge commits are authored by `hhh-bot`; directus/cla-bot reads `contributors.yml` from
+  the **head ref** (hhh-main), so compose appends `- hhh-bot` to contributors.yml on hhh-main before commit (kept off
+  `main`).
+
+Excluded from the stack: **#46** (refused upstream → `superseded`), **#52** (divergent history — see
+[[directus-stacked-rebuild-gotchas]]). #67 = the upstream-compare view of hhh-main.

--- a/.agents/auto-memory/project_directus_compose_stack_order_rubric.md
+++ b/.agents/auto-memory/project_directus_compose_stack_order_rubric.md
@@ -1,0 +1,33 @@
+---
+name: directus-compose-stack-order-rubric
+description:
+  How to order the upstream-draft PR copies in the hhh-main compose stack (root→leaf) and which PRs are tree roots — the
+  ranking rubric driving the rebased hhh-main-stacked tree and compose's auto-proposal.
+metadata:
+  type: project
+---
+
+For composing `hhh-main` the conflicting `upstream-draft:` PRs are reproduced as **rebased copies** (`hhh-main-root:`
+isolated / `hhh-main-stacked:` rebased onto its parent copy) so file overlaps resolve once.
+
+## Tree structure
+
+- **Roots = ONLY isolated PRs** — a PR with no file overlap with any other PR (its own size-1 component).
+- Every overlapping PR belongs to **one connected component** (bridges: a PR touching two clusters' files links them) →
+  a single stack/tree, all `hhh-main-stacked`, base rebased on `main`.
+
+## Order rubric (root = merge first → leaf = merge last)
+
+1. **bugfixes**
+2. **perf** (no contract change)
+3. **light contract consistency** (e.g. payload/error-type fix, error reasons)
+4. **contract changes**, ordered by impact (light → heavy)
+5. **refused upstream** (top)
+
+Dependencies override pure rank **only** when a PR's branch literally carries another's code (then the carried PR sits
+below). The rubric is also what compose's auto-proposal step should encode (it can't know "refused upstream", so that
+tier is human-maintained).
+
+Worked example (2026-06-16, PRs into the fork): roots `#55 #57`; component bottom→top `#54 #48 #60` (bugfix) → `#50`
+(perf) → `#62 #61` (payload, reasons) → `#59 #58 #51 #52` (contract light→heavy) → `#46` (refused). See
+[[directus-fork-integration-branches]] and [[directus-v12-license-dual-compose]].

--- a/.agents/auto-memory/project_directus_db_clients.md
+++ b/.agents/auto-memory/project_directus_db_clients.md
@@ -1,0 +1,32 @@
+---
+name: directus-db-clients-and-returning-support
+description: Canonical Directus DB client list lives in api/src/types/database.ts; which clients return all IDs after batch insert vs. only the last
+metadata:
+  type: project
+---
+
+The 7 Directus DB clients are defined in `api/src/types/database.ts:3`:
+
+```
+DatabaseClients = ['mysql', 'postgres', 'cockroachdb', 'sqlite', 'oracle', 'mssql', 'redshift']
+```
+
+MariaDB is **not** a distinct client — it rides under the `mysql` client (via the mysql2 driver).
+
+Batch-insert ID return behavior (relevant to `ItemsService.createMany` fallback at `api/src/services/items.ts:823` / `:862`):
+
+- **Return all inserted IDs** (`.returning(pk)` works end-to-end):
+  - postgres — native `INSERT ... RETURNING`
+  - cockroachdb — Postgres-compatible
+  - redshift — Postgres-derived, same RETURNING semantics
+  - mssql — `OUTPUT INSERTED.*`
+  - oracle — `RETURNING ... INTO`
+
+- **Return only the last inserted ID** — triggers the fallback loop that re-queries by PK desc:
+  - mysql — no RETURNING; knex returns `LAST_INSERT_ID()` (first row of batch)
+  - mariadb (under `mysql` client) — server supports `INSERT ... RETURNING` since 10.5, but knex's mysql2 driver path doesn't use it, so it behaves like MySQL
+  - sqlite — engine supports RETURNING since 3.35, but knex's batchInsert path only surfaces the last lastID
+
+**Why:** answering DB-capability questions about Directus by reciting generic SQL knowledge produced an imprecise answer (omitted Redshift, miscounted MariaDB as a separate client). Grounding on the source file gives the right list.
+
+**How to apply:** when asked which DBMSes Directus supports — or how a given DB capability behaves across them — open `api/src/types/database.ts` first, and remember that Knex's driver path is the gate, not just raw DB capability.

--- a/.agents/auto-memory/project_directus_forbidden_error_conventions.md
+++ b/.agents/auto-memory/project_directus_forbidden_error_conventions.md
@@ -1,0 +1,26 @@
+---
+name: project_directus_forbidden_error_conventions
+description:
+  Directus error conventions — 403 for missing items (anti-enumeration), pre-access input validation should be 400,
+  ForbiddenError({reason}) is upstream, status never env-gated
+metadata:
+  type: project
+---
+
+How Directus models permission/not-found errors (verified on `origin/main`):
+
+- **403 for a missing item, by design.** `ItemsService.readOne` (`api/src/services/items.ts`, the `results.length === 0`
+  guard) throws `ForbiddenError` whether the row is **absent** or **permission-filtered out** — indistinguishable. There
+  is **no `NotFoundError`/404 in the items path** (anti-enumeration). So a missing item = 403, not 404.
+- **`ForbiddenError({ reason })` is upstream** — `packages/errors/src/errors/forbidden.ts` `messageConstructor` surfaces
+  `reason` as the message, **always-visible in every env** (no env-gating). The permissions engine
+  (`permissions/modules/validate-access/`, `process-ast/.../create-error.ts`) already builds reasoned errors
+  (collection/field/action/path + "or it does not exist" hedge).
+- **`error-handler.ts`** takes status from the error **type** and adds dev-only detail (`extensions.stack` only when
+  `getNodeEnv()==='development'`). Status is **never** env-conditional — see [[feedback_api_status_code_is_contract]].
+- **Pre-access input validation → 400, not 403.** `validateKeys` runs before any lookup, so a malformed PK is a bad
+  request (`InvalidPayloadError`), not an authorization failure — no existence to protect. Done in PR #62.
+
+**This session's PRs:** #61 = the fork's full `ForbiddenError` reason sweep (~54 reasons / 16 files, his exact wording +
+`// 404 ?` / `// InvalidPayload ?` TODOs); #62 = validate-keys `403→400`. #61 carries a comment inventorying 47
+still-bare `ForbiddenError()` sites. Extraction policy: [[feedback_extract_keep_all_but_upstream_equiv]].

--- a/.agents/auto-memory/project_directus_fork_integration_branches.md
+++ b/.agents/auto-memory/project_directus_fork_integration_branches.md
@@ -1,0 +1,91 @@
+---
+name: directus-fork-integration-branches
+description:
+  jclaveau/directus branch model — main = upstream + thin overlay, hhh-main = derived integration branch auto-composed
+  from open PRs by compose-hhh-main.yml; plus blackbox/e2e label-gating + mssql fork-runner saturation
+metadata:
+  type: project
+---
+
+The fork `jclaveau/directus` runs a soft-fork integration setup (built 2026-06-10).
+
+## Branch model
+
+```
+main      = upstream directus/directus + ONE overlay: .github/workflows/compose-hhh-main.yml
+            (+ a temp blackbox.yml mssql-matrix edit). default branch. sync = `git merge upstream/main`.
+feature/* = individual proposals PR'd INTO main, titled `upstream-draft: …` (e.g. #46 batch insert, #48 #35 drop-index-if-exists).
+hhh-main  = DERIVED = main + merge(open non-draft PRs into main TITLED `upstream-draft: `). force-pushed each run. never commit to it.
+```
+
+`hhh-main` = "main as it would be if our PRs were accepted." Never authored — `compose-hhh-main.yml` rebuilds it.
+
+## Patching the overlay workflows — commit straight to main
+
+The fork-internal overlay files (`compose-hhh-main.yml`, the temp `blackbox.yml` matrix edit) are **ours**, not upstream
+proposals. Fix them with a **direct commit to `main`** — do NOT branch + PR. User: _"you don't need PR to patch your wf
+in main, commit directly."_
+
+- A PR for the overlay is pure overhead: it can't even self-validate — `compose-hhh-main.yml` is a direct `pull_request`
+  workflow, so a PR runs the **base** (old) copy, never the patched one (see [[gha-pull-request-workflow-resolution]]).
+  The fix only proves out post-merge regardless.
+- This is the carve-out to [[feedback_branch_large_ci_refactors]]: branch+PR is for upstream-bound `feature/*` and big
+  matrix re-architectures; a focused fix to the fork's own overlay is direct-to-main.
+- Push over SSH (`git@github.com:…`) so the workflow-file change needs no `workflow` token scope.
+
+## Divergences from upstream on main (keep-ours on sync)
+
+`main` is meant to be upstream + the ONE overlay (`compose-hhh-main.yml`). A small number of **edits to upstream-owned
+files** also live on main and must be **kept on every `git merge upstream/main`** — never "reconciled" back to the
+upstream form:
+
+- **`.github/workflows/check.yml` — Codecov auth** (commit `3f6f600683`, 2026-06-11). Added `if: always()` +
+  `env: CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}` to the "Upload coverage to Codecov" step. **Why the fork needs
+  it:** tokenless Codecov upload only works for the canonical `directus/directus` slug; the fork uploads under
+  `jclaveau/directus` (a separate Codecov project) so it needs an explicit token — which Codecov's own "Using GitHub
+  Actions" setup wizard issued and told us to add. Kept the per-folder-flag CLI loop (NOT `codecov-action@v5`, which
+  does a single upload and would regress the `codecov.yaml` flag carryforward). `CODECOV_TOKEN` secret set on the repo
+  2026-06-11. **On sync:** if upstream rewrites that step, resolve the one conflict hunk **keep-ours** (don't drop the
+  token/`if: always()`). Low odds — it's 3 isolated lines in a stable step. Same workflow-file class as
+  [[feedback_gh_pr_merge_workflow_scope]]; push over SSH.
+
+## compose-hhh-main.yml
+
+Triggers: `pull_request` (base main) + `workflow_dispatch` + daily cron. Steps: merge upstream→main + push → discover
+open non-draft PRs into main whose title starts with `upstream-draft: ` (`gh pr list ... select(.title|startswith)`) →
+`checkout -B hhh-main main` + merge each via `refs/pull/N/head` (skip-on-conflict, report skipped in a tracking issue) →
+`prepare` (full build) → `pnpm --filter @directus/api test` → force-push hhh-main only if green.
+
+**Why overlay-on-main, not byte-pure main:** byte-pure main forces the default branch off main (schedule fires only from
+default's workflow copy) AND kills the `pull_request` instant-trigger. One overlay file avoids all of it; the overlay
+doesn't pollute feature-PR diffs (already in base). See [[gha-pull-request-workflow-resolution]].
+
+**Recurring sync-step failure — upstream workflow-file changes:** the in-workflow
+`git merge upstream/main + git push origin main` step pushes over **HTTPS with the default `GITHUB_TOKEN`**, which has
+no `workflow` scope. Whenever upstream's merge touches a `.github/workflows/*` file (e.g. `prepare-release.yml`), the
+push is rejected:
+`! [remote rejected] main -> main (refusing to allow a GitHub App to create or update workflow ... without workflows permission)`
+→ compose run fails. This is **integration-overlay infra, NOT any feature PR's gate** — a red `compose` check on a
+feature PR with this signature is not that PR's fault. Fix options (not yet applied): add `permissions: contents: write`
+won't help (GitHub Apps can't push workflow files at all); use a PAT/deploy-key with `workflow` scope for the sync push,
+or `actions/checkout` over SSH like the overlay edits do (line above). Same root mechanism as
+[[feedback_gh_pr_merge_workflow_scope]] (workflow-file push needs workflow scope), here in the auto-sync push.
+
+## Fork CI quirks
+
+- **blackbox + e2e are label-gated**: `blackbox-pr.yml` runs Blackbox only with the `Run Blackbox` label, E2E only with
+  `Run E2E`, on `synchronize`/`labeled`. A PR runs NEITHER by default — only Check/Changeset/CLA/agent-scan. Add the
+  label via REST (`gh api -X POST .../issues/<N>/labels`), not `gh pr edit` ([[gh-issue-view-quirk]]).
+- **`blackbox-pr.yml` is `name: Check`** — so in `gh run list` the Blackbox run shows as **"Check"**, not "Blackbox". A
+  push spawns TWO "Check" runs: the real one (Lint/Unit/Format/Stylelint jobs) AND this one (`Blackbox Tests / <db>`
+  jobs, via `uses: ./.github/workflows/blackbox.yml`). Identify by listing each run's jobs, not by name.
+- **CI gates = build + eslint + stylelint only** (`build` recursive = tsdown/esbuild, no full typecheck; `lint`=eslint;
+  `lint:style`=stylelint). There is **no `tsc`/`tsgo` gate** — running `tsgo --noEmit` floods pre-existing baseline
+  errors (schemas.ts, snapshots.ts, ai/chat, even untouched dialect files) the repo doesn't enforce. Don't chase tsgo
+  noise; verify a change with build + eslint + the targeted vitest run.
+- **mssql shard melts down on the fork runner**: the full parallel `db` suite saturates the mssql/tedious container —
+  100+ tests time out at 15s en masse (json-filter 103, no-relation 35, batch-insert collateral) and the shard cancels.
+  Dropped mssql from `blackbox.yml`'s matrix. **pg + sqlite are the healthy batch-insert signal** (both green, ~1s;
+  mssql inconclusive, not a logic bug).
+
+Related: [[directus-db-clients-and-returning-support]].

--- a/.agents/auto-memory/project_directus_fork_integration_branches.md
+++ b/.agents/auto-memory/project_directus_fork_integration_branches.md
@@ -1,15 +1,35 @@
 ---
 name: directus-fork-integration-branches
 description:
-  jclaveau/directus branch model — main = upstream + thin overlay, hhh-main = derived integration branch auto-composed
-  from open PRs by compose-hhh-main.yml; plus blackbox/e2e label-gating + mssql fork-runner saturation
+  jclaveau/directus branch model — pr-controle = default/trunk (fork CI), main = clean upstream base, hhh-main = derived
+  integration auto-composed from the hhh-main-* copy stack; plus blackbox/e2e label-gating + mssql fork-runner
+  saturation
 metadata:
   type: project
 ---
 
 The fork `jclaveau/directus` runs a soft-fork integration setup (built 2026-06-10).
 
-## Branch model
+## CURRENT topology (2026-06-16) — supersedes the "Branch model" block below
+
+The original "main = upstream + overlay" model was replaced by a **dedicated default branch** once the overlay outgrew
+one file (denylist, release-fork, .gitattributes, codecov, copy-stack hack). See [[directus-compose-copy-stack]] for the
+full compose architecture.
+
+```
+pr-controle = DEFAULT branch / fork trunk: upstream content + ALL fork CI
+              (compose-hhh-main.yml, release-fork.yml, .gitattributes, codecov token, denylist).
+              schedule/dispatch fire from here. Patch fork CI by DIRECT COMMIT to pr-controle (SSH push).
+main        = clean upstream mirror — base for `upstream-draft:` PRs (clean diffs). (purification still in progress)
+hhh-main    = DERIVED, force-pushed: composed from the hhh-main-root:/hhh-main-stacked: copy PRs. never authored.
+```
+
+Trade-off accepted vs the old single-overlay model: lose the `pull_request` instant compose-trigger (rely on schedule +
+dispatch), PRs default-base to pr-controle (retarget upstream-draft to main), one GitHub default flip. Win: clean
+upstream PR bases, no keep-ours overlay-conflict dance, fork CI has an honest home. `upstream-diff:` = fork-permanent
+change that lands on the trunk, never headed upstream (vs `upstream-draft:`).
+
+## Branch model (HISTORICAL — superseded by the topology above)
 
 ```
 main      = upstream directus/directus + ONE overlay: .github/workflows/compose-hhh-main.yml

--- a/.agents/auto-memory/project_directus_knex_deepsort_regression.md
+++ b/.agents/auto-memory/project_directus_knex_deepsort_regression.md
@@ -1,0 +1,33 @@
+---
+name: directus-knex-deepsort-regression
+description:
+  Directus is incompatible with knex >= 3.2.10 (PR #6392) — it double-escapes the rowNumber window alias
+  and 500s every deep o2m/m2m/m2a sort on all dialects; the fork pins knex 3.1.0
+metadata:
+  type: project
+---
+
+Bumping knex past 3.1.0 in this Directus fork breaks **deep relational sort**.
+
+**Why:** knex 3.2.10 (PR [#6392](https://github.com/knex/knex/pull/6392), "Properly Escape Aliases in Analytic
+Functions") now wraps window-function aliases via `formatter.wrap`. Directus pre-wraps its `directus_row_number` alias
+with `knex.ref('directus_row_number').toQuery()` in `api/src/database/run-ast/lib/get-db-query.ts:205` (the
+`hasMultiRelationalSort` path). So 3.2.x double-escapes it → `... as ""directus_row_number""` → invalid SQL → **HTTP 500
+on every nested o2m/m2m/m2a sort, all dialects**.
+
+- Symptom in blackbox: `m2m/o2m/m2a.test.ts` `AssertionError: expected 500 to deeply equal 200`, only in the sort
+  describe-blocks ("without limit", "sort depth limit"). Simple sorts/CRUD pass.
+- Caught it during PR #48 (#35 drop-index): the PR had bumped knex 3.1.0→3.2.10 for native `table.dropUniqueIfExists`.
+  Reverted the bump and hand-rolled the conditional drop instead.
+
+**How to apply:**
+
+- Keep `knex: 3.1.0` in `pnpm-workspace.yaml`. Do NOT bump to 3.2.x without first patching `get-db-query.ts:205` to pass
+  the bare `'directus_row_number'` (valid unquoted on old knex, wrapped on new).
+- That alias double-escape is a **latent upstream Directus bug** — worth filing/PR'ing upstream independently (option D,
+  not yet done).
+- For the #35 conditional drops without native knex: base `dropUniqueIfExists` = raw
+  `ALTER TABLE ?? DROP CONSTRAINT IF EXISTS ??` (pg/cockroach/mssql 2016+), sqlite overrides with `DROP INDEX IF EXISTS`
+  (uniques are indexes), mysql/oracle keep catalog checks.
+
+Related: [[directus-fork-integration-branches]], [[directus-db-clients-and-returning-support]], [[knex-drop-if-exists]].

--- a/.agents/auto-memory/project_directus_stacked_rebuild_gotchas.md
+++ b/.agents/auto-memory/project_directus_stacked_rebuild_gotchas.md
@@ -1,0 +1,33 @@
+---
+name: directus-stacked-rebuild-gotchas
+description:
+  Gotchas building the hhh-main copy stack via cherry-pick — branches are independent (fix low → rebuild above),
+  divergent stacked history isn't a mechanical rebase, merge-tree forced-base lies, and the test-file two-block merge.
+metadata:
+  type: project
+---
+
+Hard-won while building the conflict-resolved copy stack ([[directus-compose-copy-stack]]).
+
+- **Cherry-pick branches are independent — they do NOT inherit a parent's fix.** Each `hhh-main-stacked-*` is its own
+  commits; fixing a low PR (e.g. #48's dialect-test merge) does NOT propagate to the branches above it. A fix near the
+  bottom forces **re-rolling the whole chain above** (re-cherry-pick + re-resolve). Sequence fixes before building up.
+
+- **Divergent stacked history = reconciliation, not rebase.** #52 (cancel-mutations) is "based on" #51 in the PR, but
+  its branch carries its OWN takeover commit (different SHA than #51's). `git cherry-pick base..head` re-applies a
+  duplicate → conflicts on items.ts. Such a PR can't be mechanically stacked; it needs real reconciliation. Detect: the
+  same commit subject appears with two SHAs across the two branches.
+
+- **`git merge-tree --merge-base=origin/main` LIES when branches are behind main.** Forcing the merge-base invents false
+  "revert" conflicts (e.g. on `compose-hhh-main.yml`/`contributors.yml`) because the stale branch "lacks" newer main
+  commits. Trust the **real `git merge`** result + **three-dot diffs** (`origin/main...pr`) for true overlap.
+
+- **Test-file two-block merge pattern.** When a conflict is two sibling `describe`/`it` blocks (both PRs append at the
+  same spot), keep BOTH — but the first block's closing `});` was usually in the conflict-excluded region, so naive
+  marker-stripping leaves it unclosed → `Unexpected end of file`. Resolution:
+  `HEAD-body + "\n});" (close the first) + theirs-body`; the common closing after the conflict closes the last block.
+  Same for `it(...)` and SchemaBuilder fixtures (merge fields, don't pick one side).
+
+- **Semantic (non-textual) interactions surface only in tests.** #50 (skip no-op empty updates) silently broke #58's
+  await-update test which used an empty `{}` payload → now a no-op skip → action never fires. Git merged clean; only the
+  api test caught it. Run the full api test on the assembled hhh-main, not just per-file.

--- a/.agents/auto-memory/project_directus_v12_license_dual_compose.md
+++ b/.agents/auto-memory/project_directus_v12_license_dual_compose.md
@@ -1,0 +1,26 @@
+---
+name: directus-v12-license-dual-compose
+description:
+  Directus v12+ requires a license key (relicensing); v11.9.2 = last license-free release Hippocast runs, so the fork
+  keeps two live integration lines and compose must eventually target both. Current infra targets main only.
+metadata:
+  type: project
+---
+
+Directus **relicensed at v12** — v12+ requires a **license key** to run. `v11.9.2` is the **last license-free release**,
+which is what Hippocast deploys.
+
+**Consequence for the fork model:** two integration lines must stay alive in parallel:
+
+- **last-v11 line** (`v11.9.2-hhh-dev` + `-dist`) — the license-free **deployment** line Hippocast actually runs.
+- **`main` line** (v12, upstream-tracking) — where the `upstream-draft:` proposals soak (see
+  [[directus-fork-integration-branches]]).
+
+**Compose roadmap = dual-target.** The compose / `upstream-diff:` infra (PRs #64 = compose-hhh-main denylist +
+release-fork dispatch + `.gitattributes`; #65 = `.agents/` tracking; both opened 2026-06-16) currently targets **`main`
+only**. Applying the same compose to the **last-v11 line** is a **deferred later phase** — explicitly out of scope for
+the 2026-06-16 work.
+
+`upstream-diff:` = title-prefix class for **fork-permanent** changes that land on `main` but are **never headed
+upstream** (vs `upstream-draft:` which aspires to upstream merge). Lands on main because the workflows must live on the
+default branch to trigger/dispatch.

--- a/.agents/auto-memory/reference_api_typecheck_blocked.md
+++ b/.agents/auto-memory/reference_api_typecheck_blocked.md
@@ -1,0 +1,21 @@
+---
+name: reference_api_typecheck_blocked
+description: Why vitest typecheck (*.test-d.ts) can't be turned on in the api package without a cleanup PR
+metadata:
+  type: reference
+---
+
+The `api` package's `*.test-d.ts` type assertions (e.g. `api/src/emitter.test-d.ts`) are collected by vitest but NEVER
+executed — `api/vitest.config.ts` has no `typecheck` block.
+
+Enabling `typecheck: { enabled: true }` is blocked by pre-existing type debt:
+
+- Package-wide it surfaces **~203 type errors** across `api/src` (vitest runs `tsc` over the whole tsconfig
+  `include: ["src"]`, not just the test-d file). Example: `src/websocket/errors.test.ts` zod `$ZodIssue` shape mismatch.
+- Even scoping via a custom `typecheck.tsconfig` that includes only `src/emitter.ts` + `src/emitter.test-d.ts` still
+  fails: `emitter.ts` → `logger/index.ts` imports `pino-http-print`, which ships **no type declarations** → implicit-any
+  error under the strict base config (`@directus/tsconfig/node22`).
+
+So wiring up vitest typecheck needs a dedicated type-cleanup PR (ambient `declare module 'pino-http-print'`, fix the
+~203 errors), not a coverage change. Until then, type-level tests are documentation only. Seen while covering PR #59
+(typed FilterHandler).

--- a/.agents/plans/split-fork-batch-insert-pr.md
+++ b/.agents/plans/split-fork-batch-insert-pr.md
@@ -1,0 +1,111 @@
+# Plan — Separate fork changes into upstreamable buckets; first PR = `insert → batchInsert`
+
+## Context
+
+Branch `feature/make_batch_insert_prable_6` carries ~30 fork-specific commits ahead of `upstream/main` (now at `d6e706e647`). Many of them entangle in `api/src/services/items.ts` (912 lines of diff vs upstream), and the next goal is to **open a first PR to `directus/directus` containing ONLY the `insert → batchInsert` refactor** — no other fork features. To do that we first inventory what's actually on the branch, classify each commit by feature concern, and identify the coupling points that need to be removed when extracting the batch-insert change for upstream review.
+
+This plan is a triage + extraction strategy. It does not yet write the upstream PR branch.
+
+## Phase 1 — Inventory of fork commits touching `items.ts`
+
+Cut-off between fork and upstream is between commits `4c07cca6f7` (ours, oldest fork commit) and `3961dc0593` (upstream "Add key/value information to db errors"). From `git log upstream/main..HEAD -- api/src/services/items.ts`:
+
+| # | SHA | Subject | Concern |
+|---|-----|---------|---------|
+| 1 | `d178f4387e` | refacto: move IsPrimaryKey type guard to utils | **batch-insert** support (extracts `isPrimaryKey`/`isNotPrimaryKey` to `api/src/utils/is-primary-key.ts`) |
+| 2 | `32d1a39ce0` | refacto: returning ids support in the database helpers | **batch-insert** (moves dialect probe into `api/src/database/helpers/capabilities/dialects/{postgres,oracle,sqlite,mssql}.ts` + base `types.ts`) |
+| 3 | `76adb1ca48` | perf: explain why MariaDB / Mssql do not support returning | **batch-insert** (comment-only) |
+| 4 | `aa999c51de` | perf: support batchInsert for Sqlite >= 3.35 | **batch-insert** (sqlite version probe + test branch) |
+| 5 | `f277d4f879` | style: format | **batch-insert** (prettier sweep over the above) |
+| 6 | `8e936467f2` | refacto: use batch insertMany for every insert #6 | **batch-insert** — THE big rewrite: collapses `createOne`→`createMany`, deletes 834 lines of fallback, also deletes dead `api/src/request/request-tracker.ts` |
+| 7 | `7f338f5deb` | perf: do not emit read events during update | **other** — `update*` only |
+| 8 | `776d93cc7b` | feat: allow skipping update via hooks && skip update of no fields | **other** — `update*` only |
+| 9 | `896fe04840` | perf: use where instead of whereIn if keys length is 1 | **other** — lock-scope perf |
+| 10 | `415ea65521` | feat: filter event for db.insert #32 | **other** — adds `items.db.insert` / `items.db.inserted` filters; current batch-insert code calls them at items.ts:388, :416 |
+| 11 | `ee343a26a2` | feat: make db errors filterable #34 | **other** — replaces `translateDatabaseError` with `throwDatabaseError`; current batch-insert code uses `throwDatabaseError` at items.ts:451 |
+| 12 | `bc36dfd2aa` | perf: hide console.logs and fix cockroachdb version | **other** — also touches `.github/workflows/blackbox.yml` and `docker-compose.yml` |
+| 13 | `2dd0d1255b` | ci(mysql): fix createMany for MySQL, MariaDB and Sqlite | **batch-insert** (the "fallback bucket" work, later deleted by #6 above) |
+| 14 | `7311d5cc4d` | perf: store activity and revision row with createMany | **batch-insert** (batches the side-effect writes) |
+| 15 | `7a3f613503` | feat: fix action-verify-create test | **batch-insert** (test fix for #16 below) |
+| 16 | `47833fd312` | perf: createMany batched | **batch-insert** |
+| 17 | `438dffd0e6` | feat: batched insert many filterable by create event | **batch-insert + other** — couples `createManyAtOnce` introduction with `items.db.insert*` filter calls |
+| 18 | `1ebf833129` | fix: data instead of itemsValus during translateDatabaseError | **batch-insert** (typo fix in #17) |
+| 19 | `1d7d86c048` | feat: support of batchInsert() | **batch-insert** — initial introduction |
+| 20 | `4c07cca6f7` | feat: filter items creation by returning null or PK | **other** — PR #23 (skipable creation via filter) |
+| 21 | `1ddb16ee04` | feat: optionnally async emitAction | **other** — emitter API change, not items.ts logic |
+
+Plus uncommitted: `tests/blackbox/setup/sequential-tests.ts` (single file in `git status -s`), and the stray `api/src/services/items.ts.previous-claude-refacto.bak` to discard.
+
+## Phase 2 — Bucket summary (what each upstream PR would carry)
+
+### Bucket A — `insert → batchInsert` (this is the FIRST upstream PR)
+
+What it does: replaces the per-vendor fallback maze in `createOne`/`createManyAtOnce` with a single dispatch — vendors that reliably preserve `INSERT … RETURNING` order use `knex.batchInsert(...).returning(pk)`, others use a per-row loop — and collapses `createOne` to a thin `createMany([data])` wrapper. Adds `DB_BATCH_INSERT_CHUNK_SIZE` and `DB_MSSQL_TRUST_BATCH_RETURNING` env vars.
+
+Source commits (squash candidates, in order): **#19, #18, #17, #16, #15, #14, #13, #6, #5, #4, #3, #2, #1**.
+
+Files touched by this bucket:
+- `api/src/services/items.ts` — `createOne` (now 3-line wrapper), `createMany` (real implementation), drops `createManyAtOnce` + ~500-line fallback re-query path.
+- `api/src/utils/is-primary-key.ts` (new) — `isPrimaryKey` / `isNotPrimaryKey` type guards.
+- `api/src/database/helpers/capabilities/types.ts` — adds base `preservesInsertOrderInReturning(): Promise<boolean>` (returns false).
+- `api/src/database/helpers/capabilities/dialects/{postgres,oracle,sqlite,mssql}.ts` (new) — per-dialect overrides; sqlite probes server version ≥3.35; mssql opts in via env.
+- `api/src/database/helpers/capabilities/index.ts` — wires the new dialect classes.
+- `tests/blackbox/tests/db/routes/items/batch-insert.test.ts` (new) — vendor-bucketed assertion (`isReliableBatchVendor`).
+- `tests/blackbox/extensions/query-counter/index.mjs` (new) — count-INSERT spy extension.
+- Removed: `api/src/request/request-tracker.ts` (dead code that #6 cleaned up — verify upstream `main` still has it before including the deletion).
+
+### Buckets B–I — later PRs, NOT in the first one
+
+- **B: `items.db.insert*` filter events** (PR #32-equivalent) — commits **#10, partially #17**. Needs to be split out: the filter calls at `items.ts:388-400` and `:416-428` were added by #17 and now live inside the batch dispatch.
+- **C: filterable db errors** (PR #34-equivalent) — commit **#11**. Affects the `throwDatabaseError` import + call at `items.ts:451` and a `fields.ts` edit.
+- **D: skipable item creation via filter** (PR #23-equivalent) — commit **#20**. Lives in `createMany`'s `items.create` filter handling (`items.ts:210` and the `isPrimaryKey` short-circuit at the top of the per-item prep loop).
+- **E: optionally-async emitAction** — commit **#21**. Touches `emitter.ts`, `items.ts` await sites, `types/items.ts`.
+- **F: lock-scope perf (`where` vs `whereIn`)** — commit **#9**.
+- **G: skippable update / skip empty update** — commit **#8**.
+- **H: skip read events on update** — commit **#7**.
+- **I: console.logs + cockroachdb workflow fix** — commit **#12**. Mostly CI/docker, low-value upstream — fold the items.ts piece (cleanup logs) into the batch-insert PR if minimal; drop the rest.
+
+## Phase 3 — Coupling points to remove from the FIRST PR
+
+Today's `items.ts` (HEAD) has three non-batch features bleeding into the batch dispatch path. For the upstream PR these must be reverted to upstream behavior:
+
+| Line(s) | Current (fork) | Required for upstream PR |
+|---|---|---|
+| `items.ts:388-400` | `dbQuery = await emitter.emitFilter('items.db.insert', dbQuery, …)` | **Delete.** Bucket B carries this. |
+| `items.ts:416-428` | `filteredResult = await emitter.emitFilter('items.db.inserted', insertedRows, …)` | **Delete** — iterate `insertedRows` directly. Bucket B. |
+| `items.ts:451` | `await throwDatabaseError(err, data)` | Replace with upstream's `throw await translateDatabaseError(err, …)`. Bucket C. |
+| `items.ts:210, 647` | `items.create` filter return-value handles `isPrimaryKey(result)` short-circuit | Drop the short-circuit branch; keep only upstream's filter+payload semantics. Bucket D. |
+| various `await emitter.emitAction(...)` | Always awaited | Match upstream sync/async semantics — verify per-call. Bucket E. |
+
+Concrete extraction strategy:
+
+1. Branch off `upstream/main`: `git switch -c upstream-pr/batch-insert upstream/main`.
+2. Cherry-pick the **batch-insert** commits in chronological order (#19 → #1). Expect heavy conflicts in #6 (the big rewrite) — resolve by keeping the upstream-clean version of each touchpoint above, using the fork's current `api/src/database/helpers/capabilities/dialects/*` files as reference for the dispatch logic.
+3. Squash all into one commit with a clear message; this becomes the upstream PR.
+4. Smoke-test locally (`pnpm --filter api typecheck`, blackbox `batch-insert.test.ts` against postgres + sqlite + mysql + oracle).
+
+If cherry-picking #6 is too conflict-heavy (likely — it's a 1000-line negative diff), an alternative is to **rewrite from upstream**: copy the current fork's `createMany` body into upstream's `items.ts` and prune the four coupling points by hand. End state is identical; pick whichever takes less time.
+
+## Critical files
+
+- `api/src/services/items.ts` (HEAD: lines 350–470 contain the entire batch dispatch — this is the surface to keep in the upstream PR).
+- `api/src/utils/is-primary-key.ts`
+- `api/src/database/helpers/capabilities/dialects/{postgres,oracle,sqlite,mssql}.ts`
+- `api/src/database/helpers/capabilities/{types.ts,index.ts}`
+- `tests/blackbox/tests/db/routes/items/batch-insert.test.ts`
+- `tests/blackbox/extensions/query-counter/index.mjs`
+
+## Verification
+
+1. On the new `upstream-pr/batch-insert` branch:
+   - `pnpm --filter api typecheck` — must be clean.
+   - `git diff upstream/main -- api/src/services/items.ts` — should show ONLY the batch dispatch + `createOne` collapse; no `items.db.insert*`, no `throwDatabaseError`, no skipable-creation branch, no async-emitAction churn.
+2. Blackbox: bring up postgres + sqlite + mysql + oracle, run `tests/db/routes/items/batch-insert.test.ts` and `tests/db/routes/items/no-relation.test.ts`. Branch-vs-loop assertion via `isReliableBatchVendor(vendor)` must hold.
+3. Run the upstream test suite (`pnpm --filter api test`) to confirm no unit regressions from the createOne→createMany collapse.
+
+## Out of scope (for the first PR)
+
+- Buckets B–I above — track separately, each its own PR.
+- Docs for `DB_BATCH_INSERT_CHUNK_SIZE` and `DB_MSSQL_TRUST_BATCH_RETURNING` in `docs/` — include in the upstream PR description, decide with maintainers whether they want a docs commit in the same PR.
+- The current `.bak` file (`api/src/services/items.ts.previous-claude-refacto.bak`) — discard locally; do not include in any PR.
+- The uncommitted `tests/blackbox/setup/sequential-tests.ts` change — review and either commit on the fork or discard; not for the upstream PR.

--- a/.agents/plans/upstream-pr-batch-insert.md
+++ b/.agents/plans/upstream-pr-batch-insert.md
@@ -1,0 +1,208 @@
+# Plan — Upstream PR: `INSERT` → `batchInsert` for `ItemsService.createMany`
+
+## Context
+
+- Fork: `feature/extensions_constants_issue` at `aaa1ad0d5b`. CI green (mssql aside — pre-existing slow tests).
+- Upstream: `directus/directus` `main` at `d6e706e647` (no `dev` branch — only `main`).
+- Destination branch: `feature/batch-insert-upstream` (already exists locally at `upstream/main`, no commits yet).
+- **Histories are disconnected** (`git merge-base upstream/main HEAD` → "no common ancestor"). Cherry-pick is **not
+  viable**. The PR must be hand-ported.
+
+## What the PR delivers (Bucket A)
+
+Replace upstream's per-row `createOne` insert with a vendor-bucketed dispatch in `createMany`:
+
+- Vendors that contractually preserve `INSERT … RETURNING` row order → single
+  `knex.batchInsert(table, rows, chunkSize).returning(pk)`.
+- Vendors that don't → per-row `trx.insert(row).into(...).returning(pk)` loop (same path upstream uses today).
+- Collapse `createOne` to a thin `createMany([data]).then(([pk]) => pk)` wrapper.
+- Introduce capability `preservesInsertOrderInReturning(): Promise<boolean>` on `CapabilitiesHelper`.
+- New env vars: `DB_BATCH_INSERT_CHUNK_SIZE` (knex passthrough, default 1000), `DB_MSSQL_TRUST_BATCH_RETURNING` (opt-in
+  for MSSQL).
+
+That's it. No filter-event changes, no error-model changes, no skipable-creation, no async-emitAction churn.
+
+## Commit classification (fork → upstream PR)
+
+`IN` = port into Bucket A. `OUT` = exclude. `SPLIT` = port the batch-insert slice only.
+
+| SHA          | Subject                                                                  | Bucket            | Notes                                                                                                                                                                                                                                                     |
+| ------------ | ------------------------------------------------------------------------ | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `1d7d86c048` | feat(items): support of batchInsert()                                    | IN                | Initial introduction.                                                                                                                                                                                                                                     |
+| `1ebf833129` | fix: data instead of itemsValus during translateDatabaseError            | IN                | Typo fix, drop the rename.                                                                                                                                                                                                                                |
+| `438dffd0e6` | feat(items): batched insert many filterable by create event              | SPLIT             | Keep the `createManyAtOnce` introduction; **drop the `items.db.insert*` filter calls** — those belong to Bucket B.                                                                                                                                        |
+| `47833fd312` | perf(items): createMany batched                                          | IN                |                                                                                                                                                                                                                                                           |
+| `7a3f613503` | feat(items): fix action-verify-create test                               | IN                |                                                                                                                                                                                                                                                           |
+| `7311d5cc4d` | perf(items): store activity and revision row with createMany             | IN                | Batches activity + revisions; upstream's per-row `activityService.createOne` becomes `createMany`.                                                                                                                                                        |
+| `2dd0d1255b` | ci(mysql): fix createMany for MySQL, MariaDB and Sqlite                  | OUT               | Built the fallback bucket; later deleted by `8e936467f2`. Final-state-equivalent already in `8e936467f2`.                                                                                                                                                 |
+| `76adb1ca48` | perf: explain why MariaDB / Mssql do not support returning               | IN (comment-only) | Drop the obsolete fallback comments; keep the per-dialect rationale (lives in `dialects/mssql.ts`).                                                                                                                                                       |
+| `aa999c51de` | perf: support batchInsert for Sqlite >= 3.35                             | IN                | Moves into `dialects/sqlite.ts` (per-version probe).                                                                                                                                                                                                      |
+| `32d1a39ce0` | refacto: returning ids support in the database helpers                   | IN                | Adds `preservesInsertOrderInReturning` capability + per-dialect overrides.                                                                                                                                                                                |
+| `d178f4387e` | refacto: move IsPrimaryKey type guard to utils                           | **OUT**           | The guards only exist because of the skipable-creation `string\|number` short-circuit (Bucket D). Without Bucket D, `ItemValues` is no longer a union, and the guards are dead. **`api/src/utils/is-primary-key.ts` does NOT belong in the upstream PR.** |
+| `8e936467f2` | refacto: use batch insertMany for every insert #6                        | IN                | The big rewrite. Deletes the fallback maze + `api/src/request/request-tracker.ts`. Verify `request-tracker.ts` exists on upstream before deleting (it doesn't — it's fork-only, leave alone).                                                             |
+| `f277d4f879` | style: format                                                            | IN (format only)  | Apply prettier as the last step, not as a separate commit.                                                                                                                                                                                                |
+| `14b44844f1` | refacto(items): review cleanups + batch-insert edge case tests           | IN                |                                                                                                                                                                                                                                                           |
+| `d932cbb1df` | style: format                                                            | IN (format only)  |                                                                                                                                                                                                                                                           |
+| `cf5e2d8a4c` | test: pin MSSQL identity-insert limitation in homogeneous-explicit block | IN                |                                                                                                                                                                                                                                                           |
+| `547e37d1f9` | test: extend mixed-batch (explicit + auto) test to integer PKs           | IN                |                                                                                                                                                                                                                                                           |
+| `4bb9592c3d` | test: deep-equal sorted arrays instead of per-field byName loops         | IN                |                                                                                                                                                                                                                                                           |
+| `ce1fa86f40` | fix(ci): unblock cockroachdb image + drop nested ternary                 | SPLIT             | Test fix IN; docker-compose change OUT (CI infra, fork-only).                                                                                                                                                                                             |
+| `0b27449465` | feat(items): default-order reads by primary key (env-toggleable)         | **OUT**           | Separate feature — `readByQuery` change unrelated to insert. Track for a follow-up PR.                                                                                                                                                                    |
+| `295153a9bf` | refacto(items): restrict default PK sort to integer / bigInteger PKs     | OUT               | Same feature as above.                                                                                                                                                                                                                                    |
+| `56ab8ea527` | test: actively verify DB_DEFAULT_ORDER_READS_BY_PK                       | OUT               | Same.                                                                                                                                                                                                                                                     |
+| `f985e17863` | fix(items): emitFilter result is non-extensible                          | OUT               | Fix is for `readByQuery` (line 721, after the items.read filter), not insert.                                                                                                                                                                             |
+| `62cba42b54` | fix(items): skip default PK sort when query has group/aggregate          | OUT               | Same.                                                                                                                                                                                                                                                     |
+| `712bae95e2` | test(mssql): cover both loop and trust-batch paths via env-inject        | IN                | Adds `extensions/env-inject/`. Keep — exercises `DB_MSSQL_TRUST_BATCH_RETURNING`.                                                                                                                                                                         |
+| `ecb051b5bd` | fix(lint): extract explicit-id mapping                                   | IN                | Cleanup.                                                                                                                                                                                                                                                  |
+| `df46b9c134` | fix(blackbox): cockroachdb in-mem store + mssql UUID case                | SPLIT             | mssql UUID assertion fix IN; cockroachdb docker tweak OUT.                                                                                                                                                                                                |
+| `8bb330c72f` | test(mssql): scope DB_MSSQL_TRUST_BATCH_RETURNING toggle                 | IN                |                                                                                                                                                                                                                                                           |
+| `44c8a01897` | test: batchInsert with createMany                                        | IN                | Adds `extensions/query-counter/` + the main `batch-insert.test.ts`.                                                                                                                                                                                       |
+
+### Excluded buckets (separate PRs later)
+
+| Bucket                                             | Driving commits                                       | Coupling site in items.ts                                                                                                                                                                                                        |
+| -------------------------------------------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **B** — `items.db.insert*` filter events (PR #32)  | `415ea65521` + filter calls added inside `438dffd0e6` | Lines 379–391 (`db.insert`), 407–419 (`db.inserted`).                                                                                                                                                                            |
+| **C** — filterable db errors (PR #34)              | `ee343a26a2`                                          | Line 442 (`throwDatabaseError`).                                                                                                                                                                                                 |
+| **D** — skipable item creation via filter (PR #23) | `4c07cca6f7` + `0a93627178`                           | Lines 225–228 (`if (payloadAfterHooks === null) continue`), 230–237 (`typeof === 'string'\|'number'` short-circuit), 627 (filter), 673–679 (`isPrimaryKey` final map), plus the entire `ItemValues = PrimaryKey \| {...}` union. |
+| **E** — optionally async `emitAction`              | `1ddb16ee04`                                          | `await emitter.emitAction(...)` sites — upstream calls them sync.                                                                                                                                                                |
+| **F** — `where` vs `whereIn` (lock perf)           | `896fe04840`                                          | Outside createOne/createMany.                                                                                                                                                                                                    |
+| **G** — skippable update                           | `776d93cc7b`                                          | `updateOne` / `updateMany`.                                                                                                                                                                                                      |
+| **H** — skip read events on update                 | `7f338f5deb`                                          | `updateOne` / `updateMany`.                                                                                                                                                                                                      |
+| **I** — error tracking for Railway sleep           | `d6f9f15fcf`                                          | Outside items.ts.                                                                                                                                                                                                                |
+
+## Coupling points to remove from fork `createMany` body
+
+Reference: current fork `api/src/services/items.ts` lines 142–680. For the upstream PR these must NOT carry over:
+
+| Fork lines                                            | What it does                                                      | Decoupling action                                                                                                                                                                                                                             |
+| ----------------------------------------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 19, 442, 1052                                         | `import { throwDatabaseError }` + use                             | Replace with upstream's `import { translateDatabaseError } from '../database/errors/translate.js'` and the upstream `catch` block (lines 148–160 of upstream): translate, special-case `RecordNotUnique` w/ `pkField.field`, `throw dbError`. |
+| 30                                                    | `import { isNotPrimaryKey, isPrimaryKey }`                        | Delete.                                                                                                                                                                                                                                       |
+| 166–186                                               | `type ItemValues = PrimaryKey \| { … }` union                     | Collapse to just the object type (the union variant exists only for skipable-creation). Drop the `PrimaryKey` arm.                                                                                                                            |
+| 225–228                                               | `if (payloadAfterHooks === null) continue;`                       | Delete (no skipable).                                                                                                                                                                                                                         |
+| 230–237                                               | `typeof payloadAfterHooks === 'string' \| 'number'` short-circuit | Delete (no skipable).                                                                                                                                                                                                                         |
+| 326                                                   | `preparedItems.filter(isNotPrimaryKey)`                           | Delete the `.filter(isNotPrimaryKey)` — `preparedItems` is already pure objects.                                                                                                                                                              |
+| 379–391                                               | `emitter.emitFilter('items.db.insert', …)`                        | Delete the whole block. The batchInsert path becomes: `const insertedRows = await trx.batchInsert(...).returning(primaryKeyField)`.                                                                                                           |
+| 407–419                                               | `emitter.emitFilter('items.db.inserted', …)`                      | Delete. Iterate `insertedRows` directly in the `forEach` that follows.                                                                                                                                                                        |
+| 442                                                   | `await throwDatabaseError(err, data)`                             | Replace with upstream's `translateDatabaseError(err, data)` + `RecordNotUnique` handling shown above.                                                                                                                                         |
+| 542                                                   | `.filter(isNotPrimaryKey)` on `preparedForPostInsert`             | Drop the filter — pure objects.                                                                                                                                                                                                               |
+| 627                                                   | `for (const itemValues of itemsValues.filter(isNotPrimaryKey))`   | Drop the filter.                                                                                                                                                                                                                              |
+| 673–679                                               | `itemsValues.map(... isPrimaryKey ? ... : itemValues.primaryKey)` | Simplify to `itemsValues.map((iv) => iv.primaryKey)`.                                                                                                                                                                                         |
+| any `await emitter.emitAction(...)` in lines 655, 664 | Async-awaited per Bucket E                                        | Match upstream: drop the `await` — upstream emits sync.                                                                                                                                                                                       |
+
+## Features missing from fork's items.ts that **must** be preserved in the port
+
+Upstream's `createOne` has functionality the fork has lost. The upstream PR must keep these intact:
+
+1. **MSSQL trigger-modifications option** (upstream lines 128–133):
+   ```ts
+   if (getDatabaseClient(trx) === 'mssql') {
+   	returningOptions = { includeTriggerModifications: true };
+   }
+   ```
+   For the per-row loop path, retain this. For `batchInsert`, check whether knex's `batchInsert` accepts a similar
+   passthrough; if not, document the loss and decide with maintainers.
+2. **`opts.overwriteDefaults`** — passed to `PayloadService` constructor; used by Insights/Flows. Fork dropped it; add
+   back.
+3. **`opts.skipTracking`** — gates the activity/revisions block. Fork doesn't honor it; add back.
+4. **`opts.onItemCreate`** callback after PK is known. Fork doesn't honor it; add back.
+5. **Fallback `trx.max(pk).first()`** when RETURNING returned no PK (MySQL/SQLite old versions, upstream lines 165–173).
+   For the per-row loop path, retain. For `batchInsert` (only used when `preservesInsertOrderInReturning()===true`),
+   this fallback isn't needed.
+6. **`getRelationsForCollection` + `omit(payloadWithPresets, relationalFields)` for revision delta** (upstream lines
+   233–235). Fork's batched path uses `payloadService.prepareDelta(payloadAfterHooks)` directly — verify the semantic
+   difference and decide.
+7. **`transaction(this.knex, ...)` helper** (upstream's retry/nesting-safe wrapper). Fork uses
+   `this.knex.transaction(...)` directly. Use upstream's helper.
+
+## File manifest for the upstream PR
+
+```
+api/src/services/items.ts                                              # edited
+api/src/database/helpers/capabilities/types.ts                         # edited — add preservesInsertOrderInReturning
+api/src/database/helpers/capabilities/dialects/postgres.ts             # edited — add override
+api/src/database/helpers/capabilities/dialects/oracle.ts               # NEW — extends CapabilitiesHelperDefault, overrides preservesInsertOrderInReturning
+api/src/database/helpers/capabilities/dialects/sqlite.ts               # NEW — version probe ≥3.35
+api/src/database/helpers/capabilities/dialects/mssql.ts                # NEW — opt-in via DB_MSSQL_TRUST_BATCH_RETURNING
+api/src/database/helpers/capabilities/index.ts                         # edited — re-route mssql/oracle/sqlite from Default to new classes
+
+tests/blackbox/tests/db/routes/items/batch-insert.test.ts              # NEW
+tests/blackbox/extensions/query-counter/index.mjs                      # NEW
+tests/blackbox/extensions/query-counter/package.json                   # NEW
+tests/blackbox/extensions/env-inject/index.mjs                         # NEW
+tests/blackbox/extensions/env-inject/package.json                      # NEW
+
+docs/self-hosted/config-options.md                                     # edited (if upstream maintains env-var docs there) — add DB_BATCH_INSERT_CHUNK_SIZE, DB_MSSQL_TRUST_BATCH_RETURNING
+```
+
+Explicitly NOT in the PR:
+
+- `api/src/utils/is-primary-key.ts` — dead without Bucket D.
+- Deletion of `api/src/request/request-tracker.ts` — doesn't exist on upstream.
+- `tests/blackbox/utils/set-directus-env.ts` — confirm upstream doesn't have it; if it's tied only to Bucket A tests,
+  IN. Otherwise OUT.
+- Any `.github/` or `docker-compose.yml` change from `bc36dfd2aa` / `ce1fa86f40`.
+
+## Materialization strategy
+
+**Cherry-pick will not work** (disconnected histories). Use direct port:
+
+1. `git switch feature/batch-insert-upstream` (already at `upstream/main`).
+2. Create new files in `capabilities/dialects/*` by hand from the fork copies, adjusted to extend
+   `CapabilitiesHelperDefault` (upstream's pattern) rather than `CapabilitiesHelper` directly. Update
+   `capabilities/index.ts` and `capabilities/types.ts`.
+3. Open upstream's `items.ts` `createOne` (lines 8–307) and refactor it in place:
+   - Move the bulk into `createMany` body.
+   - Replace the single-row `trx.insert(...).returning(...)` with
+     `if (await getHelpers(trx).capabilities.preservesInsertOrderInReturning()) { /* batchInsert */ } else { /* per-row loop with returningOptions */ }`.
+   - Batch the `activityService.createOne` / `revisionsService.createOne` into `createMany`.
+   - Re-shape `createOne` to `const [pk] = await this.createMany([data], opts); return pk`.
+4. Drop the fork's filter/error/skipable coupling per the table above as you go.
+5. Copy `batch-insert.test.ts`, `extensions/query-counter/`, `extensions/env-inject/` verbatim (these are net-new on the
+   fork; should apply cleanly).
+6. Run prettier across changed files.
+7. Single commit (squash all of the above):
+   `feat(items): use knex.batchInsert for vendors with reliable RETURNING order`.
+
+## Verification
+
+After the port:
+
+1. `pnpm install` (workspace bootstrap on the upstream baseline).
+2. `pnpm --filter api typecheck` → clean.
+3. `pnpm --filter api test` (unit) → clean.
+4. `git diff upstream/main -- api/src/services/items.ts` should contain ONLY:
+   - The `createOne` collapse.
+   - The vendor-bucketed dispatch.
+   - The activity/revisions batching.
+   - **Zero** mention of `items.db.insert`, `throwDatabaseError`, `isPrimaryKey`, payload-null short-circuits, async
+     `emitAction`, default-PK-sort.
+5. Blackbox: `pnpm --filter tests-blackbox test` against postgres + sqlite + mysql + maria + mssql + oracle. The
+   `batch-insert.test.ts` `isReliableBatchVendor(vendor)` partition must match the capability dispatch.
+6. Sanity-grep on the diff:
+   `grep -nE 'items\.db\.insert|throwDatabaseError|isPrimaryKey|isNotPrimaryKey|DEFAULT_ORDER_READS_BY_PK'` — must
+   return nothing.
+
+## Design decisions (locked to PR #43)
+
+User directive: stick to the design established during PR #43. The questions previously raised are answered as follows:
+
+- **MSSQL trigger-modifications**: trust mode (`DB_MSSQL_TRUST_BATCH_RETURNING=true`) routes through `knex.batchInsert`,
+  which doesn't carry the `{ includeTriggerModifications: true }` option — so trust mode is **not compatible with
+  triggered MSSQL tables**. Document in the PR description. The default path (trust mode off) still goes through
+  upstream's `createOne` via the per-row loop branch, which retains `includeTriggerModifications` — so out-of-the-box
+  behavior is unchanged for triggered tables.
+- **`opts.overwriteDefaults` indexing**: positional via `opts.overwriteDefaults?.[index]` in the batched prep loop,
+  matching the fork's PR #43 semantics. Already applied.
+- **Env-var naming**: `DB_BATCH_INSERT_CHUNK_SIZE` and `DB_MSSQL_TRUST_BATCH_RETURNING` verbatim from PR #43. Already
+  applied.
+- **`DB_DEFAULT_ORDER_READS_BY_PK` default = `true`**: matches PR #43. Behavior change for existing deployments — flag
+  it in the release-note bullet but ship the default as `true`.
+
+## Out of scope (do not include in the first PR)
+
+- Buckets B–I above.
+- The fork's per-dialect dialect-helper file restructure (only add the files we need).
+- Any docs updates beyond the two new env vars.
+- The `.bak` file and the uncommitted `tests/blackbox/setup/sequential-tests.ts` change on the fork.

--- a/.agents/skills/watch-gh-ci-run/SKILL.md
+++ b/.agents/skills/watch-gh-ci-run/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: watch-gh-ci-run
+description:
+  Wait for a GitHub Actions workflow run to finish, emitting one event per job as it lands and a final RUN_COMPLETE with
+  the overall conclusion. Use right after `git push` to babysit CI without polling — events arrive as
+  `<task-notification>` messages from the Monitor tool. On failure, the skill points at logs/artifacts; diagnosis is the
+  user's call.
+version: 1.0.0
+---
+
+# watch-gh-ci-run
+
+Babysits a single GitHub Actions workflow run via the Monitor tool. Each completed job is one event; the workflow's
+overall completion is one final event. No `sleep` loops in the conversation; the harness wakes you on each event.
+
+## When to use
+
+- Right after `git push` — confirm CI passed before moving on (memory: `feedback_watch_ci_after_push`).
+- When the user asks "watch CI" / "check CI" mid-flow.
+- After a rerun (`gh run rerun <id> --failed`).
+
+Not for:
+
+- Cross-branch / cross-workflow audits — use `gh run list` directly.
+- Local CI reproduction — different skill.
+
+## Procedure
+
+### 1. Resolve the run id
+
+After a push:
+
+```sh
+git push origin <branch> 2>&1 | tail -3
+sleep 6
+gh run list --repo <owner/repo> --branch <branch> --workflow=<workflow.yml> --limit 3 \
+  --json databaseId,headSha,status \
+  --jq '.[] | select(.headSha | startswith("<sha-prefix>")) | .databaseId'
+```
+
+- `<sha-prefix>` is the 6+ char prefix of the commit you just pushed (`git rev-parse --short HEAD`).
+- Specify `--workflow=<file.yml>` when the repo has multiple workflows on the branch; otherwise drop the flag.
+- The `sleep 6` is intentional — GitHub needs a few seconds to materialize the run after the push event.
+
+If the user pinned a specific run id, skip this step.
+
+### 2. Arm the Monitor
+
+The polling loop lives in `watch-ci.sh` alongside this skill; the Monitor invocation just hands it the run id + repo.
+
+```js
+Monitor({
+	description: 'CI jobs landing on PR #N sha <short-sha>',
+	persistent: true,
+	timeout_ms: 3_600_000, // 1h covers most workflows; raise if needed
+	command: '.agents/skills/watch-gh-ci-run/watch-ci.sh <RUN_ID> <owner/repo>',
+});
+```
+
+Optional third arg is the poll interval in seconds (default `45`). Drop it lower (e.g. `15`) only when you actually need
+sub-minute granularity — gh API rate limits favor 30–60s.
+
+Why this shape:
+
+- The script emits only the _newly completed_ jobs each tick (`comm -13 <(prev) <(cur)`), so each task-notification
+  carries one or two delta lines, not the full job list every poll.
+- Emit-on-completion (not on every status change) avoids `queued` / `in_progress` / `waiting` noise.
+- `persistent: true` survives the long tail of slow vendors; the script self-terminates with a final
+  `RUN_COMPLETE: <conclusion>` line.
+- Script exits `0` on success, `1` otherwise — Monitor surfaces both as `completed` and you decide what to do based on
+  the final line.
+
+### 3. React to events
+
+Each `<task-notification>` contains one line of the form `<job-name>: <conclusion>`, or the terminal
+`RUN_COMPLETE: <conclusion>`.
+
+- **`success`** — acknowledge in one line ("X ✅"). No `PushNotification` (routine).
+- **`failure`** — fetch the job log immediately and report the assertion details (next section). `PushNotification` only
+  if the user is away and the failure changes what they'd do next.
+- **`cancelled`** — usually means a newer push superseded this run, or the workflow timeout fired. Verify before action.
+- **`RUN_COMPLETE`** — summarize the matrix and stop. Don't re-arm.
+
+### 4. Diagnose a failure
+
+```sh
+gh run view <RUN_ID> --repo <owner/repo> --json jobs \
+  --jq '.jobs[] | select(.name=="<failed-job>") | .databaseId'
+# Then:
+gh api repos/<owner/repo>/actions/jobs/<job-id>/logs > /tmp/<vendor>-job.log
+```
+
+The raw log is large; filter with `awk` (memory: `feedback_prefer_awk_over_sed`):
+
+```sh
+awk 'tolower($0) ~ /exit code|##\[error\]|directus.*failed|unhandled rejection/' /tmp/<vendor>-job.log \
+  | grep -viE 'sdk build|api build|\[CJS\]|\[ESM\]|file copy|tsserver|workspace' \
+  | tail -30
+```
+
+For deeper failures (need server logs, traces), grab the artifact:
+
+```sh
+gh api repos/<owner/repo>/actions/runs/<RUN_ID>/artifacts --jq '.artifacts[] | select(.name | test("<vendor>"))'
+gh api repos/<owner/repo>/actions/artifacts/<artifact-id>/zip > /tmp/logs.zip
+unzip -p /tmp/logs.zip <log-file>.txt | awk '/<pattern>/'
+```
+
+(memory: `feedback_use_pnpm_in_monorepo` — `pnpm dlx` over `npx` if a CLI is needed.)
+
+### 5. Handle re-pushes mid-watch
+
+If the user pushes a new commit while a Monitor is running:
+
+1. Stop the old Monitor with `TaskStop <task-id>`. The old run will be cancelled by GitHub's concurrency rule (most
+   workflows have `cancel-in-progress: true`); if not, decide whether to wait for it.
+2. Resolve the new run id (step 1) and arm a fresh Monitor with the new id in the command.
+
+Don't leave two Monitors running on the same workflow — events from both will arrive interleaved.
+
+### 6. Fallback heartbeat
+
+Monitor takes care of waking you on events, but if the gh poll loop ever stalls (network blip, transient API outage)
+you'd wait forever. Pair it with a `ScheduleWakeup` fallback:
+
+```js
+ScheduleWakeup({
+	delaySeconds: 1500,
+	reason: 'Fallback heartbeat in case the gh-poll monitor stalls',
+	prompt: '/loop check CI on PR #N (<owner/repo>, latest HEAD). ...',
+});
+```
+
+The wakeup is a safety net, not the primary signal. With a Monitor armed, lean 1200–1800s — past the prompt-cache 5-min
+window but cheap because it rarely fires.
+
+## Common gotchas
+
+- **Workflow timeout vs job cancellation** — `cancelled` on the last vendor while others succeeded usually means
+  `timeout-minutes` in the workflow hit, not your code. Check `startedAt`/`completedAt` deltas in the json — if it's
+  exactly 60min, that's the workflow timeout.
+- **Don't poll outside the Monitor** — once the Monitor is armed, do other work or wait. Manual `gh run view` calls in
+  the same conversation just burn context without surfacing anything new.
+- **Concurrency cancel-in-progress** — many workflows include `concurrency: { cancel-in-progress: true }`. A fresh push
+  aborts the old run; the Monitor will see `cancelled` for whatever was still running. That's expected, not a failure to
+  investigate.
+- **Two `_cache`-style hazards in CI** — `pnpm deploy --prod` produces non-symlinked copies of workspace packages, so
+  module-level singletons can desync between runtime contexts. Diagnose with `gh api repos/.../jobs/.../logs` if you see
+  "doesn't provide an export named X" or "ELOOP".
+
+## Quick reference
+
+```sh
+# 1. After push: resolve run id (sha prefix from `git rev-parse --short HEAD`)
+gh run list --repo <owner/repo> --branch <branch> --workflow=<file.yml> --limit 3 \
+  --json databaseId,headSha,status --jq '.[] | select(.headSha|startswith("<sha>")) | .databaseId'
+
+# 2. Arm the Monitor (wraps watch-ci.sh — see step 2 for the full call).
+.agents/skills/watch-gh-ci-run/watch-ci.sh <run-id> <owner/repo>
+
+# 3. On failure event, pull the job log:
+gh api repos/<owner/repo>/actions/jobs/<job-id>/logs > /tmp/job.log
+awk '/##\[error\]|exit code|failed/' /tmp/job.log | tail -30
+
+# 4. On re-push, stop the old monitor:
+TaskStop <task-id>
+```
+
+## What this skill does NOT do
+
+- **Does not apply fixes.** Diagnose, propose, ask. (memory: `feedback_propose_before_applying`,
+  `feedback_questions_never_trigger_edits`.)
+- **Does not trigger reruns automatically.** `gh run rerun --failed` is a user decision — it consumes CI minutes and can
+  mask flakes.
+- **Does not babysit non-GitHub CI.** GitLab / Buildkite / Circle need their own monitors.
+- **Does not chain across pushes.** One push → one Monitor → one outcome. A new push needs a fresh Monitor on the fresh
+  run id.

--- a/.agents/skills/watch-gh-ci-run/watch-ci.sh
+++ b/.agents/skills/watch-gh-ci-run/watch-ci.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# watch-ci.sh — poll a GitHub Actions workflow run and emit one stdout line
+# per newly completed job, then a terminal RUN_COMPLETE line.
+#
+# Designed to be invoked from the Monitor tool so each line becomes a
+# task-notification. Self-terminates on workflow completion.
+#
+# Usage:
+#   watch-ci.sh <run-id> <owner/repo> [poll-seconds]
+#
+# Output format:
+#   <job-name>: <conclusion>     # one line per newly completed job
+#   RUN_COMPLETE: <conclusion>   # final line when workflow status flips to completed
+#
+# Exit codes:
+#   0  workflow finished with conclusion == success
+#   1  workflow finished with any other conclusion (failure/cancelled/timed_out/...)
+#   2  usage error
+
+set -uo pipefail
+
+if [ "$#" -lt 2 ]; then
+	printf 'usage: %s <run-id> <owner/repo> [poll-seconds]\n' "$0" >&2
+	exit 2
+fi
+
+run_id="$1"
+repo="$2"
+poll="${3:-45}"
+
+prev=""
+while true; do
+	s=$(gh run view "$run_id" --repo "$repo" --json status,conclusion,jobs 2>/dev/null) || s=""
+
+	if [ -n "$s" ]; then
+		cur=$(jq -r '.jobs[]? | select(.status=="completed") | "\(.name): \(.conclusion)"' <<<"$s" | sort)
+		comm -13 <(printf '%s\n' "$prev") <(printf '%s\n' "$cur")
+		prev="$cur"
+
+		run_state=$(jq -r '.status // empty' <<<"$s")
+
+		if [ "$run_state" = "completed" ]; then
+			conclusion=$(jq -r '.conclusion // "unknown"' <<<"$s")
+			echo "RUN_COMPLETE: $conclusion"
+			[ "$conclusion" = "success" ] && exit 0
+			exit 1
+		fi
+	fi
+
+	sleep "$poll"
+done


### PR DESCRIPTION
Companion to #64. I want the fork's agent working context tracked in the repo, not stranded on one machine — so it travels with `clone`/worktrees and survives a box change. `upstream-diff:` because it's fork-permanent and never headed upstream.

## What's here

- **`.agents/auto-memory/`** — project memories (db clients, codecov flags, knex deep-sort regression, forbidden-error conventions, the fork integration-branch model) + a couple of workflow-preference notes.
- **`.agents/plans/`** — the batch-insert upstream-PR planning docs.
- **`.agents/skills/watch-gh-ci-run/`** — reusable CI-watch skill.

## Not here

- `AGENTS.md` and `.claude/CLAUDE.md` — these are **upstream** files, byte-identical to upstream. Not fork divergence, nothing to track. Left untouched.

## Heads-up

- This publishes the notes to a **public** fork. I scanned for secrets/keys/credentials — none; content is technical fork-engineering notes intended to be shared. Flag anything you'd rather keep private and I'll strip it.
- `.agents/` is **not** gitignored, so once on `main` every branch inherits it and it's tracked going forward — that inverts the old "don't let `.agents/` leak into a PR" habit. Intentional here.

## Follow-up

- After #64 merges, add `.agents/ export-ignore` to `.gitattributes` so the dev context stays out of the codeload deploy tarball.