### PR TITLE
fork-feat: 04 — better message on migration version collision

### DIFF
--- a/.changeset/migration-collision-detail.md
+++ b/.changeset/migration-collision-detail.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Improved the "Migration keys collide" startup error to list which version collides and the exact files sharing it, instead of a generic message that left you to hunt for the duplicate by hand.

--- a/api/src/database/migrations/run.test.ts
+++ b/api/src/database/migrations/run.test.ts
@@ -107,4 +107,107 @@ describe('run', () => {
 			});
 		});
 	});
+
+	describe('when migration keys collide', () => {
+		afterEach(() => {
+			vi.doUnmock('fs-extra');
+			vi.resetModules();
+		});
+
+		it('throws an error listing the colliding version and its files', async () => {
+			vi.resetModules();
+
+			vi.doMock('fs-extra', () => ({
+				default: {
+					readdir: vi.fn().mockResolvedValue(['20201028A-first.js', '20201028A-second.js']),
+					pathExists: vi.fn().mockResolvedValue(false),
+				},
+			}));
+
+			const { default: runWithCollision } = await import('./run.js');
+
+			tracker.on.select('directus_migrations').response([]);
+
+			const error = await runWithCollision(db, 'up').catch((e: Error) => e);
+
+			expect(error).toBeInstanceOf(Error);
+			expect((error as Error).message).toContain('Migration keys collide!');
+			expect((error as Error).message).toContain('"20201028A"');
+			expect((error as Error).message).toContain('first.js');
+			expect((error as Error).message).toContain('second.js');
+		});
+
+		it('formats each collision as a tab-dashed line listing comma-separated files', async () => {
+			vi.resetModules();
+
+			vi.doMock('fs-extra', () => ({
+				default: {
+					readdir: vi.fn().mockResolvedValue(['20201028A-first.js', '20201028A-second.js']),
+					pathExists: vi.fn().mockResolvedValue(false),
+				},
+			}));
+
+			const { default: runWithCollision } = await import('./run.js');
+
+			tracker.on.select('directus_migrations').response([]);
+
+			const error = await runWithCollision(db, 'up').catch((e: Error) => e);
+
+			expect((error as Error).message).toMatch(
+				/\n\t- "20201028A": [^\n]*20201028A-[a-z]+\.js, [^\n]*20201028A-[a-z]+\.js/,
+			);
+		});
+
+		it('lists every colliding version when several versions collide', async () => {
+			vi.resetModules();
+
+			vi.doMock('fs-extra', () => ({
+				default: {
+					readdir: vi
+						.fn()
+						.mockResolvedValue([
+							'20201028A-first.js',
+							'20201028A-second.js',
+							'20201029B-third.js',
+							'20201029B-fourth.js',
+						]),
+					pathExists: vi.fn().mockResolvedValue(false),
+				},
+			}));
+
+			const { default: runWithCollision } = await import('./run.js');
+
+			tracker.on.select('directus_migrations').response([]);
+
+			const error = await runWithCollision(db, 'up').catch((e: Error) => e);
+
+			const message = (error as Error).message;
+
+			expect(message).toContain('"20201028A"');
+			expect(message).toContain('"20201029B"');
+			// one line per colliding version
+			expect(message.match(/\n\t- "/g)).toHaveLength(2);
+		});
+
+		it('does not report a collision when every version is unique', async () => {
+			vi.resetModules();
+
+			vi.doMock('fs-extra', () => ({
+				default: {
+					readdir: vi.fn().mockResolvedValue(['20201028A-first.js', '20201029B-second.js']),
+					pathExists: vi.fn().mockResolvedValue(false),
+				},
+			}));
+
+			const { default: runWithCollision } = await import('./run.js');
+
+			tracker.on.select('directus_migrations').response([]);
+
+			const result = await runWithCollision(db, 'up').catch((e: Error) => e);
+
+			if (result instanceof Error) {
+				expect(result.message).not.toContain('Migration keys collide!');
+			}
+		});
+	});
 });

--- a/api/src/database/migrations/run.ts
+++ b/api/src/database/migrations/run.ts
@@ -38,7 +38,20 @@ export default async function run(database: Knex, direction: 'up' | 'down' | 'la
 	const migrationKeys = new Set(migrations.map((m) => m.version));
 
 	if (migrations.length > migrationKeys.size) {
-		throw new Error('Migration keys collide! Please ensure that every migration uses a unique key.');
+		const filesByVersion = new Map<string, string[]>();
+
+		for (const migration of migrations) {
+			const files = filesByVersion.get(migration.version!) ?? [];
+			files.push(migration.file);
+			filesByVersion.set(migration.version!, files);
+		}
+
+		const collisions = [...filesByVersion]
+			.filter(([, files]) => files.length > 1)
+			.map(([version, files]) => `\t- "${version}": ${files.join(', ')}`)
+			.join('\n');
+
+		throw new Error(`Migration keys collide! Please ensure that every migration uses a unique key:\n${collisions}`);
 	}
 
 	function parseFilePath(filePath: string, custom = false) {


### PR DESCRIPTION
Fork-permanent feature on the v11 (BSL) integration line. First end-to-end slice validating the version-parameterized `compose-hhh-v11` pipeline.

**What:** when two migrations share a version key, the thrown error now lists the colliding version(s) + files instead of a bare "keys collide" message.

**Source of truth:** cherry-picked from `v11.9.2-hhh-dev` (commit `662ad3a`) onto `hhh-v11-base` (v11.10.1). The v12 reimplementation (#55) reformatted the output (tab-dashed lines) — we keep the v11 source-of-truth implementation (JSON of colliding pairs).

**Type:** root feature (base `hhh-v11-base`, no overlap with other features). Consumed directly by compose (collapsed single `fork-feat:` class — no separate copy needed now that the line is fork-permanent).

Out of scope: a dedicated test matching the v11 output format (follow-up; v11.10.1 has no existing collision test so nothing regresses).