### PR TITLE
hhh-main-stacked: feat(items): skip no-op item updates (#36)

### DIFF
--- a/.changeset/skip-noop-item-updates.md
+++ b/.changeset/skip-noop-item-updates.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+'@directus/constants': patch
+---
+
+Skip item updates that have nothing to write — when the payload is empty, contains only the primary key, is cleared by an `items.update` filter hook, or reduces a nested relation to an all-empty `{ create, update, delete }`, the update now short-circuits and returns `[]` instead of running a no-op transaction, avoiding needless activity/revision rows and integrity checks. A bare empty relational array (e.g. `translations: []`) is intentionally **not** treated as a no-op, since for o2m it means "remove all existing children". A filter hook that clears the payload to `null` now raises `InvalidPayloadError` rather than silently no-op'ing — cancelling a mutation is a separate, opt-in capability (`allowFilterCancel`). Adds the `ALTERATIONS_KEYS` constant (`['create', 'update', 'delete']`, the keys of the `Alterations` type) to `@directus/constants`.

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -1,10 +1,12 @@
 import { VERSION_KEY_PUBLISHED, VERSION_KEY_PUBLISHED_LEGACY } from '@directus/constants';
+import { InvalidPayloadError } from '@directus/errors';
 import { SchemaBuilder } from '@directus/schema-builder';
 import { type Accountability, UserIntegrityCheckFlag } from '@directus/types';
 import knex, { type Knex } from 'knex';
 import { createTracker, MockClient, Tracker } from 'knex-mock-client';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, type MockedFunction, test, vi } from 'vitest';
 import { getDatabaseClient } from '../database/index.js';
+import emitter from '../emitter.js';
 import { validateUserCountIntegrity } from '../utils/validate-user-count-integrity.js';
 import { handleVersion } from '../utils/versioning/handle-version.js';
 import { ActivityService } from './activity.js';
@@ -25,6 +27,11 @@ const schema = new SchemaBuilder()
 		c.field('status').string();
 		c.field('sort').integer().sort();
 		c.field('name').string();
+		c.field('children').o2m('children', 'parent_id');
+	})
+	.collection('children', (c) => {
+		c.field('id').id();
+		c.field('parent_id').m2o('test');
 	})
 	.collection('directus_versions', (c) => {
 		c.field('id').id();
@@ -45,6 +52,7 @@ describe('Integration Tests', () => {
 
 	beforeEach(() => {
 		tracker.on.any('test').response({});
+		tracker.on.any('children').response([]);
 	});
 
 	afterEach(() => {
@@ -194,10 +202,78 @@ describe('Integration Tests', () => {
 		});
 
 		describe('updateMany', () => {
-			it('should validate user count if requested', async () => {
-				await service.updateMany([1], {}, { userIntegrityCheckFlags: UserIntegrityCheckFlag.All });
+			it('should run the update and validate user count for a non-empty payload', async () => {
+				await service.updateMany([1], { name: 'test' }, { userIntegrityCheckFlags: UserIntegrityCheckFlag.All });
 
 				expect(validateUserCountIntegrity).toHaveBeenCalled();
+				// a real write opens a transaction and issues the update query
+				expect(tracker.history.all.length).toBeGreaterThan(0);
+			});
+
+			it('should skip the update and not validate user count when the payload is empty', async () => {
+				const keys = await service.updateMany([1], {}, { userIntegrityCheckFlags: UserIntegrityCheckFlag.All });
+
+				expect(keys).toEqual([]);
+				expect(validateUserCountIntegrity).not.toHaveBeenCalled();
+				expect(tracker.history.all).toHaveLength(0);
+			});
+
+			it('should skip the update when the payload only contains the primary key', async () => {
+				const keys = await service.updateMany([1], { id: 1 }, { userIntegrityCheckFlags: UserIntegrityCheckFlag.All });
+
+				expect(keys).toEqual([]);
+				expect(validateUserCountIntegrity).not.toHaveBeenCalled();
+				expect(tracker.history.all).toHaveLength(0);
+			});
+
+			it('should skip the update when a nested relation is reduced to an empty alterations object', async () => {
+				const keys = await service.updateMany(
+					[1],
+					{ children: { create: [], update: [], delete: [] } },
+					{ userIntegrityCheckFlags: UserIntegrityCheckFlag.All },
+				);
+
+				expect(keys).toEqual([]);
+				expect(validateUserCountIntegrity).not.toHaveBeenCalled();
+				// no query for the parent row nor the nested relation
+				expect(tracker.history.all).toHaveLength(0);
+			});
+
+			it('should skip the update for a partial alterations object with only empty operations', async () => {
+				for (const alterations of [{ create: [] }, { update: [] }, { delete: [] }, {}]) {
+					const keys = await service.updateMany([1], { children: alterations });
+
+					expect(keys).toEqual([]);
+				}
+
+				expect(validateUserCountIntegrity).not.toHaveBeenCalled();
+				expect(tracker.history.all).toHaveLength(0);
+			});
+
+			it('should NOT skip a bare empty relational array (it removes all existing children)', async () => {
+				await service.updateMany([1], { children: [] });
+
+				// the relation is processed (children are detached/removed), so queries are issued
+				expect(tracker.history.all.length).toBeGreaterThan(0);
+			});
+
+			it('should NOT skip an alterations object that carries an operation', async () => {
+				await service.updateMany([1], { children: { create: [], update: [], delete: [5] } });
+
+				expect(tracker.history.all.length).toBeGreaterThan(0);
+			});
+
+			it('should NOT skip an object on a relational alias that is not alterations-shaped', async () => {
+				await expect(service.updateMany([1], { children: { foo: 1 } })).rejects.toThrow();
+			});
+
+			it('should throw when a filter hook clears the payload to null (cancellation is opt-in)', async () => {
+				const emitFilterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(null);
+
+				await expect(service.updateMany([1], { name: 'test' })).rejects.toThrow(InvalidPayloadError);
+				expect(tracker.history.all).toHaveLength(0);
+
+				emitFilterSpy.mockRestore();
 			});
 
 			it('should match revision snapshots to items by primary key', async () => {

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -345,6 +345,50 @@ describe('Integration Tests', () => {
 					createRevisionsSpy.mockRestore();
 				}
 			});
+
+			it('should not emit an action hook when the update is skipped as a no-op', async () => {
+				const emitActionSpy = vi.spyOn(emitter, 'emitAction');
+
+				const keys = await service.updateMany([1], {});
+
+				expect(keys).toEqual([]);
+				expect(emitActionSpy).not.toHaveBeenCalled();
+
+				emitActionSpy.mockRestore();
+			});
+
+			it('should emit an action hook for a real write (control for the skip case)', async () => {
+				const emitActionSpy = vi.spyOn(emitter, 'emitAction');
+
+				await service.updateMany([1], { name: 'test' });
+
+				expect(emitActionSpy).toHaveBeenCalled();
+
+				emitActionSpy.mockRestore();
+			});
+
+			it('should skip when a filter hook strips the only changed field down to the primary key', async () => {
+				// the decision is made on the post-hook payload, so a hook can turn a write into a no-op
+				const emitFilterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue({ id: 1 });
+
+				const keys = await service.updateMany([1], { name: 'changed' });
+
+				expect(keys).toEqual([]);
+				expect(tracker.history.all).toHaveLength(0);
+
+				emitFilterSpy.mockRestore();
+			});
+
+			it('should write when a filter hook adds a real field to a would-be no-op payload', async () => {
+				// the inverse: a PK-only payload that a hook enriches must no longer be skipped
+				const emitFilterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue({ id: 1, name: 'added' });
+
+				await service.updateMany([1], { id: 1 });
+
+				expect(tracker.history.all.length).toBeGreaterThan(0);
+
+				emitFilterSpy.mockRestore();
+			});
 		});
 
 		describe('deleteMany', () => {

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -1,4 +1,4 @@
-import { Action, isPublishedVersionKey } from '@directus/constants';
+import { Action, ALTERATIONS_KEYS, isPublishedVersionKey } from '@directus/constants';
 import { useEnv } from '@directus/env';
 import { ErrorCode, ForbiddenError, InvalidPayloadError, isDirectusError } from '@directus/errors';
 import { isSystemCollection } from '@directus/system-data';
@@ -7,6 +7,7 @@ import type {
 	AbstractServiceOptions,
 	Accountability,
 	ActionEventParams,
+	Alterations,
 	Item as AnyItem,
 	MutationOptions,
 	MutationTracker,
@@ -19,7 +20,7 @@ import { UserIntegrityCheckFlag } from '@directus/types';
 import { getRelationsForCollection } from '@directus/utils';
 import type Keyv from 'keyv';
 import type { Knex } from 'knex';
-import { assign, clone, cloneDeep, difference, omit, pick, without } from 'lodash-es';
+import { assign, clone, cloneDeep, difference, isPlainObject, omit, pick, without } from 'lodash-es';
 import { getCache } from '../cache.js';
 import { translateDatabaseError } from '../database/errors/translate.js';
 import { getAstFromQuery } from '../database/get-ast-from-query/get-ast-from-query.js';
@@ -775,6 +776,48 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 						},
 					)
 				: payload;
+
+		if (payloadAfterHooks === null) {
+			// A filter hook cleared the payload to null. Treating that as an explicit, opt-in
+			// cancellation (returning a null per key) is owned by the `allowFilterCancel` mutation
+			// option; on its own a null payload is invalid rather than a silent no-op.
+			throw new InvalidPayloadError({
+				reason: `A filter hook cancelled the update, but this operation requires it`,
+			});
+		}
+
+		const isEmptyAlterations = (value: unknown): boolean => {
+			// A bare `[]` is not empty here: for o2m it removes every existing child (see processO2M),
+			// so only the `{ create, update, delete }` object form can count as no change.
+			if (!isPlainObject(value)) return false;
+
+			const alterations = value as Partial<Alterations>;
+
+			// Guard against a JSON column that merely looks like an alterations object.
+			const isNotAlterationsShaped = Object.keys(alterations).some(
+				(key) => !ALTERATIONS_KEYS.includes(key as keyof Alterations),
+			);
+
+			if (isNotAlterationsShaped) return false;
+
+			// None of create / update / delete carries an item.
+			return ALTERATIONS_KEYS.every((operation) => !alterations[operation]?.length);
+		};
+
+		const changesNothing = (field: string): boolean => {
+			if (field === primaryKeyField) return true;
+			if (aliases.includes(field)) return isEmptyAlterations(payloadAfterHooks![field]);
+			return false;
+		};
+
+		const changedFields = Object.keys(payloadAfterHooks ?? {}).filter((field) => !changesNothing(field));
+
+		if (changedFields.length === 0) {
+			// An empty payload, a PK-only update, or a filter hook that cleared every field to an
+			// empty alterations object leaves nothing to change — skip the transaction,
+			// activity/revision rows and integrity checks.
+			return [];
+		}
 
 		// Sort keys to ensure that the order is maintained
 		keys.sort();

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -3,6 +3,7 @@ export * from './extensions.js';
 export * from './fields.js';
 export * from './files.js';
 export * from './injection.js';
+export * from './items.js';
 export * from './number.js';
 export * from './permissions.js';
 export * from './regex.js';

--- a/packages/constants/src/items.test.ts
+++ b/packages/constants/src/items.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+// Import through the package barrel so the new `export * from './items.js'` line in
+// index.ts is exercised too (otherwise it shows as an uncovered patch line).
+import { ALTERATIONS_KEYS } from './index.js';
+
+describe('ALTERATIONS_KEYS', () => {
+	it('lists the create/update/delete alteration keys in order', () => {
+		expect(ALTERATIONS_KEYS).toEqual(['create', 'update', 'delete']);
+	});
+});

--- a/packages/constants/src/items.ts
+++ b/packages/constants/src/items.ts
@@ -1,0 +1,5 @@
+/**
+ * Keys of a nested relational mutation input (the `Alterations` type in `@directus/types`):
+ * `create` new children, `update` existing children by primary key, `delete` children by primary key.
+ */
+export const ALTERATIONS_KEYS = ['create', 'update', 'delete'] as const;


### PR DESCRIPTION
**hhh-main-stacked copy of #50** — rebased onto **#60** (`hhh-main-stacked-schema-builder-alias`) for the conflict-free `hhh-main` compose stack. The isolated upstream PR #50 stays untouched for upstream submission. Always open. Integration tree: #67.

**Why on #60:** file overlap with the PRs below it in the stack (see resolution).

**Resolution applied:**
- `items.test.ts` SchemaBuilder fixture: merged — kept main's `status`/`sort`/`name` fields AND added this PR's `children` o2m + `children` collection.
- `items.test.ts` describe: kept main's `match revision snapshots` test AND this PR's no-op-skip tests (closed the prior `it` before appending).

**Re-rebase recipe** (after a `main` sync, rebuild from the upstream-draft head onto the refreshed parent copy):
```
git checkout -B hhh-main-stacked-skip-noop hhh-main-stacked-schema-builder-alias
git cherry-pick feature/schema-builder-alias-flag..feature/skip-noop-item-updates
# re-apply the resolution above, then:
git push -f origin hhh-main-stacked-skip-noop
```