### PR TITLE
hhh-main-stacked: feat(filters): typed filter output (TIn/TOut) and items.create take-over (#32)

### DIFF
--- a/.changeset/filter-cancel-create.md
+++ b/.changeset/filter-cancel-create.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': minor
+---
+
+Let an `items.create` filter take over the creation by returning a primary key. When a `*.items.create` filter returns a `string`/`number` instead of a payload, `ItemsService.createOne` short-circuits the insert and surfaces that key (e.g. dedupe to an existing row, or hand off to an external store). Builds on the typed filter output (`FilterHandler<TIn, TOut>`); a filter returning a normal payload object inserts exactly as before.

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -280,6 +280,58 @@ describe('Integration Tests', () => {
 
 				transactionSpy.mockRestore();
 			});
+
+			it('should short-circuit and return the key when a create filter returns a string primary key', async () => {
+				const emitFilterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue('abc');
+
+				const insert = vi.fn().mockReturnThis();
+
+				const transactionSpy = vi.spyOn(db, 'transaction').mockImplementation(async (callback) => {
+					return await callback({ ...db, insert } as any);
+				});
+
+				const result = await service.createOne({ name: 'Test' });
+
+				expect(result).toBe('abc');
+				expect(insert).not.toHaveBeenCalled();
+
+				transactionSpy.mockRestore();
+				emitFilterSpy.mockRestore();
+			});
+
+			it('should NOT emit an items.create action when a filter takes over the create', async () => {
+				const emitFilterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(5);
+				const emitActionSpy = vi.spyOn(emitter, 'emitAction');
+
+				const transactionSpy = vi.spyOn(db, 'transaction').mockImplementation(async (callback) => {
+					return await callback({ ...db } as any);
+				});
+
+				await service.createOne({ name: 'Test' });
+
+				// the row was never created through this service, so the action must not fire
+				expect(emitActionSpy).not.toHaveBeenCalled();
+
+				transactionSpy.mockRestore();
+				emitActionSpy.mockRestore();
+				emitFilterSpy.mockRestore();
+			});
+
+			it('should insert and emit the action normally when a filter returns a payload object (no take-over)', async () => {
+				// control case: a filter that returns the payload (not a key) leaves creation to the service
+				const emitFilterSpy = vi
+					.spyOn(emitter, 'emitFilter')
+					.mockImplementation(async (_event: any, payload: any) => payload);
+
+				const emitActionSpy = vi.spyOn(emitter, 'emitAction');
+
+				await service.createOne({ name: 'Test' });
+
+				expect(emitActionSpy).toHaveBeenCalled();
+
+				emitActionSpy.mockRestore();
+				emitFilterSpy.mockRestore();
+			});
 		});
 
 		describe('createMany', () => {

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -263,6 +263,23 @@ describe('Integration Tests', () => {
 					emitter.offAction('test.items.create', secondHandler);
 				}
 			});
+
+			it('should short-circuit and return the key when a create filter returns a primary key', async () => {
+				vi.spyOn(emitter, 'emitFilter').mockResolvedValue(5);
+
+				const insert = vi.fn().mockReturnThis();
+
+				const transactionSpy = vi.spyOn(db, 'transaction').mockImplementation(async (callback) => {
+					return await callback({ ...db, insert } as any);
+				});
+
+				const result = await service.createOne({ name: 'Test' });
+
+				expect(result).toBe(5);
+				expect(insert).not.toHaveBeenCalled();
+
+				transactionSpy.mockRestore();
+			});
 		});
 
 		describe('createMany', () => {

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -170,6 +170,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 		const payload: AnyItem = cloneDeep(data);
 		let actionHookPayload = payload;
+		let createWasTakenOver = false;
 		const nestedActionEvents: ActionEventParams[] = [];
 
 		/**
@@ -203,7 +204,10 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 			if (typeof payloadAfterHooks === 'string' || typeof payloadAfterHooks === 'number') {
 				// A filter hook returned a primary key instead of a payload: it has taken over the
-				// creation, so short-circuit and surface that key.
+				// creation, so short-circuit and surface that key. No row was created through this
+				// service, so the items.create action must not fire with the original payload — the
+				// hook that took over owns any events.
+				createWasTakenOver = true;
 				return payloadAfterHooks;
 			}
 
@@ -427,7 +431,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			return primaryKey;
 		});
 
-		if (opts.emitEvents !== false) {
+		if (opts.emitEvents !== false && !createWasTakenOver) {
 			const actionEvent = {
 				event:
 					this.eventScope === 'items'

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -185,7 +185,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			// item that is about to be saved
 			const payloadAfterHooks =
 				opts.emitEvents !== false
-					? await emitter.emitFilter(
+					? await emitter.emitFilter<AnyItem, PrimaryKey>(
 							this.eventScope === 'items'
 								? ['items.create', `${this.collection}.items.create`]
 								: `${this.eventScope}.create`,
@@ -200,6 +200,12 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 							},
 						)
 					: payload;
+
+			if (typeof payloadAfterHooks === 'string' || typeof payloadAfterHooks === 'number') {
+				// A filter hook returned a primary key instead of a payload: it has taken over the
+				// creation, so short-circuit and surface that key.
+				return payloadAfterHooks;
+			}
 
 			const payloadWithPresets = this.accountability
 				? await processPayload(


### PR DESCRIPTION
**hhh-main-stacked copy of #51** — rebased onto **#58** (`hhh-main-stacked-await-action`) for the conflict-free `hhh-main` compose stack. The isolated upstream PR #51 stays untouched for upstream submission. Always open. Integration tree: #67.

**Why on #58:** file overlap with the PRs below it in the stack (see resolution).

**Resolution applied:**
- `items.test.ts`: kept BOTH #58's awaited-hook tests AND this PR's create-takeover test (closed the prior `it` before appending).

**Re-rebase recipe** (after a `main` sync, rebuild from the upstream-draft head onto the refreshed parent copy):
```
git checkout -B hhh-main-stacked-cancel-create hhh-main-stacked-await-action
git cherry-pick feature/filter-output-types..feature/cancel-create-via-filter
# re-apply the resolution above, then:
git push -f origin hhh-main-stacked-cancel-create
```