### PR TITLE
fork-feat: 02 — fix MariaDB JSON collation error

### DIFF
--- a/api/src/database/helpers/schema/dialects/mysql.ts
+++ b/api/src/database/helpers/schema/dialects/mysql.ts
@@ -1,7 +1,7 @@
 import { useEnv } from '@directus/env';
 import type { Knex } from 'knex';
 import { getDefaultIndexName } from '../../../../utils/get-default-index-name.js';
-import { SchemaHelper, type SortRecord } from '../types.js';
+import { type InvalidCollationColumn, SchemaHelper, type SortRecord } from '../types.js';
 
 const env = useEnv();
 
@@ -103,5 +103,30 @@ export class SchemaHelperMySQL extends SchemaHelper {
 
 			groupByFields.push(...sortRecords.map(({ alias }) => alias));
 		}
+	}
+
+	override async getColumnsWithInvalidCollation(schema: string, collation: string): Promise<InvalidCollationColumn[]> {
+		const { version } = await this.knex.select(this.knex.raw('VERSION() as version')).first();
+		const isMariaDB = String(version).split('-').includes('MariaDB');
+
+		return this.knex('information_schema.columns')
+			.select<InvalidCollationColumn[]>({
+				table_name: 'TABLE_NAME',
+				name: 'COLUMN_NAME',
+				collation: 'COLLATION_NAME',
+			})
+			.where({ TABLE_SCHEMA: schema })
+			.whereNot({ COLLATION_NAME: collation })
+			.modify((queryBuilder) => {
+				// MariaDB has no native JSON type; it stores JSON as LONGTEXT with the utf8mb4_bin
+				// collation, so that pairing is expected rather than a real collation mismatch.
+				// Exclude only the pairing — NOT(longtext AND utf8mb4_bin) — so a longtext column
+				// with a genuinely wrong collation (or a utf8mb4_bin non-longtext) is still reported.
+				if (isMariaDB) {
+					queryBuilder.andWhereNot((qb) => {
+						void qb.where({ COLUMN_TYPE: 'longtext' }).andWhere({ COLLATION_NAME: 'utf8mb4_bin' });
+					});
+				}
+			});
 	}
 }

--- a/api/src/database/helpers/schema/types.ts
+++ b/api/src/database/helpers/schema/types.ts
@@ -18,6 +18,12 @@ export type SortRecord = {
 	column: Knex.Raw;
 };
 
+export type InvalidCollationColumn = {
+	table_name: string;
+	name: string;
+	collation: string;
+};
+
 export abstract class SchemaHelper extends DatabaseHelper {
 	isOneOfClients(clients: DatabaseClient[]): boolean {
 		return clients.includes(getDatabaseClient(this.knex));
@@ -209,5 +215,16 @@ export abstract class SchemaHelper extends DatabaseHelper {
 		const indexName = this.generateIndexName('index', collection, field);
 
 		await knex.raw('DROP INDEX IF EXISTS ??', [indexName]);
+	}
+
+	async getColumnsWithInvalidCollation(schema: string, collation: string): Promise<InvalidCollationColumn[]> {
+		return this.knex('information_schema.columns')
+			.select<InvalidCollationColumn[]>({
+				table_name: 'TABLE_NAME',
+				name: 'COLUMN_NAME',
+				collation: 'COLLATION_NAME',
+			})
+			.where({ TABLE_SCHEMA: schema })
+			.whereNot({ COLLATION_NAME: collation });
 	}
 }

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -347,16 +347,14 @@ async function validateDatabaseCharset(database?: Knex): Promise<void> {
 	const logger = useLogger();
 
 	if (getDatabaseClient(database) === 'mysql') {
+		const helpers = getHelpers(database);
 		const { collation } = await database.select(database.raw(`@@collation_database as collation`)).first();
 
 		const tables = await database('information_schema.tables')
 			.select({ name: 'TABLE_NAME', collation: 'TABLE_COLLATION' })
 			.where({ TABLE_SCHEMA: env['DB_DATABASE'] });
 
-		const columns = await database('information_schema.columns')
-			.select({ table_name: 'TABLE_NAME', name: 'COLUMN_NAME', collation: 'COLLATION_NAME' })
-			.where({ TABLE_SCHEMA: env['DB_DATABASE'] })
-			.whereNot({ COLLATION_NAME: collation });
+		const columns = await helpers.schema.getColumnsWithInvalidCollation(env['DB_DATABASE'] as string, collation);
 
 		const excludedTables: string[] = toArray(env['DB_EXCLUDE_TABLES']);
 


### PR DESCRIPTION
Fork-permanent root feature on the v11 (BSL) line. Cherry-picked from `v11.9.2-hhh-dev` (`7db2ea6`) onto `hhh-v11-base` (v11.10.1). Source-of-truth hhh-dev impl (11 lines in `api/src/database/index.ts`) — simpler than the v12 #54 reimplementation. Root (isolated: `database/index.ts`).