### PR TITLE
hhh-main-stacked: fix(items): malformed primary key → InvalidPayloadError (400) not Forbidden (403)

### DIFF
--- a/.changeset/invalid-payload-on-bad-key.md
+++ b/.changeset/invalid-payload-on-bad-key.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+A malformed primary key on a by-key item operation — a non-uuid value for a `uuid` primary key, or a non-integer for an `integer` primary key — now raises `InvalidPayloadError` (400) instead of `ForbiddenError` (403). The key shape is validated before any access check, so a malformed key is a bad request, not an authorization failure.

--- a/api/src/utils/validate-keys.test.ts
+++ b/api/src/utils/validate-keys.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { InvalidPayloadError } from '@directus/errors';
 import { SchemaBuilder } from '@directus/schema-builder';
 import { describe, expect, it } from 'vitest';
 import { validateKeys } from './validate-keys.js';
@@ -15,13 +16,13 @@ const schema = new SchemaBuilder()
 describe('validate keys', () => {
 	describe('of integer type', () => {
 		it('Throws an error when provided with an invalid integer key', () => {
-			expect(() => validateKeys(schema, 'pk_integer', 'id', 'invalid')).toThrowError();
-			expect(() => validateKeys(schema, 'pk_integer', 'id', NaN)).toThrowError();
+			expect(() => validateKeys(schema, 'pk_integer', 'id', 'invalid')).toThrowError(InvalidPayloadError);
+			expect(() => validateKeys(schema, 'pk_integer', 'id', NaN)).toThrowError(InvalidPayloadError);
 		});
 
 		it('Throws an error when provided with an array containing an invalid integer key', () => {
-			expect(() => validateKeys(schema, 'pk_integer', 'id', [111, 'invalid', 222])).toThrowError();
-			expect(() => validateKeys(schema, 'pk_integer', 'id', [555, NaN, 666])).toThrowError();
+			expect(() => validateKeys(schema, 'pk_integer', 'id', [111, 'invalid', 222])).toThrowError(InvalidPayloadError);
+			expect(() => validateKeys(schema, 'pk_integer', 'id', [555, NaN, 666])).toThrowError(InvalidPayloadError);
 		});
 
 		it('Does not throw an error when provided with a valid integer key', () => {
@@ -37,20 +38,31 @@ describe('validate keys', () => {
 
 	describe('of uuid type', () => {
 		it('Throws an error when provided with an invalid uuid key', () => {
-			expect(() => validateKeys(schema, 'pk_uuid', 'id', 'fakeuuid-62d9-434d-a7c7-878c8376782e')).toThrowError();
-			expect(() => validateKeys(schema, 'pk_uuid', 'id', 'invalid')).toThrowError();
-			expect(() => validateKeys(schema, 'pk_uuid', 'id', NaN)).toThrowError();
-			expect(() => validateKeys(schema, 'pk_uuid', 'id', 111)).toThrowError();
+			expect(() => validateKeys(schema, 'pk_uuid', 'id', 'fakeuuid-62d9-434d-a7c7-878c8376782e')).toThrowError(
+				InvalidPayloadError,
+			);
+
+			expect(() => validateKeys(schema, 'pk_uuid', 'id', 'invalid')).toThrowError(InvalidPayloadError);
+			expect(() => validateKeys(schema, 'pk_uuid', 'id', NaN)).toThrowError(InvalidPayloadError);
+			expect(() => validateKeys(schema, 'pk_uuid', 'id', 111)).toThrowError(InvalidPayloadError);
 		});
 
 		it('Throws an error when provided with an array containing an invalid uuid key', () => {
 			expect(() =>
 				validateKeys(schema, 'pk_uuid', 'id', [randomUUID(), 'fakeuuid-62d9-434d-a7c7-878c8376782e', randomUUID()]),
-			).toThrowError();
+			).toThrowError(InvalidPayloadError);
 
-			expect(() => validateKeys(schema, 'pk_uuid', 'id', [randomUUID(), 'invalid', randomUUID()])).toThrowError();
-			expect(() => validateKeys(schema, 'pk_uuid', 'id', [randomUUID(), NaN, randomUUID()])).toThrowError();
-			expect(() => validateKeys(schema, 'pk_uuid', 'id', [randomUUID(), 111, randomUUID()])).toThrowError();
+			expect(() => validateKeys(schema, 'pk_uuid', 'id', [randomUUID(), 'invalid', randomUUID()])).toThrowError(
+				InvalidPayloadError,
+			);
+
+			expect(() => validateKeys(schema, 'pk_uuid', 'id', [randomUUID(), NaN, randomUUID()])).toThrowError(
+				InvalidPayloadError,
+			);
+
+			expect(() => validateKeys(schema, 'pk_uuid', 'id', [randomUUID(), 111, randomUUID()])).toThrowError(
+				InvalidPayloadError,
+			);
 		});
 
 		it('Does not throw an error when provided with a valid uuid key', () => {

--- a/api/src/utils/validate-keys.ts
+++ b/api/src/utils/validate-keys.ts
@@ -1,4 +1,4 @@
-import { ForbiddenError } from '@directus/errors';
+import { InvalidPayloadError } from '@directus/errors';
 import type { PrimaryKey, SchemaOverview } from '@directus/types';
 import { isValidUuid } from './is-valid-uuid.js';
 
@@ -19,9 +19,13 @@ export function validateKeys(
 		const primaryKeyFieldType = schema.collections[collection]?.fields[keyField]?.type;
 
 		if (primaryKeyFieldType === 'uuid' && !isValidUuid(String(keys))) {
-			throw new ForbiddenError();
+			throw new InvalidPayloadError({
+				reason: `Primary key of ${collection} must be a uuid instead of ${JSON.stringify(keys, null, 2)}`,
+			});
 		} else if (primaryKeyFieldType === 'integer' && !Number.isInteger(Number(keys))) {
-			throw new ForbiddenError();
+			throw new InvalidPayloadError({
+				reason: `Primary key of ${collection} must be an integer instead of ${JSON.stringify(keys, null, 2)}`,
+			});
 		}
 	}
 }


### PR DESCRIPTION
**hhh-main-stacked copy of #62** — rebased onto **#50** (`hhh-main-stacked-skip-noop`) for the conflict-free `hhh-main` compose stack. The isolated upstream PR #62 stays untouched for upstream submission. Always open. Integration tree: #67.

**Why on #50:** file overlap with the PRs below it in the stack (see resolution).

**Resolution applied:**
- applied BELOW #61 (re-ordered vs git, where #62 sat on #61): clean input fix first.
- `validate-keys.ts`: took this PR's `InvalidPayloadError` over main's `ForbiddenError` (the whole point of the PR).

**Re-rebase recipe** (after a `main` sync, rebuild from the upstream-draft head onto the refreshed parent copy):
```
git checkout -B hhh-main-stacked-invalid-payload hhh-main-stacked-skip-noop
git cherry-pick feature/forbidden-error-reasons..feature/invalid-payload-on-bad-key
# re-apply the resolution above, then:
git push -f origin hhh-main-stacked-invalid-payload
```