### PR TITLE
hhh-main-stacked: fix(schema): stop charset validation warning about MariaDB JSON columns

### DIFF
--- a/.changeset/mariadb-json-collation.md
+++ b/.changeset/mariadb-json-collation.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Stopped the database charset validation from warning about MariaDB JSON columns. MariaDB has no native JSON type and stores JSON as `LONGTEXT` with the `utf8mb4_bin` collation, which the validator previously reported as a collation mismatch on every startup. The MySQL schema helper now detects MariaDB via `VERSION()` and excludes that expected `LONGTEXT`/`utf8mb4_bin` pairing.

--- a/api/src/database/helpers/schema/dialects/default.test.ts
+++ b/api/src/database/helpers/schema/dialects/default.test.ts
@@ -1,4 +1,5 @@
-import type { Knex } from 'knex';
+import knex, { type Knex } from 'knex';
+import { createTracker, MockClient } from 'knex-mock-client';
 import { describe, expect, test, vi } from 'vitest';
 import { SchemaHelperDefault } from './default.js';
 
@@ -64,5 +65,21 @@ describe('SchemaHelperDefault', () => {
 			'categories',
 			'name',
 		]);
+	});
+
+	describe('getColumnsWithInvalidCollation', () => {
+		test('queries information_schema columns without dialect-specific exclusions', async () => {
+			const db = knex.default({ client: MockClient });
+			const tracker = createTracker(db);
+			tracker.on.select('information_schema').response([]);
+			const helper = new SchemaHelperDefault(db);
+
+			await helper.getColumnsWithInvalidCollation('directus', 'utf8mb4_general_ci');
+
+			const query = tracker.history.select.find((q) => q.sql.includes('information_schema'));
+
+			expect(query?.sql).not.toMatch(/column_type/i);
+			expect(query?.bindings).toEqual(expect.arrayContaining(['directus', 'utf8mb4_general_ci']));
+		});
 	});
 });

--- a/api/src/database/helpers/schema/dialects/mysql.test.ts
+++ b/api/src/database/helpers/schema/dialects/mysql.test.ts
@@ -1,5 +1,6 @@
-import type { Knex } from 'knex';
-import { describe, expect, test, vi } from 'vitest';
+import knex, { type Knex } from 'knex';
+import { createTracker, MockClient, type Tracker } from 'knex-mock-client';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { SchemaHelperMySQL } from './mysql.js';
 
 vi.mock('../../index.js', () => ({
@@ -147,6 +148,44 @@ describe('SchemaHelperMySQL', () => {
 
 			expect(result).toBe('MyCollection');
 			expect(mockRaw).toHaveBeenCalledWith('SELECT @@lower_case_table_names AS lctn');
+		});
+	});
+
+	describe('getColumnsWithInvalidCollation', () => {
+		let tracker: Tracker;
+
+		function setup(version: string) {
+			const db = knex.default({ client: MockClient });
+			tracker = createTracker(db);
+			tracker.on.select('VERSION()').response([{ version }]);
+			tracker.on.select('information_schema').response([]);
+			return new SchemaHelperMySQL(db);
+		}
+
+		afterEach(() => {
+			tracker?.reset();
+		});
+
+		test('excludes JSON-as-longtext (utf8mb4_bin) on MariaDB', async () => {
+			const helper = setup('10.11.2-MariaDB-1:10.11.2+maria~ubu2204');
+
+			await helper.getColumnsWithInvalidCollation('directus', 'utf8mb4_general_ci');
+
+			const query = tracker.history.select.find((q) => q.sql.includes('information_schema'));
+
+			expect(query?.sql).toMatch(/column_type/i);
+			expect(query?.bindings).toEqual(expect.arrayContaining(['longtext', 'utf8mb4_bin']));
+		});
+
+		test('does not exclude longtext on MySQL', async () => {
+			const helper = setup('8.0.34');
+
+			await helper.getColumnsWithInvalidCollation('directus', 'utf8mb4_general_ci');
+
+			const query = tracker.history.select.find((q) => q.sql.includes('information_schema'));
+
+			expect(query?.sql).not.toMatch(/column_type/i);
+			expect(query?.bindings).not.toContain('longtext');
 		});
 	});
 });

--- a/api/src/database/helpers/schema/dialects/mysql.test.ts
+++ b/api/src/database/helpers/schema/dialects/mysql.test.ts
@@ -1,6 +1,7 @@
 import knex, { type Knex } from 'knex';
 import { createTracker, MockClient, type Tracker } from 'knex-mock-client';
 import { afterEach, describe, expect, test, vi } from 'vitest';
+import type { InvalidCollationColumn } from '../types.js';
 import { SchemaHelperMySQL } from './mysql.js';
 
 vi.mock('../../index.js', () => ({
@@ -154,11 +155,11 @@ describe('SchemaHelperMySQL', () => {
 	describe('getColumnsWithInvalidCollation', () => {
 		let tracker: Tracker;
 
-		function setup(version: string) {
+		function setup(version: string, columns: InvalidCollationColumn[] = []) {
 			const db = knex.default({ client: MockClient });
 			tracker = createTracker(db);
 			tracker.on.select('VERSION()').response([{ version }]);
-			tracker.on.select('information_schema').response([]);
+			tracker.on.select('information_schema').response(columns);
 			return new SchemaHelperMySQL(db);
 		}
 
@@ -186,6 +187,42 @@ describe('SchemaHelperMySQL', () => {
 
 			expect(query?.sql).not.toMatch(/column_type/i);
 			expect(query?.bindings).not.toContain('longtext');
+		});
+
+		test('only excludes longtext AND utf8mb4_bin together (a longtext with another collation still warns)', async () => {
+			const helper = setup('10.11.2-MariaDB-1:10.11.2+maria~ubu2204');
+
+			await helper.getColumnsWithInvalidCollation('directus', 'utf8mb4_general_ci');
+
+			const query = tracker.history.select.find((q) => q.sql.includes('information_schema'));
+
+			// the exclusion is a compound NOT(type AND collation), not two independent excludes,
+			// so a longtext column with a different collation is NOT filtered out
+			expect(query?.sql).toMatch(/not \([^)]*column_type[^)]*and[^)]*collation_name[^)]*\)/i);
+		});
+
+		test('detects MariaDB even with the 5.5.5- client-compat version prefix', async () => {
+			const helper = setup('5.5.5-10.11.2-MariaDB-1:10.11.2+maria~ubu2204');
+
+			await helper.getColumnsWithInvalidCollation('directus', 'utf8mb4_general_ci');
+
+			const query = tracker.history.select.find((q) => q.sql.includes('information_schema'));
+
+			expect(query?.sql).toMatch(/column_type/i);
+		});
+
+		test('returns the columns reported by the database (genuine mismatches surface)', async () => {
+			const mismatch: InvalidCollationColumn = {
+				table_name: 'articles',
+				name: 'title',
+				collation: 'latin1_swedish_ci',
+			};
+
+			const helper = setup('10.11.2-MariaDB-1:10.11.2+maria~ubu2204', [mismatch]);
+
+			const result = await helper.getColumnsWithInvalidCollation('directus', 'utf8mb4_general_ci');
+
+			expect(result).toEqual([mismatch]);
 		});
 	});
 });

--- a/api/src/database/helpers/schema/dialects/mysql.ts
+++ b/api/src/database/helpers/schema/dialects/mysql.ts
@@ -149,8 +149,12 @@ export class SchemaHelperMySQL extends SchemaHelper {
 			.modify((queryBuilder) => {
 				// MariaDB has no native JSON type; it stores JSON as LONGTEXT with the utf8mb4_bin
 				// collation, so that pairing is expected rather than a real collation mismatch.
+				// Exclude only the pairing — NOT(longtext AND utf8mb4_bin) — so a longtext column
+				// with a genuinely wrong collation (or a utf8mb4_bin non-longtext) is still reported.
 				if (isMariaDB) {
-					queryBuilder.andWhereNot({ COLUMN_TYPE: 'longtext', COLLATION_NAME: 'utf8mb4_bin' });
+					queryBuilder.andWhereNot((qb) => {
+						void qb.where({ COLUMN_TYPE: 'longtext' }).andWhere({ COLLATION_NAME: 'utf8mb4_bin' });
+					});
 				}
 			});
 	}

--- a/api/src/database/helpers/schema/dialects/mysql.ts
+++ b/api/src/database/helpers/schema/dialects/mysql.ts
@@ -3,7 +3,7 @@ import { useEnv } from '@directus/env';
 import { toArray } from '@directus/utils';
 import type { Knex } from 'knex';
 import { getDefaultIndexName } from '../../../../utils/get-default-index-name.js';
-import { type CreateIndexOptions, SchemaHelper, type SortRecord } from '../types.js';
+import { type CreateIndexOptions, type InvalidCollationColumn, SchemaHelper, type SortRecord } from '../types.js';
 
 const env = useEnv();
 let lowerCaseTableNames: number | undefined;
@@ -132,5 +132,26 @@ export class SchemaHelperMySQL extends SchemaHelper {
 		}
 
 		return collection;
+	}
+
+	override async getColumnsWithInvalidCollation(schema: string, collation: string): Promise<InvalidCollationColumn[]> {
+		const { version } = await this.knex.select(this.knex.raw('VERSION() as version')).first();
+		const isMariaDB = String(version).split('-').includes('MariaDB');
+
+		return this.knex('information_schema.columns')
+			.select<InvalidCollationColumn[]>({
+				table_name: 'TABLE_NAME',
+				name: 'COLUMN_NAME',
+				collation: 'COLLATION_NAME',
+			})
+			.where({ TABLE_SCHEMA: schema })
+			.whereNot({ COLLATION_NAME: collation })
+			.modify((queryBuilder) => {
+				// MariaDB has no native JSON type; it stores JSON as LONGTEXT with the utf8mb4_bin
+				// collation, so that pairing is expected rather than a real collation mismatch.
+				if (isMariaDB) {
+					queryBuilder.andWhereNot({ COLUMN_TYPE: 'longtext', COLLATION_NAME: 'utf8mb4_bin' });
+				}
+			});
 	}
 }

--- a/api/src/database/helpers/schema/types.ts
+++ b/api/src/database/helpers/schema/types.ts
@@ -25,6 +25,12 @@ export type CreateIndexOptions = {
 	unique?: boolean;
 };
 
+export type InvalidCollationColumn = {
+	table_name: string;
+	name: string;
+	collation: string;
+};
+
 export abstract class SchemaHelper extends DatabaseHelper {
 	isOneOfClients(clients: DatabaseClient[]): boolean {
 		return clients.includes(getDatabaseClient(this.knex));
@@ -222,5 +228,16 @@ export abstract class SchemaHelper extends DatabaseHelper {
 
 	async parseCollectionName(collection: string): Promise<string> {
 		return collection;
+	}
+
+	async getColumnsWithInvalidCollation(schema: string, collation: string): Promise<InvalidCollationColumn[]> {
+		return this.knex('information_schema.columns')
+			.select<InvalidCollationColumn[]>({
+				table_name: 'TABLE_NAME',
+				name: 'COLUMN_NAME',
+				collation: 'COLLATION_NAME',
+			})
+			.where({ TABLE_SCHEMA: schema })
+			.whereNot({ COLLATION_NAME: collation });
 	}
 }

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -348,16 +348,14 @@ async function validateDatabaseCharset(database?: Knex): Promise<void> {
 	const logger = useLogger();
 
 	if (getDatabaseClient(database) === 'mysql') {
+		const helpers = getHelpers(database);
 		const { collation } = await database.select(database.raw(`@@collation_database as collation`)).first();
 
 		const tables = await database('information_schema.tables')
 			.select({ name: 'TABLE_NAME', collation: 'TABLE_COLLATION' })
 			.where({ TABLE_SCHEMA: env['DB_DATABASE'] });
 
-		const columns = await database('information_schema.columns')
-			.select({ table_name: 'TABLE_NAME', name: 'COLUMN_NAME', collation: 'COLLATION_NAME' })
-			.where({ TABLE_SCHEMA: env['DB_DATABASE'] })
-			.whereNot({ COLLATION_NAME: collation });
+		const columns = await helpers.schema.getColumnsWithInvalidCollation(env['DB_DATABASE'] as string, collation);
 
 		const excludedTables: string[] = toArray(env['DB_EXCLUDE_TABLES']);
 


### PR DESCRIPTION
**hhh-main-stacked copy of #54** — rebased onto **#main** (`main`) for the conflict-free `hhh-main` compose stack. The isolated upstream PR #54 stays untouched for upstream submission. Always open. Integration tree: #67.

**Why on #main:** file overlap with the PRs below it in the stack (see resolution).

**Resolution applied:**
- chain base, applied on `main` — clean cherry-pick, no conflicts.

**Re-rebase recipe** (after a `main` sync, rebuild from the upstream-draft head onto the refreshed parent copy):
```
git checkout -B hhh-main-stacked-mariadb-json main
git cherry-pick origin/main..feature/mariadb-json-collation
# re-apply the resolution above, then:
git push -f origin hhh-main-stacked-mariadb-json
```