### PR TITLE
hhh-main-stacked: feat(items): cancel any mutation (create/update/delete) from a filter hook (#32)

### DIFF
--- a/.changeset/filter-cancel-mutations.md
+++ b/.changeset/filter-cancel-mutations.md
@@ -1,0 +1,11 @@
+---
+'@directus/types': minor
+'@directus/api': minor
+---
+
+Let a filter hook cancel a create, update or delete by returning `null`, gated by a new `allowFilterCancel` mutation option.
+
+- When a `*.items.create` / `*.items.update` / `*.items.delete` filter returns `null` and the caller passed `{ allowFilterCancel: true }`, the service skips the mutation. `createOne` resolves to `null`; the batch variants keep the cancelled slots as `null` so the result stays index-aligned with the input (`createMany` returns a `null` per cancelled item, `updateMany`/`deleteMany` return a `null` per key on a batch cancel) — `(PrimaryKey | null)[]` under the opt-in overload. Without the opt-in, a `null` return throws `InvalidPayloadError`, so the default signatures (and all existing callers) are unchanged.
+- The public endpoints opt in, so an extension hook can cancel a create/update/delete for any user collection through REST, GraphQL and WebSocket. A cancelled single create responds with `{ data: null }`; a cancelled update reads back the unchanged item; a cancelled delete leaves the item in place.
+
+Builds on the `FilterHandler<TIn, TOut>` output type. Internal/system mutations keep the strict default. Upsert-create cancellation is out of scope.

--- a/api/src/controllers/items.ts
+++ b/api/src/controllers/items.ts
@@ -36,20 +36,28 @@ router.post(
 		const savedKeys: PrimaryKey[] = [];
 
 		if (Array.isArray(req.body)) {
-			const keys = await service.createMany(req.body);
-			savedKeys.push(...keys);
+			const keys = await service.createMany(req.body, { allowFilterCancel: true });
+			// Cancelled creates come back as null; drop them before reading the created items.
+			savedKeys.push(...keys.filter((key): key is PrimaryKey => key !== null));
 		} else {
-			const key = await service.createOne(req.body);
-			savedKeys.push(key);
+			const key = await service.createOne(req.body, { allowFilterCancel: true });
+
+			if (key !== null) {
+				// A filter hook may cancel the creation by returning null; nothing to read back then.
+				savedKeys.push(key);
+			}
 		}
 
 		try {
 			if (Array.isArray(req.body)) {
 				const result = await service.readMany(savedKeys, req.sanitizedQuery);
 				res.locals['payload'] = { data: result || null };
-			} else {
+			} else if (savedKeys.length > 0) {
 				const result = await service.readOne(savedKeys[0]!, req.sanitizedQuery);
 				res.locals['payload'] = { data: result || null };
+			} else {
+				// The single create was cancelled by a filter hook: no item to return.
+				res.locals['payload'] = { data: null };
 			}
 		} catch (error: any) {
 			if (isDirectusError(error, ErrorCode.Forbidden)) {
@@ -151,19 +159,24 @@ router.patch(
 			return next();
 		}
 
-		let keys: PrimaryKey[] = [];
+		let keys: (PrimaryKey | null)[] = [];
 
 		if (Array.isArray(req.body)) {
-			keys = await service.updateBatch(req.body);
+			keys = await service.updateBatch(req.body, { allowFilterCancel: true });
 		} else if (req.body.keys) {
-			keys = await service.updateMany(req.body.keys, req.body.data);
+			keys = await service.updateMany(req.body.keys, req.body.data, { allowFilterCancel: true });
 		} else {
 			const sanitizedQuery = await sanitizeQuery(req.body.query, req.schema, req.accountability);
-			keys = await service.updateByQuery(sanitizedQuery, req.body.data);
+			keys = await service.updateByQuery(sanitizedQuery, req.body.data, { allowFilterCancel: true });
 		}
 
 		try {
-			const result = await service.readMany(keys, req.sanitizedQuery);
+			// Cancelled updates come back as null; drop them before reading the affected items.
+			const result = await service.readMany(
+				keys.filter((key): key is PrimaryKey => key !== null),
+				req.sanitizedQuery,
+			);
+
 			res.locals['payload'] = { data: result };
 		} catch (error: any) {
 			if (isDirectusError(error, ErrorCode.Forbidden)) {
@@ -196,7 +209,7 @@ router.patch(
 			schema: req.schema,
 		});
 
-		const updatedPrimaryKey = await service.updateOne(req.params['pk']!, req.body);
+		const updatedPrimaryKey = await service.updateOne(req.params['pk']!, req.body, { allowFilterCancel: true });
 
 		try {
 			const result = await service.readOne(updatedPrimaryKey, req.sanitizedQuery);
@@ -230,12 +243,12 @@ router.delete(
 		});
 
 		if (Array.isArray(req.body)) {
-			await service.deleteMany(req.body);
+			await service.deleteMany(req.body, { allowFilterCancel: true });
 		} else if (req.body.keys) {
-			await service.deleteMany(req.body.keys);
+			await service.deleteMany(req.body.keys, { allowFilterCancel: true });
 		} else {
 			const sanitizedQuery = await sanitizeQuery(req.body.query, req.schema, req.accountability);
-			await service.deleteByQuery(sanitizedQuery);
+			await service.deleteByQuery(sanitizedQuery, { allowFilterCancel: true });
 		}
 
 		return next();
@@ -257,7 +270,7 @@ router.delete(
 			schema: req.schema,
 		});
 
-		await service.deleteOne(req.params['pk']!);
+		await service.deleteOne(req.params['pk']!, { allowFilterCancel: true });
 		return next();
 	}),
 	respond,

--- a/api/src/emitter.test-d.ts
+++ b/api/src/emitter.test-d.ts
@@ -50,13 +50,3 @@ test('register.filter plumbs the output type so a hook can return a primary key'
 		return 5;
 	});
 });
-
-test('offFilter accepts the same typed handler shape as onFilter', () => {
-	const handler: FilterHandler<Item, number> = (payload) => {
-		expectTypeOf(payload).toEqualTypeOf<Item>();
-		return 5;
-	};
-
-	emitter.onFilter<Item, number>('items.create', handler);
-	emitter.offFilter<Item, number>('items.create', handler);
-});

--- a/api/src/services/deployment.ts
+++ b/api/src/services/deployment.ts
@@ -5,6 +5,7 @@ import type {
 	CachedResult,
 	Credentials,
 	DeploymentConfig,
+	MutationOptions,
 	Options,
 	PrimaryKey,
 	Project,
@@ -34,7 +35,7 @@ export class DeploymentService extends ItemsService<DeploymentConfig> {
 		super('directus_deployments', options);
 	}
 
-	override async createOne(data: Partial<DeploymentConfig>, opts?: any): Promise<PrimaryKey> {
+	override async createOne(data: Partial<DeploymentConfig>, opts?: MutationOptions): Promise<PrimaryKey> {
 		const provider = data.provider as ProviderType | undefined;
 
 		if (!provider) {

--- a/api/src/services/graphql/resolvers/mutation.ts
+++ b/api/src/services/graphql/resolvers/mutation.ts
@@ -46,17 +46,18 @@ export async function resolveMutation(
 	try {
 		if (single) {
 			if (action === 'create') {
-				const key = await service.createOne(args['data']);
-				return hasQuery ? await service.readOne(key, query) : true;
+				const key = await service.createOne(args['data'], { allowFilterCancel: true });
+				// A filter hook may cancel the create (null key); there is then no item to read back.
+				return hasQuery && key !== null ? await service.readOne(key, query) : true;
 			}
 
 			if (action === 'update') {
-				const key = await service.updateOne(args['id'], args['data']);
+				const key = await service.updateOne(args['id'], args['data'], { allowFilterCancel: true });
 				return hasQuery ? await service.readOne(key, query) : true;
 			}
 
 			if (action === 'delete') {
-				await service.deleteOne(args['id']);
+				await service.deleteOne(args['id'], { allowFilterCancel: true });
 				return { id: args['id'] };
 			}
 
@@ -73,14 +74,18 @@ export async function resolveMutation(
 				if (batchUpdate) {
 					keys.push(...(await service.updateBatch(args['data'])));
 				} else {
-					keys.push(...(await service.updateMany(args['ids'], args['data'])));
+					keys.push(
+						...(await service.updateMany(args['ids'], args['data'], { allowFilterCancel: true })).filter(
+							(key): key is PrimaryKey => key !== null,
+						),
+					);
 				}
 
 				return hasQuery ? await service.readMany(keys, query) : true;
 			}
 
 			if (action === 'delete') {
-				const keys = await service.deleteMany(args['ids']);
+				const keys = await service.deleteMany(args['ids'], { allowFilterCancel: true });
 				return { ids: keys };
 			}
 

--- a/api/src/services/items.test-d.ts
+++ b/api/src/services/items.test-d.ts
@@ -1,0 +1,13 @@
+import type { PrimaryKey } from '@directus/types';
+import { expectTypeOf, test } from 'vitest';
+import { ItemsService } from './items.js';
+
+const service = {} as ItemsService;
+
+test('createOne resolves to a primary key by default', () => {
+	expectTypeOf(service.createOne({})).toEqualTypeOf<Promise<PrimaryKey>>();
+});
+
+test('createOne may resolve to null when filter cancel is opted in', () => {
+	expectTypeOf(service.createOne({}, { allowFilterCancel: true })).toEqualTypeOf<Promise<PrimaryKey | null>>();
+});

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -281,8 +281,8 @@ describe('Integration Tests', () => {
 				transactionSpy.mockRestore();
 			});
 
-			it('should short-circuit and return the key when a create filter returns a string primary key', async () => {
-				const emitFilterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue('abc');
+			it('should cancel the create and return null when a filter returns null and cancel is allowed', async () => {
+				const filterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(null);
 
 				const insert = vi.fn().mockReturnThis();
 
@@ -290,47 +290,53 @@ describe('Integration Tests', () => {
 					return await callback({ ...db, insert } as any);
 				});
 
-				const result = await service.createOne({ name: 'Test' });
+				const result = await service.createOne({ name: 'Test' }, { allowFilterCancel: true });
 
-				expect(result).toBe('abc');
+				expect(result).toBeNull();
 				expect(insert).not.toHaveBeenCalled();
 
 				transactionSpy.mockRestore();
-				emitFilterSpy.mockRestore();
+				filterSpy.mockRestore();
 			});
 
-			it('should NOT emit an items.create action when a filter takes over the create', async () => {
-				const emitFilterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(5);
-				const emitActionSpy = vi.spyOn(emitter, 'emitAction');
+			it('should throw when a filter returns null but cancel is not allowed', async () => {
+				const filterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(null);
 
 				const transactionSpy = vi.spyOn(db, 'transaction').mockImplementation(async (callback) => {
 					return await callback({ ...db } as any);
 				});
 
-				await service.createOne({ name: 'Test' });
-
-				// the row was never created through this service, so the action must not fire
-				expect(emitActionSpy).not.toHaveBeenCalled();
+				await expect(service.createOne({ name: 'Test' })).rejects.toThrow(InvalidPayloadError);
 
 				transactionSpy.mockRestore();
-				emitActionSpy.mockRestore();
-				emitFilterSpy.mockRestore();
+				filterSpy.mockRestore();
 			});
 
-			it('should insert and emit the action normally when a filter returns a payload object (no take-over)', async () => {
-				// control case: a filter that returns the payload (not a key) leaves creation to the service
-				const emitFilterSpy = vi
+			it('should create normally when a filter returns the payload (cancel allowed but not triggered)', async () => {
+				// control: the cancel/take-over guards must only fire on null / a key, never on a payload
+				const filterSpy = vi
 					.spyOn(emitter, 'emitFilter')
 					.mockImplementation(async (_event: any, payload: any) => payload);
 
-				const emitActionSpy = vi.spyOn(emitter, 'emitAction');
+				const mockReturning = vi.fn().mockResolvedValue([{ id: 1 }]);
 
-				await service.createOne({ name: 'Test' });
+				const mockQuery = {
+					insert: vi.fn().mockReturnThis(),
+					into: vi.fn().mockReturnThis(),
+					returning: mockReturning,
+				};
 
-				expect(emitActionSpy).toHaveBeenCalled();
+				const transactionSpy = vi
+					.spyOn(db, 'transaction')
+					.mockImplementation(async (callback) => callback({ ...db, ...mockQuery } as any));
 
-				emitActionSpy.mockRestore();
-				emitFilterSpy.mockRestore();
+				const result = await service.createOne({ name: 'Test' }, { allowFilterCancel: true });
+
+				expect(mockQuery.insert).toHaveBeenCalled();
+				expect(result).not.toBeNull();
+
+				transactionSpy.mockRestore();
+				filterSpy.mockRestore();
 			});
 		});
 
@@ -339,6 +345,16 @@ describe('Integration Tests', () => {
 				await service.createMany([{}], { userIntegrityCheckFlags: UserIntegrityCheckFlag.All });
 
 				expect(validateUserCountIntegrity).toHaveBeenCalled();
+			});
+
+			it('should keep cancelled creates as null to stay index-aligned with the input', async () => {
+				const filterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(null);
+
+				const result = await service.createMany([{ name: 'A' }, { name: 'B' }], { allowFilterCancel: true });
+
+				expect(result).toEqual([null, null]);
+
+				filterSpy.mockRestore();
 			});
 		});
 
@@ -538,6 +554,42 @@ describe('Integration Tests', () => {
 
 				emitFilterSpy.mockRestore();
 			});
+
+			it('should cancel the update and return a null per key when a filter returns null and cancel is allowed', async () => {
+				const filterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(null);
+				const transactionSpy = vi.spyOn(db, 'transaction');
+
+				const result = await service.updateMany([1], { name: 'Test' }, { allowFilterCancel: true });
+
+				expect(result).toEqual([null]);
+				expect(transactionSpy).not.toHaveBeenCalled();
+
+				filterSpy.mockRestore();
+			});
+
+			it('should throw when a filter returns null but cancel is not allowed', async () => {
+				const filterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(null);
+
+				await expect(service.updateMany([1], { name: 'Test' })).rejects.toThrow(InvalidPayloadError);
+
+				filterSpy.mockRestore();
+			});
+
+			it('should run the update normally when a filter returns a non-null payload', async () => {
+				const filterSpy = vi
+					.spyOn(emitter, 'emitFilter')
+					.mockImplementation(async (_event: any, payload: any) => payload);
+
+				const transactionSpy = vi.spyOn(db, 'transaction');
+
+				const result = await service.updateMany([1], { name: 'Test' }, { allowFilterCancel: true });
+
+				expect(transactionSpy).toHaveBeenCalled();
+				expect(result).toEqual([1]);
+
+				transactionSpy.mockRestore();
+				filterSpy.mockRestore();
+			});
 		});
 
 		describe('deleteMany', () => {
@@ -545,6 +597,42 @@ describe('Integration Tests', () => {
 				await service.deleteMany([1], { userIntegrityCheckFlags: UserIntegrityCheckFlag.All });
 
 				expect(validateUserCountIntegrity).toHaveBeenCalled();
+			});
+
+			it('should cancel the deletion and return a null per key when a filter returns null and cancel is allowed', async () => {
+				const filterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(null);
+				const transactionSpy = vi.spyOn(db, 'transaction');
+
+				const result = await service.deleteMany([1], { allowFilterCancel: true });
+
+				expect(result).toEqual([null]);
+				expect(transactionSpy).not.toHaveBeenCalled();
+
+				filterSpy.mockRestore();
+			});
+
+			it('should throw when a filter returns null but cancel is not allowed', async () => {
+				const filterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(null);
+
+				await expect(service.deleteMany([1])).rejects.toThrow(InvalidPayloadError);
+
+				filterSpy.mockRestore();
+			});
+
+			it('should run the deletion normally when a filter returns a non-null payload', async () => {
+				const filterSpy = vi
+					.spyOn(emitter, 'emitFilter')
+					.mockImplementation(async (_event: any, payload: any) => payload);
+
+				const transactionSpy = vi.spyOn(db, 'transaction');
+
+				const result = await service.deleteMany([1], { allowFilterCancel: true });
+
+				expect(transactionSpy).toHaveBeenCalled();
+				expect(result).toEqual([1]);
+
+				transactionSpy.mockRestore();
+				filterSpy.mockRestore();
 			});
 		});
 

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -149,7 +149,9 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	/**
 	 * Create a single new item.
 	 */
-	async createOne(data: Partial<Item>, opts: MutationOptions = {}): Promise<PrimaryKey> {
+	async createOne(data: Partial<Item>, opts: MutationOptions & { allowFilterCancel: true }): Promise<PrimaryKey | null>;
+	async createOne(data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey>;
+	async createOne(data: Partial<Item>, opts: MutationOptions = {}): Promise<PrimaryKey | null> {
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
 
 		if (!opts.bypassLimits) {
@@ -170,7 +172,6 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 		const payload: AnyItem = cloneDeep(data);
 		let actionHookPayload = payload;
-		let createWasTakenOver = false;
 		const nestedActionEvents: ActionEventParams[] = [];
 
 		/**
@@ -179,14 +180,14 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		 * that any errors thrown in any nested relational changes will bubble up and cancel the whole
 		 * update tree
 		 */
-		const primaryKey: PrimaryKey = await transaction(this.knex, async (trx) => {
+		const primaryKey: PrimaryKey | null = await transaction(this.knex, async (trx) => {
 			const previousSeatCount = await captureSeatCount(trx, opts.userIntegrityCheckFlags);
 
 			// Run all hooks that are attached to this event so the end user has the chance to augment the
 			// item that is about to be saved
 			const payloadAfterHooks =
 				opts.emitEvents !== false
-					? await emitter.emitFilter<AnyItem, PrimaryKey>(
+					? await emitter.emitFilter<AnyItem, PrimaryKey | null>(
 							this.eventScope === 'items'
 								? ['items.create', `${this.collection}.items.create`]
 								: `${this.eventScope}.create`,
@@ -204,11 +205,19 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 			if (typeof payloadAfterHooks === 'string' || typeof payloadAfterHooks === 'number') {
 				// A filter hook returned a primary key instead of a payload: it has taken over the
-				// creation, so short-circuit and surface that key. No row was created through this
-				// service, so the items.create action must not fire with the original payload — the
-				// hook that took over owns any events.
-				createWasTakenOver = true;
+				// creation, so short-circuit and surface that key.
 				return payloadAfterHooks;
+			}
+
+			if (payloadAfterHooks === null) {
+				if (!opts.allowFilterCancel) {
+					throw new InvalidPayloadError({
+						reason: `A filter hook cancelled the creation, but this operation requires a created item`,
+					});
+				}
+
+				// The filter cancelled the creation: no item is inserted and no key is produced.
+				return null;
 			}
 
 			const payloadWithPresets = this.accountability
@@ -431,7 +440,12 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			return primaryKey;
 		});
 
-		if (opts.emitEvents !== false && !createWasTakenOver) {
+		// A filter hook cancelled the creation: nothing was inserted, so skip the action hooks entirely.
+		if (primaryKey === null) {
+			return null;
+		}
+
+		if (opts.emitEvents !== false) {
 			const actionEvent = {
 				event:
 					this.eventScope === 'items'
@@ -464,7 +478,13 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	 *
 	 * Uses `this.createOne` under the hood.
 	 */
-	async createMany(data: Partial<Item>[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
+	async createMany(
+		data: Partial<Item>[],
+		opts: MutationOptions & { allowFilterCancel: true },
+	): Promise<(PrimaryKey | null)[]>;
+
+	async createMany(data: Partial<Item>[], opts?: MutationOptions): Promise<PrimaryKey[]>;
+	async createMany(data: Partial<Item>[], opts: MutationOptions = {}): Promise<(PrimaryKey | null)[]> {
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
 
 		if (this.collection === 'directus_users') {
@@ -479,7 +499,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 			let userIntegrityCheckFlags = opts.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None;
 
-			const primaryKeys: PrimaryKey[] = [];
+			const primaryKeys: (PrimaryKey | null)[] = [];
 			const nestedActionEvents: ActionEventParams[] = [];
 
 			const pkField = this.schema.collections[this.collection]!.primary;
@@ -493,7 +513,9 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					bypassAutoIncrementSequenceReset = false;
 				}
 
-				const primaryKey = await service.createOne(payload, {
+				// `allowFilterCancel` is propagated via `opts`; the overload resolves to the non-null
+				// signature, but a cancelling filter can still return null at runtime — hence the guard.
+				const primaryKey: PrimaryKey | null = await service.createOne(payload, {
 					...(opts || {}),
 					autoPurgeCache: false,
 					onRequireUserIntegrityCheck: (flags) => (userIntegrityCheckFlags |= flags),
@@ -503,6 +525,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					bypassAutoIncrementSequenceReset,
 				});
 
+				// A filter hook may cancel an individual create by returning null; the null is kept in
+				// place so the result stays index-aligned with the input (mirrors createOne).
 				primaryKeys.push(primaryKey);
 			}
 
@@ -752,7 +776,18 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	/**
 	 * Update many items by primary key, setting all items to the same change.
 	 */
-	async updateMany(keys: PrimaryKey[], data: Partial<Item>, opts: MutationOptions = {}): Promise<PrimaryKey[]> {
+	async updateMany(
+		keys: PrimaryKey[],
+		data: Partial<Item>,
+		opts: MutationOptions & { allowFilterCancel: true },
+	): Promise<(PrimaryKey | null)[]>;
+
+	async updateMany(keys: PrimaryKey[], data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey[]>;
+	async updateMany(
+		keys: PrimaryKey[],
+		data: Partial<Item>,
+		opts: MutationOptions = {},
+	): Promise<(PrimaryKey | null)[]> {
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
 
 		if (!opts.bypassLimits) {
@@ -780,7 +815,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		// item that is about to be saved
 		const payloadAfterHooks =
 			opts.emitEvents !== false
-				? await emitter.emitFilter(
+				? await emitter.emitFilter<Partial<AnyItem>, null>(
 						this.eventScope === 'items'
 							? ['items.update', `${this.collection}.items.update`]
 							: `${this.eventScope}.update`,
@@ -798,12 +833,15 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				: payload;
 
 		if (payloadAfterHooks === null) {
-			// A filter hook cleared the payload to null. Treating that as an explicit, opt-in
-			// cancellation (returning a null per key) is owned by the `allowFilterCancel` mutation
-			// option; on its own a null payload is invalid rather than a silent no-op.
-			throw new InvalidPayloadError({
-				reason: `A filter hook cancelled the update, but this operation requires it`,
-			});
+			if (!opts.allowFilterCancel) {
+				throw new InvalidPayloadError({
+					reason: `A filter hook cancelled the update, but this operation requires it`,
+				});
+			}
+
+			// The filter cancelled the update: nothing is written; return a null per key so the
+			// result stays index-aligned with the input keys.
+			return keys.map(() => null);
 		}
 
 		const isEmptyAlterations = (value: unknown): boolean => {
@@ -1158,7 +1196,13 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	/**
 	 * Delete multiple items by primary key.
 	 */
-	async deleteMany(keys: PrimaryKey[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
+	async deleteMany(
+		keys: PrimaryKey[],
+		opts: MutationOptions & { allowFilterCancel: true },
+	): Promise<(PrimaryKey | null)[]>;
+
+	async deleteMany(keys: PrimaryKey[], opts?: MutationOptions): Promise<PrimaryKey[]>;
+	async deleteMany(keys: PrimaryKey[], opts: MutationOptions = {}): Promise<(PrimaryKey | null)[]> {
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
 
 		if (!opts.bypassLimits) {
@@ -1170,7 +1214,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 		const keysAfterHooks =
 			opts.emitEvents !== false
-				? await emitter.emitFilter(
+				? await emitter.emitFilter<PrimaryKey[], null>(
 						this.eventScope === 'items'
 							? ['items.delete', `${this.collection}.items.delete`]
 							: `${this.eventScope}.delete`,
@@ -1185,6 +1229,18 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 						},
 					)
 				: keys;
+
+		if (keysAfterHooks === null) {
+			if (!opts.allowFilterCancel) {
+				throw new InvalidPayloadError({
+					reason: `A filter hook cancelled the deletion, but this operation requires it`,
+				});
+			}
+
+			// The filter cancelled the deletion: nothing is deleted; return a null per key so the
+			// result stays index-aligned with the input keys.
+			return keys.map(() => null);
+		}
 
 		if (this.accountability) {
 			await validateAccess(

--- a/api/src/websocket/handlers/items.test.ts
+++ b/api/src/websocket/handlers/items.test.ts
@@ -118,7 +118,9 @@ describe('WebSocket heartbeat handler', () => {
 		// do mocking
 		(getSchema as Mock).mockImplementation(() => ({ collections: { test: [] } }));
 
-		const createMany = vi.fn(),
+		// A filter hook may cancel an individual create, leaving a null in place; the handler
+		// must drop those before reading back, so the read only sees the surviving key.
+		const createMany = vi.fn().mockResolvedValue([1, null]),
 			readMany = vi.fn();
 
 		(ItemsService as Mock).mockImplementation(() => ({ createMany, readMany }));
@@ -137,7 +139,7 @@ describe('WebSocket heartbeat handler', () => {
 		await vi.runAllTimersAsync(); // flush promises to make sure the event is handled
 		// expect service functions
 		expect(createMany).toBeCalled();
-		expect(readMany).toBeCalled();
+		expect(readMany).toBeCalledWith([1], expect.anything());
 		expect(fakeClient.send).toBeCalled();
 	});
 
@@ -198,7 +200,9 @@ describe('WebSocket heartbeat handler', () => {
 		// do mocking
 		(getSchema as Mock).mockImplementation(() => ({ collections: { test: [] } }));
 
-		const updateMany = vi.fn(),
+		// A filter hook may cancel an individual update, leaving a null in place; the handler
+		// must drop those before reading back, so the read only sees the surviving key.
+		const updateMany = vi.fn().mockResolvedValue([1, null]),
 			readMany = vi.fn();
 
 		(ItemsService as Mock).mockImplementation(() => ({ updateMany, readMany }));
@@ -220,7 +224,7 @@ describe('WebSocket heartbeat handler', () => {
 		// expect service functions
 		expect(updateMany).toBeCalled();
 		expect(getMetaForQuery).toBeCalled();
-		expect(readMany).toBeCalled();
+		expect(readMany).toBeCalledWith([1], expect.anything());
 		expect(fakeClient.send).toBeCalled();
 	});
 

--- a/api/src/websocket/handlers/items.ts
+++ b/api/src/websocket/handlers/items.ts
@@ -1,4 +1,5 @@
 import { isSystemCollection } from '@directus/system-data';
+import type { PrimaryKey } from '@directus/types';
 import emitter from '../../emitter.js';
 import { ItemsService, MetaService } from '../../services/index.js';
 import { getSchema } from '../../utils/get-schema.js';
@@ -49,11 +50,16 @@ export class ItemsHandler {
 			const query = await sanitizeQuery(message?.query ?? {}, schema, accountability);
 
 			if (Array.isArray(message.data)) {
-				const keys = await service.createMany(message.data);
-				result = await service.readMany(keys, query);
+				const keys = await service.createMany(message.data, { allowFilterCancel: true });
+
+				result = await service.readMany(
+					keys.filter((key): key is PrimaryKey => key !== null),
+					query,
+				);
 			} else {
-				const key = await service.createOne(message.data);
-				result = await service.readOne(key, query);
+				const key = await service.createOne(message.data, { allowFilterCancel: true });
+				// A filter hook may cancel the create (null key); there is then no item to read back.
+				result = key !== null ? await service.readOne(key, query) : null;
 			}
 		}
 
@@ -77,12 +83,16 @@ export class ItemsHandler {
 			const query = await sanitizeQuery(message.query ?? {}, schema, accountability);
 
 			if (message.id) {
-				const key = await service.updateOne(message.id, message.data);
+				const key = await service.updateOne(message.id, message.data, { allowFilterCancel: true });
 				result = await service.readOne(key);
 			} else if (message.ids) {
-				const keys = await service.updateMany(message.ids, message.data);
+				const keys = await service.updateMany(message.ids, message.data, { allowFilterCancel: true });
 				meta = await metaService.getMetaForQuery(message.collection, query);
-				result = await service.readMany(keys, query);
+
+				result = await service.readMany(
+					keys.filter((key): key is PrimaryKey => key !== null),
+					query,
+				);
 			} else if (isSingleton) {
 				await service.upsertSingleton(message.data);
 				result = await service.readSingleton(query);
@@ -91,7 +101,7 @@ export class ItemsHandler {
 				meta = await metaService.getMetaForQuery(message.collection, query);
 				result = await service.readMany(keys, query);
 			} else {
-				const keys = await service.updateByQuery(query, message.data);
+				const keys = await service.updateByQuery(query, message.data, { allowFilterCancel: true });
 				meta = await metaService.getMetaForQuery(message.collection, query);
 				result = await service.readMany(keys, query);
 			}
@@ -99,14 +109,14 @@ export class ItemsHandler {
 
 		if (message.action === 'delete') {
 			if (message.id) {
-				await service.deleteOne(message.id);
+				await service.deleteOne(message.id, { allowFilterCancel: true });
 				result = message.id;
 			} else if (message.ids) {
-				await service.deleteMany(message.ids);
+				await service.deleteMany(message.ids, { allowFilterCancel: true });
 				result = message.ids;
 			} else if (message.query) {
 				const query = await sanitizeQuery(message.query, schema, accountability);
-				result = await service.deleteByQuery(query);
+				result = await service.deleteByQuery(query, { allowFilterCancel: true });
 			} else {
 				throw new WebSocketError(
 					'items',

--- a/packages/types/src/items.ts
+++ b/packages/types/src/items.ts
@@ -114,6 +114,12 @@ export type MutationOptions = {
 	 * Callback function that is called whenever a mutation requires a user integrity check to be made
 	 */
 	onRequireUserIntegrityCheck?: ((flags: UserIntegrityCheckFlag) => void) | undefined;
+
+	/**
+	 * Allow an `items.create` filter hook to cancel the creation by returning `null`. When set,
+	 * `createOne` resolves to `null` instead of a primary key; otherwise a `null` return throws.
+	 */
+	allowFilterCancel?: boolean | undefined;
 };
 
 export type FieldMutationOptions = MutationOptions & {


### PR DESCRIPTION
## What

Conflict-resolved **copy of #52** for the compose stack. The isolated `upstream-draft:` PR #52 stays clean off `main`; this `hhh-main-stacked:` copy is what `compose-hhh-main` consumes.

Base = `hhh-main-stacked-cancel-create` (#78) — the cancel-create copy of #51. Top of the stack (leaf), above #78.

## Why it's a copy, not a rebase

#52 has **divergent history**: it carries its *own* create-take-over commit (`b0338278ce`) which differs from #51's (`354ee0719d` / `76973561ca`). A mechanical cherry-pick replays the take-over and conflicts against #78 (which already has #51's). Instead this copy applies #52's **net delta over #51** onto #78:

```
git diff pr-51 pr-52 | git apply --3way
```

That nets out the duplicate take-over, leaving only #52's true additions: `allowFilterCancel` cancel-via-null for create/update/delete, index-aligned null results, and the take-over detection refactor (`createWasTakenOver` flag → `primaryKey === null`).

## Conflicts resolved (2 files only)

This is now a **pure mechanical derivation** — the only hand-resolved conflicts are the two items files; everything else (incl. the websocket test) applies cleanly from #52.

- **`api/src/services/items.ts`** (`updateMany`): #78 already had both a `payloadAfterHooks === null` throw *and* the skip-noop block. Kept the skip-noop block; replaced the bare throw with #52's `allowFilterCancel` guard + `keys.map(() => null)` (index-aligned).
- **`api/src/services/items.test.ts`**: kept the `ForbiddenError` import (#78 needs it for the forbidden-reasons tests; #52 only imported `InvalidPayloadError`).

## Upstream fix folded into #52

A latent bug — #52's handler did `keys.filter(k => k !== null)` while its `createMany`/`updateMany` mocks still returned `undefined`, so `.filter` threw and `readMany` was never reached — has been **fixed in #52 itself** (`56ee5e7ce6`), not patched here. This copy inherits it via the net delta.

## Verification

- `pnpm --filter @directus/api test` — green except the pre-existing `schedule.test` "25+ days" timer flake (wall-clock dependent; CI passes it; this diff touches zero schedule files).
- `items.test.ts` 45/45, `websocket/handlers/items.test.ts` 11/11, type-tests 10/10.

## Re-rebase recipe (after a `main` sync)

When `main` moves, #78 gets re-rebased first, then refresh this copy:

```sh
git fetch origin
git checkout -B hhh-main-stacked-cancel-mutations origin/hhh-main-stacked-cancel-create
git fetch origin refs/pull/51/head:pr-51 refs/pull/52/head:pr-52
git diff pr-51 pr-52 | git apply --3way --index
# resolve only items.ts (keep skip-noop + allowFilterCancel null-cancel) and the
# items.test.ts ForbiddenError import as above
pnpm --filter @directus/types build && pnpm --filter @directus/api test
git commit && git push --force-with-lease
```
