### PR TITLE
upstream-diff: release-fork dist generator + codeload export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# --- codeload tarball shrink (export-ignore = git-archive only; clone/build unaffected) ---
+# Downstream monorepos consume this fork as `github:jclaveau/directus#<ref>&path:<sub>`.
+# codeload has no subpath extraction, so EVERY subpath fetch downloads the whole-repo
+# tarball and keeps one subdir. These paths are never a consumed subpath and never imported
+# at runtime (packages ship dist/), so drop them from the archive to shrink every fetch.
+# See https://github.com/jclaveau/directus/issues/63 (the registry publish is the real fix).
+**/src/            export-ignore
+**/src/**          export-ignore
+docs/              export-ignore
+tests/             export-ignore
+pnpm-lock.yaml     export-ignore
+.github/           export-ignore
+**/.storybook/**   export-ignore
+**/*.stories.*     export-ignore
+**/*.test.*        export-ignore
+**/*.spec.*        export-ignore
+*.md               export-ignore
+Dockerfile         export-ignore
+docker-compose.yml export-ignore
+.changeset/        export-ignore

--- a/.github/workflows/release-fork.yml
+++ b/.github/workflows/release-fork.yml
@@ -1,0 +1,72 @@
+name: Release Fork
+
+# Builds the committed-dist branch `<ref>-dist` consumed by the codeload
+# tarball deploy (packages ship dist/, .gitattributes export-ignore strips
+# src/tests/.github from the archive). One `-dist` per source branch,
+# delete-then-recreate so it stays fresh.
+#
+# Triggers:
+#   - push: a branch push refreshes its own `-dist`.
+#   - workflow_dispatch: compose-hhh-main dispatches `--ref hhh-main` after a
+#     green compose, because its GITHUB_TOKEN force-push can't trigger `push`.
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Configure Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Create new branch if it doesn't exist
+        id: create_branch
+        run: |
+          CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+          DIST_BRANCH="${CURRENT_BRANCH}-dist"
+          git push origin --delete ${DIST_BRANCH} || true
+          git checkout -b ${DIST_BRANCH}
+        shell: bash
+
+      - name: Prepare
+        uses: ./.github/actions/prepare
+        with:
+          registry: https://registry.npmjs.org
+
+      - name: Pack and extract dist folders
+        run: |
+          pnpm -r --include-workspace-root exec sh -c '
+            tarball=$(pnpm pack --pack-destination . 2>/dev/null | tail -1)
+            if [ -f "$tarball" ]; then
+              tar xf "$tarball" --strip-components=1 "package/package.json"
+              echo "Extracted package.json from $tarball in $(pwd)"
+              if tar tf "$tarball" | grep -q "^package/dist/"; then
+                rm -rf dist
+                tar xf "$tarball" --strip-components=1 "package/dist/"
+                echo "Extracted dist from $tarball in $(pwd)"
+              fi
+              rm "$tarball"
+            fi
+          '
+        shell: bash
+
+      - name: Add and commit dist folder
+        run: |
+          # remove dist/ from gitignore
+          mv .gitignore .gitignore.bak
+          grep -v 'dist/' .gitignore.bak > .gitignore
+          # cat .gitignore
+
+          git add '**/dist/**'
+          git add '**/package.json'
+
+          git commit -m "Add dist folders content"
+          git push -f origin HEAD
+        shell: bash


### PR DESCRIPTION
Fork-permanent CI infra, never headed upstream (`upstream-diff:`), meant to be merged **during the compose phase**. Split out of the compose PR (#64) so that one stays a pure single-file discovery change.

## What's here

- **`release-fork.yml`** — ported from `v11.9.2-hhh-dev`. On `push` (a branch refreshes its own `<ref>-dist`) or `workflow_dispatch`. Builds `<ref>-dist`: the committed-build branch the codeload tarball deploy consumes (delete-then-recreate, one per source branch).
- **`.gitattributes`** export-ignore — every compose-target branch should carry this so its (and its derived `hhh-main`/`-dist`) codeload tarball ships `dist/` + runtime only, not `src/`/`tests/`/`.github/`.

## Scope

- **No compose wiring.** The `compose-hhh-main` → `gh workflow run release-fork --ref hhh-main` dispatch step is intentionally **not** here — `hhh-main` (v12) isn't deployed, so auto-building `hhh-main-dist` isn't required yet. release-fork lands dispatchable for when it is (and for the v11 line).
- Pairs with #64 (compose discovery denylist) and #65 (`.agents/` context).

## Heads-up

- Once on main, `release-fork`'s `on: push` triggers a `-dist` build for **every** branch push. That's the existing v11-line behavior; flag if you want a branch filter.