### PR TITLE
hhh-main-stacked: feat(items): optionally await action hooks in mutations

### DIFF
--- a/.changeset/async-emit-action.md
+++ b/.changeset/async-emit-action.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+'@directus/types': patch
+---
+
+Made `emitter.emitAction()` async so an items-service mutation can optionally wait for its action hooks to finish before resolving. Action hooks remain **fire-and-forget by default** (unchanged behaviour); pass the new `awaitActionHooks` mutation option to block a create/update/delete until its action handlers have settled — useful when a client immediately reads back a side effect a handler produces (e.g. an aggregate recompute) and would otherwise race it. A mutation's action events — the item's own plus any nested ones, and the `items`/`<collection>`-scoped variants — run in parallel, so a slow handler on one event doesn't serialize the rest. `bypassEmitAction` now also accepts an async handler. Errors thrown by action handlers are still caught and logged, not propagated.

--- a/api/src/emitter.ts
+++ b/api/src/emitter.ts
@@ -63,16 +63,24 @@ export class Emitter {
 		return updatedPayload;
 	}
 
-	public emitAction(event: string | string[], meta: Record<string, any>, context: EventContext | null = null): void {
+	public async emitAction(
+		event: string | string[],
+		meta: Record<string, any>,
+		context: EventContext | null = null,
+	): Promise<void> {
 		const logger = useLogger();
 		const events = Array.isArray(event) ? event : [event];
 
-		for (const event of events) {
-			this.actionEmitter.emitAsync(event, { event, ...meta }, context ?? this.getDefaultContext()).catch((err) => {
-				logger.warn(`An error was thrown while executing action "${event}"`);
-				logger.warn(err);
-			});
-		}
+		// Run every event's listeners in parallel and await them together, so a slow
+		// handler on one event doesn't serialize behind the others.
+		await Promise.all(
+			events.map((event) =>
+				this.actionEmitter.emitAsync(event, { event, ...meta }, context ?? this.getDefaultContext()).catch((err) => {
+					logger.warn(`An error was thrown while executing action "${event}"`);
+					logger.warn(err);
+				}),
+			),
+		);
 	}
 
 	public async emitInit(event: string, meta: Record<string, any>): Promise<void> {

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -478,5 +478,73 @@ describe('Integration Tests', () => {
 				expect(validateUserCountIntegrity).toHaveBeenCalled();
 			});
 		});
+
+		describe('action hook emission (await / bypass)', () => {
+			const macrotaskHandler = (onDone: () => void) => () =>
+				new Promise<void>((resolve) => {
+					setTimeout(() => {
+						onDone();
+						resolve();
+					}, 0);
+				});
+
+			it('still resolves when an awaited action handler throws (error caught and logged)', async () => {
+				const handler = () => Promise.reject(new Error('boom'));
+
+				emitter.onAction('test.items.create', handler);
+
+				try {
+					// emitter.emitAction swallows per-event errors, so the mutation must not reject
+					const outcome = await service.createOne({ name: 'Test' }, { awaitActionHooks: true }).then(
+						() => 'resolved',
+						() => 'rejected',
+					);
+
+					expect(outcome).toBe('resolved');
+				} finally {
+					emitter.offAction('test.items.create', handler);
+				}
+			});
+
+			it('routes action events to bypassEmitAction and skips the emitter', async () => {
+				const emitActionSpy = vi.spyOn(emitter, 'emitAction');
+				const bypassEmitAction = vi.fn().mockResolvedValue(undefined);
+
+				await service.createOne({ name: 'Test' }, { bypassEmitAction, awaitActionHooks: true });
+
+				expect(bypassEmitAction).toHaveBeenCalled();
+				expect(emitActionSpy).not.toHaveBeenCalled();
+
+				emitActionSpy.mockRestore();
+			});
+
+			it('awaits async action handlers on update when awaitActionHooks is set', async () => {
+				let actionCompleted = false;
+				const handler = macrotaskHandler(() => (actionCompleted = true));
+
+				emitter.onAction('test.items.update', handler);
+
+				try {
+					await service.updateMany([1], { name: 'test' }, { awaitActionHooks: true });
+					expect(actionCompleted).toBe(true);
+				} finally {
+					emitter.offAction('test.items.update', handler);
+				}
+			});
+
+			it('awaits async action handlers on delete when awaitActionHooks is set', async () => {
+				let actionCompleted = false;
+				const handler = macrotaskHandler(() => (actionCompleted = true));
+
+				emitter.onAction('test.items.delete', handler);
+
+				try {
+					await service.deleteMany([1], { awaitActionHooks: true });
+					expect(actionCompleted).toBe(true);
+				} finally {
+					emitter.offAction('test.items.delete', handler);
+				}
+			});
+		});
 	});
 });

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -195,6 +195,74 @@ describe('Integration Tests', () => {
 
 				transactionSpy.mockRestore();
 			});
+
+			it('awaits async action handlers before resolving when awaitActionHooks is set', async () => {
+				let actionCompleted = false;
+
+				// Resolve on a macrotask: a fire-and-forget emitAction would let createOne
+				// return before this runs, leaving actionCompleted false.
+				const handler = () =>
+					new Promise<void>((resolve) => {
+						setTimeout(() => {
+							actionCompleted = true;
+							resolve();
+						}, 0);
+					});
+
+				emitter.onAction('test.items.create', handler);
+
+				try {
+					await service.createOne({ name: 'Test' }, { awaitActionHooks: true });
+					expect(actionCompleted).toBe(true);
+				} finally {
+					emitter.offAction('test.items.create', handler);
+				}
+			});
+
+			it('does not await action handlers by default (fire-and-forget)', async () => {
+				let actionCompleted = false;
+
+				const handler = () =>
+					new Promise<void>((resolve) => {
+						setTimeout(() => {
+							actionCompleted = true;
+							resolve();
+						}, 0);
+					});
+
+				emitter.onAction('test.items.create', handler);
+
+				try {
+					await service.createOne({ name: 'Test' });
+					// Without awaitActionHooks, createOne resolves without waiting for the macrotask handler.
+					expect(actionCompleted).toBe(false);
+				} finally {
+					emitter.offAction('test.items.create', handler);
+				}
+			});
+
+			it('runs the scoped action events in parallel when awaited', async () => {
+				let signalSecondStarted!: () => void;
+				const secondStarted = new Promise<void>((resolve) => (signalSecondStarted = resolve));
+
+				// The first handler only finishes once the second has started. Run sequentially
+				// this deadlocks (the second never starts), so the test only passes when parallel.
+				const firstHandler = () => secondStarted;
+
+				const secondHandler = () => {
+					signalSecondStarted();
+				};
+
+				emitter.onAction('items.create', firstHandler);
+				emitter.onAction('test.items.create', secondHandler);
+
+				try {
+					await service.createOne({ name: 'Test' }, { awaitActionHooks: true });
+				} finally {
+					emitter.offAction('items.create', firstHandler);
+					emitter.offAction('test.items.create', secondHandler);
+				}
+			});
 		});
 
 		describe('createMany', () => {

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -40,6 +40,30 @@ import { PayloadService } from './payload.js';
 
 const env = useEnv();
 
+/**
+ * Emit a mutation's action events (the item's own event plus any queued nested ones) in parallel.
+ * They run together, so a slow handler on one event doesn't serialize the rest. By default the
+ * mutation does not wait for them (Directus' historical fire-and-forget behaviour); pass
+ * `awaitActionHooks` to block until every handler has settled.
+ */
+async function emitActionEvents(actionEvents: ActionEventParams[], opts: MutationOptions): Promise<void> {
+	const emitting = Promise.all(
+		actionEvents.map((actionEvent) =>
+			opts.bypassEmitAction
+				? opts.bypassEmitAction(actionEvent)
+				: emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context),
+		),
+	);
+
+	if (opts.awaitActionHooks) {
+		await emitting;
+	} else {
+		// Per-event errors are already caught and logged inside emitter.emitAction; swallow here so
+		// an un-awaited rejection (e.g. from a bypassEmitAction handler) doesn't go unhandled.
+		emitting.catch(() => {});
+	}
+}
+
 export class ItemsService<Item extends AnyItem = AnyItem, Collection extends string = string>
 	implements AbstractService<Item>
 {
@@ -415,19 +439,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				},
 			};
 
-			if (opts.bypassEmitAction) {
-				opts.bypassEmitAction(actionEvent);
-			} else {
-				emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context);
-			}
-
-			for (const nestedActionEvent of nestedActionEvents) {
-				if (opts.bypassEmitAction) {
-					opts.bypassEmitAction(nestedActionEvent);
-				} else {
-					emitter.emitAction(nestedActionEvent.event, nestedActionEvent.meta, nestedActionEvent.context);
-				}
-			}
+			await emitActionEvents([actionEvent, ...nestedActionEvents], opts);
 		}
 
 		if (shouldClearCache(this.cache, opts, this.collection)) {
@@ -500,13 +512,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		});
 
 		if (opts.emitEvents !== false) {
-			for (const nestedActionEvent of nestedActionEvents) {
-				if (opts.bypassEmitAction) {
-					opts.bypassEmitAction(nestedActionEvent);
-				} else {
-					emitter.emitAction(nestedActionEvent.event, nestedActionEvent.meta, nestedActionEvent.context);
-				}
-			}
+			await emitActionEvents(nestedActionEvents, opts);
 		}
 
 		if (shouldClearCache(this.cache, opts, this.collection)) {
@@ -588,7 +594,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				: records;
 
 		if (opts?.emitEvents !== false) {
-			emitter.emitAction(
+			// Read action hooks stay fire-and-forget; the await opt-in (`awaitActionHooks`) is for mutations.
+			void emitter.emitAction(
 				this.eventScope === 'items' ? ['items.read', `${this.collection}.items.read`] : `${this.eventScope}.read`,
 				{
 					payload: filteredRecords,
@@ -1041,19 +1048,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				},
 			};
 
-			if (opts.bypassEmitAction) {
-				opts.bypassEmitAction(actionEvent);
-			} else {
-				emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context);
-			}
-
-			for (const nestedActionEvent of nestedActionEvents) {
-				if (opts.bypassEmitAction) {
-					opts.bypassEmitAction(nestedActionEvent);
-				} else {
-					emitter.emitAction(nestedActionEvent.event, nestedActionEvent.meta, nestedActionEvent.context);
-				}
-			}
+			await emitActionEvents([actionEvent, ...nestedActionEvents], opts);
 		}
 
 		return keys;
@@ -1266,11 +1261,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				},
 			};
 
-			if (opts.bypassEmitAction) {
-				opts.bypassEmitAction(actionEvent);
-			} else {
-				emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context);
-			}
+			await emitActionEvents([actionEvent], opts);
 		}
 
 		return keysAfterHooks;

--- a/packages/types/src/items.ts
+++ b/packages/types/src/items.ts
@@ -67,7 +67,14 @@ export type MutationOptions = {
 	 * To bypass the emitting of action events if emitEvents is enabled
 	 * Can be used to queue up the nested events from item service's create, update and delete
 	 */
-	bypassEmitAction?: ((params: ActionEventParams) => void) | undefined;
+	bypassEmitAction?: ((params: ActionEventParams) => void) | ((params: ActionEventParams) => Promise<void>) | undefined;
+
+	/**
+	 * Await the mutation's action hooks before resolving, instead of firing them and forgetting.
+	 * Off by default (action hooks stay fire-and-forget); opt in when a client reads back a side
+	 * effect an action handler produces and would otherwise race it.
+	 */
+	awaitActionHooks?: boolean | undefined;
 
 	/**
 	 * To bypass limits so that functions would work as intended


### PR DESCRIPTION
**hhh-main-stacked copy of #58** — rebased onto **#59** (`hhh-main-stacked-filter-output-types`) for the conflict-free `hhh-main` compose stack. The isolated upstream PR #58 stays untouched for upstream submission. Always open. Integration tree: #67.

**Why on #59:** file overlap with the PRs below it in the stack (see resolution).

**Resolution applied:**
- clean cherry-pick (items.test auto-merged with the stack below).

**Re-rebase recipe** (after a `main` sync, rebuild from the upstream-draft head onto the refreshed parent copy):
```
git checkout -B hhh-main-stacked-await-action hhh-main-stacked-filter-output-types
git cherry-pick origin/main..feature/async-emit-action
# re-apply the resolution above, then:
git push -f origin hhh-main-stacked-await-action
```