### PR TITLE
hhh-main-stacked: fix(schema): tolerate missing index/unique when disabling is_indexed/is_unique (#35)

### DIFF
--- a/.changeset/drop-index-if-exists.md
+++ b/.changeset/drop-index-if-exists.md
@@ -2,4 +2,4 @@
 '@directus/api': patch
 ---
 
-Fixed schema updates failing when disabling a field's index or unique that no longer physically exists in the database. The drop is now guarded — using each dialect's native `DROP ... IF EXISTS` where available (postgres, sqlite, cockroachdb, mssql, plus knex's `dropUniqueIfExists`) and a catalog existence check on dialects without that syntax (mysql/mariadb, oracle).
+Fixed schema updates failing when disabling a field's index or unique that no longer physically exists in the database. The drop is now guarded — using each dialect's native `DROP ... IF EXISTS` where available (postgres, sqlite, cockroachdb, mssql) and a catalog existence check on dialects without that syntax (mysql/mariadb, oracle).

--- a/.changeset/drop-index-if-exists.md
+++ b/.changeset/drop-index-if-exists.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Fixed schema updates failing when disabling a field's index or unique that no longer physically exists in the database. The drop is now guarded — using each dialect's native `DROP ... IF EXISTS` where available (postgres, sqlite, cockroachdb, mssql, plus knex's `dropUniqueIfExists`) and a catalog existence check on dialects without that syntax (mysql/mariadb, oracle).

--- a/api/src/database/helpers/schema/dialects/default.test.ts
+++ b/api/src/database/helpers/schema/dialects/default.test.ts
@@ -79,7 +79,33 @@ describe('SchemaHelperDefault', () => {
 			const query = tracker.history.select.find((q) => q.sql.includes('information_schema'));
 
 			expect(query?.sql).not.toMatch(/column_type/i);
-			expect(query?.bindings).toEqual(expect.arrayContaining(['directus', 'utf8mb4_general_ci']));
+			expect(query?.bindings).toEqual(expect.arrayContaining(['directus', 'utf8mb4_general_ci']));		});
+	});
+
+	describe('drop ... ifExists (redshift/default: plain knex drop, no existence check)', () => {
+		function makeKnex() {
+			const table = { dropIndex: vi.fn(), dropUnique: vi.fn() };
+			const alterTable = vi.fn(async (_table: string, cb: (t: typeof table) => void) => cb(table));
+			const knex = { schema: { alterTable } } as unknown as Knex;
+			return { knex, table, alterTable };
+		}
+
+		test('dropUniqueIfExists drops the unique constraint unconditionally', async () => {
+			const { helper } = createHelper();
+			const { knex, table } = makeKnex();
+
+			await helper.dropUniqueIfExists(knex, 'users', 'email');
+
+			expect(table.dropUnique).toHaveBeenCalledWith(['email'], expect.stringMatching(/unique/));
+		});
+
+		test('dropIndexIfExists drops the index unconditionally', async () => {
+			const { helper } = createHelper();
+			const { knex, table } = makeKnex();
+
+			await helper.dropIndexIfExists(knex, 'users', 'email');
+
+			expect(table.dropIndex).toHaveBeenCalledWith(['email'], expect.stringMatching(/index/));
 		});
 	});
 });

--- a/api/src/database/helpers/schema/dialects/default.ts
+++ b/api/src/database/helpers/schema/dialects/default.ts
@@ -1,3 +1,22 @@
+import type { Knex } from 'knex';
 import { SchemaHelper } from '../types.js';
 
-export class SchemaHelperDefault extends SchemaHelper {}
+export class SchemaHelperDefault extends SchemaHelper {
+	// Redshift has no DROP ... IF EXISTS syntax and no real secondary indexes; knex's native
+	// dropUniqueIfExists throws on redshift. Fall back to the plain drops (pre-#35 behavior).
+	override async dropUniqueIfExists(knex: Knex, collection: string, field: string): Promise<void> {
+		const constraintName = this.generateIndexName('unique', collection, field);
+
+		await knex.schema.alterTable(collection, (table) => {
+			table.dropUnique([field], constraintName);
+		});
+	}
+
+	override async dropIndexIfExists(knex: Knex, collection: string, field: string): Promise<void> {
+		const indexName = this.generateIndexName('index', collection, field);
+
+		await knex.schema.alterTable(collection, (table) => {
+			table.dropIndex([field], indexName);
+		});
+	}
+}

--- a/api/src/database/helpers/schema/dialects/default.ts
+++ b/api/src/database/helpers/schema/dialects/default.ts
@@ -2,8 +2,9 @@ import type { Knex } from 'knex';
 import { SchemaHelper } from '../types.js';
 
 export class SchemaHelperDefault extends SchemaHelper {
-	// Redshift has no DROP ... IF EXISTS syntax and no real secondary indexes; knex's native
-	// dropUniqueIfExists throws on redshift. Fall back to the plain drops (pre-#35 behavior).
+	// Redshift has no DROP ... IF EXISTS syntax and no real secondary indexes, so the base class's
+	// DROP CONSTRAINT IF EXISTS / DROP INDEX IF EXISTS don't apply. Fall back to the plain knex
+	// drops (pre-#35 behavior).
 	override async dropUniqueIfExists(knex: Knex, collection: string, field: string): Promise<void> {
 		const constraintName = this.generateIndexName('unique', collection, field);
 

--- a/api/src/database/helpers/schema/dialects/mssql.test.ts
+++ b/api/src/database/helpers/schema/dialects/mssql.test.ts
@@ -189,4 +189,13 @@ describe('SchemaHelperMSSQL', () => {
 			'my_custom_column',
 		]);
 	});
+
+	test('dropIndexIfExists emits DROP INDEX IF EXISTS ... ON <table>', async () => {
+		const { helper } = createHelper();
+		const knex = { raw: vi.fn() } as unknown as Knex;
+
+		await helper.dropIndexIfExists(knex, 'users', 'email');
+
+		expect(knex.raw).toHaveBeenCalledWith('DROP INDEX IF EXISTS ?? ON ??', ['users_email_index', 'users']);
+	});
 });

--- a/api/src/database/helpers/schema/dialects/mssql.ts
+++ b/api/src/database/helpers/schema/dialects/mssql.ts
@@ -12,6 +12,14 @@ export class SchemaHelperMSSQL extends SchemaHelper {
 		return getDefaultIndexName(type, collection, fields, { maxLength: 128 });
 	}
 
+	// SQL Server's DROP INDEX requires the table: DROP INDEX [IF EXISTS] name ON table.
+	// dropUniqueIfExists inherits the base (knex emits the correct mssql constraint drop).
+	override async dropIndexIfExists(knex: Knex, collection: string, field: string): Promise<void> {
+		const indexName = this.generateIndexName('index', collection, field);
+
+		await knex.raw('DROP INDEX IF EXISTS ?? ON ??', [indexName, collection]);
+	}
+
 	override applyLimit(rootQuery: Knex.QueryBuilder, limit: number): void {
 		// The ORDER BY clause is invalid in views, inline functions, derived tables, subqueries,
 		// and common table expressions, unless TOP, OFFSET or FOR XML is also specified.

--- a/api/src/database/helpers/schema/dialects/mssql.ts
+++ b/api/src/database/helpers/schema/dialects/mssql.ts
@@ -13,7 +13,8 @@ export class SchemaHelperMSSQL extends SchemaHelper {
 	}
 
 	// SQL Server's DROP INDEX requires the table: DROP INDEX [IF EXISTS] name ON table.
-	// dropUniqueIfExists inherits the base (knex emits the correct mssql constraint drop).
+	// dropUniqueIfExists inherits the base — SQL Server 2016+ accepts ALTER TABLE ... DROP
+	// CONSTRAINT IF EXISTS unchanged.
 	override async dropIndexIfExists(knex: Knex, collection: string, field: string): Promise<void> {
 		const indexName = this.generateIndexName('index', collection, field);
 

--- a/api/src/database/helpers/schema/dialects/mysql.test.ts
+++ b/api/src/database/helpers/schema/dialects/mysql.test.ts
@@ -222,7 +222,48 @@ describe('SchemaHelperMySQL', () => {
 
 			const result = await helper.getColumnsWithInvalidCollation('directus', 'utf8mb4_general_ci');
 
-			expect(result).toEqual([mismatch]);
+			expect(result).toEqual([mismatch]);		});
+	});
+
+	describe('drop ... ifExists (catalog-gated, no native IF EXISTS on mysql)', () => {
+		function makeKnex(indexRow: unknown) {
+			const first = vi.fn().mockResolvedValue(indexRow);
+			const qb = { select: vi.fn(), from: vi.fn(), whereRaw: vi.fn(), andWhere: vi.fn(), first };
+			qb.select.mockReturnValue(qb);
+			qb.from.mockReturnValue(qb);
+			qb.whereRaw.mockReturnValue(qb);
+			qb.andWhere.mockReturnValue(qb);
+			const table = { dropIndex: vi.fn(), dropUnique: vi.fn() };
+			const alterTable = vi.fn(async (_table: string, cb: (t: typeof table) => void) => cb(table));
+			const knex = { select: qb.select, schema: { alterTable } } as unknown as Knex;
+			return { knex, table, alterTable };
+		}
+
+		test('dropIndexIfExists drops the index when it exists in the catalog', async () => {
+			const { helper } = createHelper();
+			const { knex, table } = makeKnex({ index_name: 'users_email_index' });
+
+			await helper.dropIndexIfExists(knex, 'users', 'email');
+
+			expect(table.dropIndex).toHaveBeenCalledWith(['email'], 'users_email_index');
+		});
+
+		test('dropIndexIfExists is a no-op when the index is missing', async () => {
+			const { helper } = createHelper();
+			const { knex, alterTable } = makeKnex(undefined);
+
+			await helper.dropIndexIfExists(knex, 'users', 'email');
+
+			expect(alterTable).not.toHaveBeenCalled();
+		});
+
+		test('dropUniqueIfExists drops the unique constraint when it exists', async () => {
+			const { helper } = createHelper();
+			const { knex, table } = makeKnex({ index_name: 'users_email_unique' });
+
+			await helper.dropUniqueIfExists(knex, 'users', 'email');
+
+			expect(table.dropUnique).toHaveBeenCalledWith(['email'], 'users_email_unique');
 		});
 	});
 });

--- a/api/src/database/helpers/schema/dialects/mysql.test.ts
+++ b/api/src/database/helpers/schema/dialects/mysql.test.ts
@@ -265,5 +265,14 @@ describe('SchemaHelperMySQL', () => {
 
 			expect(table.dropUnique).toHaveBeenCalledWith(['email'], 'users_email_unique');
 		});
+
+		test('dropUniqueIfExists is a no-op when the constraint is missing', async () => {
+			const { helper } = createHelper();
+			const { knex, alterTable } = makeKnex(undefined);
+
+			await helper.dropUniqueIfExists(knex, 'users', 'email');
+
+			expect(alterTable).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/api/src/database/helpers/schema/dialects/mysql.ts
+++ b/api/src/database/helpers/schema/dialects/mysql.ts
@@ -17,6 +17,40 @@ export class SchemaHelperMySQL extends SchemaHelper {
 		return getDefaultIndexName(type, collection, fields, { maxLength: 64 });
 	}
 
+	// MySQL has no DROP ... IF EXISTS for indexes/constraints (and MariaDB rides this same client),
+	// so check the catalog first. Unique constraints and plain indexes both surface in
+	// information_schema.statistics, so one lookup serves both drops below.
+	private async hasIndex(knex: Knex, collection: string, indexName: string): Promise<boolean> {
+		const result = await knex
+			.select('index_name')
+			.from('information_schema.statistics')
+			.whereRaw('table_schema = database()')
+			.andWhere({ table_name: collection, index_name: indexName })
+			.first();
+
+		return Boolean(result);
+	}
+
+	override async dropUniqueIfExists(knex: Knex, collection: string, field: string): Promise<void> {
+		const constraintName = this.generateIndexName('unique', collection, field);
+
+		if (await this.hasIndex(knex, collection, constraintName)) {
+			await knex.schema.alterTable(collection, (table) => {
+				table.dropUnique([field], constraintName);
+			});
+		}
+	}
+
+	override async dropIndexIfExists(knex: Knex, collection: string, field: string): Promise<void> {
+		const indexName = this.generateIndexName('index', collection, field);
+
+		if (await this.hasIndex(knex, collection, indexName)) {
+			await knex.schema.alterTable(collection, (table) => {
+				table.dropIndex([field], indexName);
+			});
+		}
+	}
+
 	override async changePrimaryKey(table: string, to: string | string[]): Promise<void> {
 		const primaryColumns = toArray(to);
 		const placeholders = primaryColumns.map(() => '??').join(', ');

--- a/api/src/database/helpers/schema/dialects/oracle.test.ts
+++ b/api/src/database/helpers/schema/dialects/oracle.test.ts
@@ -133,5 +133,14 @@ describe('SchemaHelperOracle', () => {
 
 			expect(table.dropUnique).toHaveBeenCalledWith(['email'], 'users_email_unique');
 		});
+
+		test('dropUniqueIfExists is a no-op when the constraint is missing', async () => {
+			const { helper } = createHelper();
+			const { knex, alterTable } = makeKnex(undefined);
+
+			await helper.dropUniqueIfExists(knex, 'users', 'email');
+
+			expect(alterTable).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/api/src/database/helpers/schema/dialects/oracle.test.ts
+++ b/api/src/database/helpers/schema/dialects/oracle.test.ts
@@ -93,4 +93,45 @@ describe('SchemaHelperOracle', () => {
 			'my_custom_column',
 		]);
 	});
+
+	describe('drop ... ifExists (catalog-gated, no native IF EXISTS on oracle)', () => {
+		function makeKnex(indexRow: unknown) {
+			const first = vi.fn().mockResolvedValue(indexRow);
+			const qb = { select: vi.fn(), from: vi.fn(), where: vi.fn(), first };
+			qb.select.mockReturnValue(qb);
+			qb.from.mockReturnValue(qb);
+			qb.where.mockReturnValue(qb);
+			const table = { dropIndex: vi.fn(), dropUnique: vi.fn() };
+			const alterTable = vi.fn(async (_table: string, cb: (t: typeof table) => void) => cb(table));
+			const knex = { select: qb.select, schema: { alterTable } } as unknown as Knex;
+			return { knex, table, alterTable };
+		}
+
+		test('dropIndexIfExists drops the index when user_indexes lists it', async () => {
+			const { helper } = createHelper();
+			const { knex, table } = makeKnex({ index_name: 'users_email_index' });
+
+			await helper.dropIndexIfExists(knex, 'users', 'email');
+
+			expect(table.dropIndex).toHaveBeenCalledWith(['email'], 'users_email_index');
+		});
+
+		test('dropIndexIfExists is a no-op when the index is missing', async () => {
+			const { helper } = createHelper();
+			const { knex, alterTable } = makeKnex(undefined);
+
+			await helper.dropIndexIfExists(knex, 'users', 'email');
+
+			expect(alterTable).not.toHaveBeenCalled();
+		});
+
+		test('dropUniqueIfExists drops the unique constraint when it exists', async () => {
+			const { helper } = createHelper();
+			const { knex, table } = makeKnex({ index_name: 'users_email_unique' });
+
+			await helper.dropUniqueIfExists(knex, 'users', 'email');
+
+			expect(table.dropUnique).toHaveBeenCalledWith(['email'], 'users_email_unique');
+		});
+	});
 });

--- a/api/src/database/helpers/schema/dialects/oracle.ts
+++ b/api/src/database/helpers/schema/dialects/oracle.ts
@@ -27,6 +27,35 @@ export class SchemaHelperOracle extends SchemaHelper {
 		return indexName;
 	}
 
+	// Oracle has no DROP ... IF EXISTS for indexes/constraints, so check the catalog first.
+	// knex quotes identifiers on creation, so the name is stored case-sensitively as generated;
+	// a unique constraint's backing index shares the name, so user_indexes covers both drops.
+	private async hasIndex(knex: Knex, indexName: string): Promise<boolean> {
+		const result = await knex.select('index_name').from('user_indexes').where({ index_name: indexName }).first();
+
+		return Boolean(result);
+	}
+
+	override async dropUniqueIfExists(knex: Knex, collection: string, field: string): Promise<void> {
+		const constraintName = this.generateIndexName('unique', collection, field);
+
+		if (await this.hasIndex(knex, constraintName)) {
+			await knex.schema.alterTable(collection, (table) => {
+				table.dropUnique([field], constraintName);
+			});
+		}
+	}
+
+	override async dropIndexIfExists(knex: Knex, collection: string, field: string): Promise<void> {
+		const indexName = this.generateIndexName('index', collection, field);
+
+		if (await this.hasIndex(knex, indexName)) {
+			await knex.schema.alterTable(collection, (table) => {
+				table.dropIndex([field], indexName);
+			});
+		}
+	}
+
 	override async changeToType(
 		table: string,
 		column: string,

--- a/api/src/database/helpers/schema/dialects/postgres.test.ts
+++ b/api/src/database/helpers/schema/dialects/postgres.test.ts
@@ -102,15 +102,15 @@ describe('SchemaHelperPostgres', () => {
 		expect(knex.raw).toHaveBeenCalledWith('DROP INDEX IF EXISTS ??', ['users_email_index']);
 	});
 
-	test('dropUniqueIfExists uses knex native dropUniqueIfExists', async () => {
+	test('dropUniqueIfExists emits ALTER TABLE DROP CONSTRAINT IF EXISTS', async () => {
 		const { helper } = createHelper();
-		const table = { dropUniqueIfExists: vi.fn() };
-		const alterTable = vi.fn(async (_table: string, cb: (t: typeof table) => void) => cb(table));
-		const knex = { schema: { alterTable } } as unknown as Knex;
+		const knex = { raw: vi.fn() } as unknown as Knex;
 
 		await helper.dropUniqueIfExists(knex, 'users', 'email');
 
-		expect(alterTable).toHaveBeenCalledWith('users', expect.any(Function));
-		expect(table.dropUniqueIfExists).toHaveBeenCalledWith(['email'], 'users_email_unique');
+		expect(knex.raw).toHaveBeenCalledWith('ALTER TABLE ?? DROP CONSTRAINT IF EXISTS ??', [
+			'users',
+			'users_email_unique',
+		]);
 	});
 });

--- a/api/src/database/helpers/schema/dialects/postgres.test.ts
+++ b/api/src/database/helpers/schema/dialects/postgres.test.ts
@@ -92,4 +92,25 @@ describe('SchemaHelperPostgres', () => {
 			'my_custom_column',
 		]);
 	});
+
+	test('dropIndexIfExists emits DROP INDEX IF EXISTS', async () => {
+		const { helper } = createHelper();
+		const knex = { raw: vi.fn() } as unknown as Knex;
+
+		await helper.dropIndexIfExists(knex, 'users', 'email');
+
+		expect(knex.raw).toHaveBeenCalledWith('DROP INDEX IF EXISTS ??', ['users_email_index']);
+	});
+
+	test('dropUniqueIfExists uses knex native dropUniqueIfExists', async () => {
+		const { helper } = createHelper();
+		const table = { dropUniqueIfExists: vi.fn() };
+		const alterTable = vi.fn(async (_table: string, cb: (t: typeof table) => void) => cb(table));
+		const knex = { schema: { alterTable } } as unknown as Knex;
+
+		await helper.dropUniqueIfExists(knex, 'users', 'email');
+
+		expect(alterTable).toHaveBeenCalledWith('users', expect.any(Function));
+		expect(table.dropUniqueIfExists).toHaveBeenCalledWith(['email'], 'users_email_unique');
+	});
 });

--- a/api/src/database/helpers/schema/dialects/sqlite.test.ts
+++ b/api/src/database/helpers/schema/dialects/sqlite.test.ts
@@ -65,4 +65,22 @@ describe('SchemaHelperSQLite', () => {
 			'name',
 		]);
 	});
+
+	test('dropUniqueIfExists drops the backing index (no DROP CONSTRAINT in SQLite)', async () => {
+		const { helper } = createHelper();
+		const knex = { raw: vi.fn() } as unknown as Knex;
+
+		await helper.dropUniqueIfExists(knex, 'users', 'email');
+
+		expect(knex.raw).toHaveBeenCalledWith('DROP INDEX IF EXISTS ??', ['users_email_unique']);
+	});
+
+	test('dropIndexIfExists emits DROP INDEX IF EXISTS (inherited base)', async () => {
+		const { helper } = createHelper();
+		const knex = { raw: vi.fn() } as unknown as Knex;
+
+		await helper.dropIndexIfExists(knex, 'users', 'email');
+
+		expect(knex.raw).toHaveBeenCalledWith('DROP INDEX IF EXISTS ??', ['users_email_index']);
+	});
 });

--- a/api/src/database/helpers/schema/dialects/sqlite.ts
+++ b/api/src/database/helpers/schema/dialects/sqlite.ts
@@ -1,3 +1,4 @@
+import type { Knex } from 'knex';
 import { getDefaultIndexName } from '../../../../utils/get-default-index-name.js';
 import { SchemaHelper } from '../types.js';
 
@@ -8,6 +9,14 @@ export class SchemaHelperSQLite extends SchemaHelper {
 		fields: string | string[],
 	): string {
 		return getDefaultIndexName(type, collection, fields, { maxLength: Infinity });
+	}
+
+	// SQLite has no ALTER TABLE ... DROP CONSTRAINT; a unique is backed by a unique index, so drop
+	// the index instead of the base class's DROP CONSTRAINT IF EXISTS.
+	override async dropUniqueIfExists(knex: Knex, collection: string, field: string): Promise<void> {
+		const constraintName = this.generateIndexName('unique', collection, field);
+
+		await knex.raw('DROP INDEX IF EXISTS ??', [constraintName]);
 	}
 
 	override async preColumnChange(): Promise<boolean> {

--- a/api/src/database/helpers/schema/types.ts
+++ b/api/src/database/helpers/schema/types.ts
@@ -226,14 +226,24 @@ export abstract class SchemaHelper extends DatabaseHelper {
 		return this.knex.raw(`CREATE ${isUnique ? 'UNIQUE ' : ''}INDEX ?? ON ?? (??)`, [constraintName, collection, field]);
 	}
 
-	// Default uses knex's native dropUniqueIfExists (postgres / sqlite / cockroachdb / mssql).
-	// mysql + oracle have no DROP ... IF EXISTS syntax and override with an existence check.
+	// Emit the DB-native DROP CONSTRAINT IF EXISTS directly rather than knex's native
+	// table.dropUniqueIfExists. The native method only exists on knex >= 3.2, and bumping to it
+	// is not worth the regression it brings:
+	//
+	// - knex 3.2.10 (PR #6392, "Properly Escape Aliases in Analytic Functions") now wraps a
+	//   window-function alias through formatter.wrap. Directus pre-wraps its `directus_row_number`
+	//   alias via knex.ref(...).toQuery() in run-ast/get-db-query.ts, so 3.2.x double-escapes it
+	//   (e.g. `as ""directus_row_number""`) and every deep o2m/m2m sort 500s on all dialects.
+	// - So we stay on knex 3.1.x and hand-roll the conditional drop, the same way dropIndexIfExists
+	//   below already does.
+	//
+	// Coverage: postgres / cockroachdb (and mssql 2016+) accept DROP CONSTRAINT IF EXISTS; sqlite
+	// backs uniques with an index and overrides; mysql + oracle lack the syntax and override with a
+	// catalog existence check.
 	async dropUniqueIfExists(knex: Knex, collection: string, field: string): Promise<void> {
 		const constraintName = this.generateIndexName('unique', collection, field);
 
-		await knex.schema.alterTable(collection, (table) => {
-			table.dropUniqueIfExists([field], constraintName);
-		});
+		await knex.raw('ALTER TABLE ?? DROP CONSTRAINT IF EXISTS ??', [collection, constraintName]);
 	}
 
 	// knex has no dropIndexIfExists for plain indexes on any dialect, so emit the DB-native

--- a/api/src/database/helpers/schema/types.ts
+++ b/api/src/database/helpers/schema/types.ts
@@ -226,6 +226,25 @@ export abstract class SchemaHelper extends DatabaseHelper {
 		return this.knex.raw(`CREATE ${isUnique ? 'UNIQUE ' : ''}INDEX ?? ON ?? (??)`, [constraintName, collection, field]);
 	}
 
+	// Default uses knex's native dropUniqueIfExists (postgres / sqlite / cockroachdb / mssql).
+	// mysql + oracle have no DROP ... IF EXISTS syntax and override with an existence check.
+	async dropUniqueIfExists(knex: Knex, collection: string, field: string): Promise<void> {
+		const constraintName = this.generateIndexName('unique', collection, field);
+
+		await knex.schema.alterTable(collection, (table) => {
+			table.dropUniqueIfExists([field], constraintName);
+		});
+	}
+
+	// knex has no dropIndexIfExists for plain indexes on any dialect, so emit the DB-native
+	// IF EXISTS directly (postgres / sqlite / cockroachdb). mssql needs ON <table>; mysql + oracle
+	// lack the syntax and override with an existence check.
+	async dropIndexIfExists(knex: Knex, collection: string, field: string): Promise<void> {
+		const indexName = this.generateIndexName('index', collection, field);
+
+		await knex.raw('DROP INDEX IF EXISTS ??', [indexName]);
+	}
+
 	async parseCollectionName(collection: string): Promise<string> {
 		return collection;
 	}

--- a/api/src/database/helpers/schema/types.ts
+++ b/api/src/database/helpers/schema/types.ts
@@ -239,6 +239,8 @@ export abstract class SchemaHelper extends DatabaseHelper {
 	// knex has no dropIndexIfExists for plain indexes on any dialect, so emit the DB-native
 	// IF EXISTS directly (postgres / sqlite / cockroachdb). mssql needs ON <table>; mysql + oracle
 	// lack the syntax and override with an existence check.
+	// Proposed upstream as a native conditional sibling of dropIndex — https://github.com/knex/knex/issues/6467
+	// If it lands, the native-IF-EXISTS branches here + in mssql collapse onto table.dropIndexIfExists(...).
 	async dropIndexIfExists(knex: Knex, collection: string, field: string): Promise<void> {
 		const indexName = this.generateIndexName('index', collection, field);
 

--- a/api/src/services/fields.test.ts
+++ b/api/src/services/fields.test.ts
@@ -77,6 +77,8 @@ vi.mock('../utils/should-clear-cache.js', () => ({
 }));
 
 const mockCreateIndexSpy = vi.fn().mockResolvedValue(undefined);
+const mockDropUniqueIfExistsSpy = vi.fn().mockResolvedValue(undefined);
+const mockDropIndexIfExistsSpy = vi.fn().mockResolvedValue(undefined);
 
 // Expose a mutable flag so individual tests can toggle the MSSQL client simulation
 let mockIsOneOfClientsMSSQL = false;
@@ -85,6 +87,8 @@ vi.mock('../database/helpers/index.js', () => ({
 	getHelpers: vi.fn(() => ({
 		schema: {
 			createIndex: mockCreateIndexSpy,
+			dropUniqueIfExists: mockDropUniqueIfExistsSpy,
+			dropIndexIfExists: mockDropIndexIfExistsSpy,
 			processFieldType: vi.fn((field) => field.type),
 			preColumnChange: vi.fn().mockResolvedValue(true),
 			postColumnChange: vi.fn().mockResolvedValue(undefined),
@@ -667,6 +671,67 @@ describe('Integration Tests', () => {
 				await service.updateField('test_collection', field);
 
 				expect(createOneSpy).toHaveBeenCalled();
+			});
+
+			test('drops a toggled-off unique/index through the schema helpers (tolerant of a missing one)', async () => {
+				mockDropUniqueIfExistsSpy.mockClear();
+				mockDropIndexIfExistsSpy.mockClear();
+
+				const service = new FieldsService({
+					knex: db,
+					schema,
+					accountability: null,
+				});
+
+				const baseColumn = {
+					name: 'name',
+					table: 'test_collection',
+					data_type: 'varchar',
+					default_value: null,
+					max_length: 255,
+					numeric_precision: null,
+					numeric_scale: null,
+					is_generated: false,
+					generation_expression: null,
+					is_nullable: true,
+					is_primary_key: false,
+					has_auto_increment: false,
+					foreign_key_column: null,
+					foreign_key_table: null,
+				};
+
+				// existing column currently has both a unique constraint and an index
+				vi.spyOn(service, 'columnInfo').mockResolvedValue({
+					...baseColumn,
+					is_unique: true,
+					is_indexed: true,
+				} as any);
+
+				// isolate the drop dispatch from the real DDL builder
+				vi.spyOn(service as any, 'addColumnToTable').mockReturnValue(undefined);
+				db.schema.alterTable = vi.fn(async (_collection: string, cb: (t: any) => void) => cb({})) as any;
+
+				tracker.on.select('directus_fields').response([]);
+
+				const field: Field = {
+					collection: 'test_collection',
+					field: 'name',
+					type: 'string',
+					schema: {
+						...baseColumn,
+						is_unique: false,
+						is_indexed: false,
+					} as any,
+					meta: null,
+					name: '',
+				};
+
+				// the helper spies resolve undefined (the missing-index case): the update must still succeed
+				await expect(service.updateField('test_collection', field)).resolves.not.toThrow();
+
+				// trx === knex under mockTransaction
+				expect(mockDropUniqueIfExistsSpy).toHaveBeenCalledWith(db, 'test_collection', 'name');
+				expect(mockDropIndexIfExistsSpy).toHaveBeenCalledWith(db, 'test_collection', 'name');
 			});
 		});
 

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -571,6 +571,17 @@ export class FieldsService {
 									attemptConcurrentIndex,
 								});
 							});
+
+							// Drop a unique/index that was toggled off. Guarded against the index not
+							// physically existing (#35) — Directus decides from its own metadata, so a
+							// missing/renamed index would otherwise throw and fail the whole update.
+							if (field.schema?.is_unique === false && existingColumn?.is_unique === true) {
+								await this.helpers.schema.dropUniqueIfExists(trx, collection, field.field);
+							}
+
+							if (field.schema?.is_indexed === false && existingColumn?.is_indexed === true) {
+								await this.helpers.schema.dropIndexIfExists(trx, collection, field.field);
+							}
 						});
 
 						// concurrent index creation cannot be done inside the transaction
@@ -1001,17 +1012,18 @@ export class FieldsService {
 				if ((!existing || existing.is_unique === false) && !options?.attemptConcurrentIndex) {
 					column.unique({ indexName: this.helpers.schema.generateIndexName('unique', collection, field.field) });
 				}
-			} else if (field.schema?.is_unique === false && existing?.is_unique === true) {
-				table.dropUnique([field.field], this.helpers.schema.generateIndexName('unique', collection, field.field));
 			}
 
 			if (field.schema?.is_indexed === true) {
 				if ((!existing || existing.is_indexed === false) && !options?.attemptConcurrentIndex) {
 					column.index(this.helpers.schema.generateIndexName('index', collection, field.field));
 				}
-			} else if (field.schema?.is_indexed === false && existing?.is_indexed === true) {
-				table.dropIndex([field.field], this.helpers.schema.generateIndexName('index', collection, field.field));
 			}
+
+			// Dropping an existing unique/index when toggled off is handled in updateField via
+			// helpers.schema.dropUniqueIfExists / dropIndexIfExists. It needs an async existence
+			// check on dialects without native IF EXISTS, which can't run inside this synchronous
+			// alterTable builder.
 		}
 
 		if (existing) {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -235,7 +235,7 @@ catalog:
   jsonschema: 1.5.0
   jsonwebtoken: 9.0.3
   keyv: 5.5.3
-  knex: 3.1.0
+  knex: 3.2.10
   knex-mock-client: 3.0.2
   ky: 1.14.0
   ldapts: 8.1.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -235,7 +235,7 @@ catalog:
   jsonschema: 1.5.0
   jsonwebtoken: 9.0.3
   keyv: 5.5.3
-  knex: 3.2.10
+  knex: 3.1.0
   knex-mock-client: 3.0.2
   ky: 1.14.0
   ldapts: 8.1.3


### PR DESCRIPTION
**hhh-main-stacked copy of #48** — rebased onto **#54** (`hhh-main-stacked-mariadb-json`) for the conflict-free `hhh-main` compose stack. The isolated upstream PR #48 stays untouched for upstream submission. Always open. Integration tree: #67.

**Why on #54:** file overlap with the PRs below it in the stack (see resolution).

**Resolution applied:**
- `schema/dialects/{default,mysql}.test.ts`: kept BOTH describe blocks (#54's `getColumnsWithInvalidCollation` + this PR's `drop … ifExists`).
- `pnpm-lock.yaml`: kept main's lock (dropped this branch's stale knex 3.2 re-add; main pins knex 3.1).

**Re-rebase recipe** (after a `main` sync, rebuild from the upstream-draft head onto the refreshed parent copy):
```
git checkout -B hhh-main-stacked-drop-index hhh-main-stacked-mariadb-json
git cherry-pick origin/main..feature/drop-index-if-exists
# re-apply the resolution above, then:
git push -f origin hhh-main-stacked-drop-index
```