### PR TITLE
fork-feat: 12 — optionally async (always-awaited) emitAction

### DIFF
--- a/api/src/emitter.ts
+++ b/api/src/emitter.ts
@@ -63,16 +63,24 @@ export class Emitter {
 		return updatedPayload;
 	}
 
-	public emitAction(event: string | string[], meta: Record<string, any>, context: EventContext | null = null): void {
+	public async emitAction(
+		event: string | string[],
+		meta: Record<string, any>,
+		context: EventContext | null = null,
+	): Promise<void> {
 		const logger = useLogger();
 		const events = Array.isArray(event) ? event : [event];
 
-		for (const event of events) {
-			this.actionEmitter.emitAsync(event, { event, ...meta }, context ?? this.getDefaultContext()).catch((err) => {
-				logger.warn(`An error was thrown while executing action "${event}"`);
-				logger.warn(err);
-			});
-		}
+		// Run every event's listeners in parallel and await them together, so a slow
+		// handler on one event doesn't serialize behind the others.
+		await Promise.all(
+			events.map((event) =>
+				this.actionEmitter.emitAsync(event, { event, ...meta }, context ?? this.getDefaultContext()).catch((err) => {
+					logger.warn(`An error was thrown while executing action "${event}"`);
+					logger.warn(err);
+				}),
+			),
+		);
 	}
 
 	public async emitInit(event: string, meta: Record<string, any>): Promise<void> {

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -38,6 +38,30 @@ import { PayloadService } from './payload.js';
 
 const env = useEnv();
 
+/**
+ * Emit a mutation's action events (the item's own event plus any queued nested ones) in parallel.
+ * They run together, so a slow handler on one event doesn't serialize the rest. By default the
+ * mutation does not wait for them (Directus' historical fire-and-forget behaviour); pass
+ * `awaitActionHooks` to block until every handler has settled.
+ */
+async function emitActionEvents(actionEvents: ActionEventParams[], opts: MutationOptions): Promise<void> {
+	const emitting = Promise.all(
+		actionEvents.map((actionEvent) =>
+			opts.bypassEmitAction
+				? opts.bypassEmitAction(actionEvent)
+				: emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context),
+		),
+	);
+
+	if (opts.awaitActionHooks) {
+		await emitting;
+	} else {
+		// Per-event errors are already caught and logged inside emitter.emitAction; swallow here so
+		// an un-awaited rejection (e.g. from a bypassEmitAction handler) doesn't go unhandled.
+		emitting.catch(() => {});
+	}
+}
+
 export class ItemsService<Item extends AnyItem = AnyItem, Collection extends string = string>
 	implements AbstractService<Item>
 {
@@ -412,19 +436,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				},
 			};
 
-			if (opts.bypassEmitAction) {
-				opts.bypassEmitAction(actionEvent);
-			} else {
-				emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context);
-			}
-
-			for (const nestedActionEvent of nestedActionEvents) {
-				if (opts.bypassEmitAction) {
-					opts.bypassEmitAction(nestedActionEvent);
-				} else {
-					emitter.emitAction(nestedActionEvent.event, nestedActionEvent.meta, nestedActionEvent.context);
-				}
-			}
+			await emitActionEvents([actionEvent, ...nestedActionEvents], opts);
 		}
 
 		if (shouldClearCache(this.cache, opts, this.collection)) {
@@ -495,13 +507,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		});
 
 		if (opts.emitEvents !== false) {
-			for (const nestedActionEvent of nestedActionEvents) {
-				if (opts.bypassEmitAction) {
-					opts.bypassEmitAction(nestedActionEvent);
-				} else {
-					emitter.emitAction(nestedActionEvent.event, nestedActionEvent.meta, nestedActionEvent.context);
-				}
-			}
+			await emitActionEvents(nestedActionEvents, opts);
 		}
 
 		if (shouldClearCache(this.cache, opts, this.collection)) {
@@ -579,7 +585,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				: records;
 
 		if (opts?.emitEvents !== false) {
-			emitter.emitAction(
+			// Read action hooks stay fire-and-forget; the await opt-in (`awaitActionHooks`) is for mutations.
+			void emitter.emitAction(
 				this.eventScope === 'items' ? ['items.read', `${this.collection}.items.read`] : `${this.eventScope}.read`,
 				{
 					payload: filteredRecords,
@@ -1015,19 +1022,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				},
 			};
 
-			if (opts.bypassEmitAction) {
-				opts.bypassEmitAction(actionEvent);
-			} else {
-				emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context);
-			}
-
-			for (const nestedActionEvent of nestedActionEvents) {
-				if (opts.bypassEmitAction) {
-					opts.bypassEmitAction(nestedActionEvent);
-				} else {
-					emitter.emitAction(nestedActionEvent.event, nestedActionEvent.meta, nestedActionEvent.context);
-				}
-			}
+			await emitActionEvents([actionEvent, ...nestedActionEvents], opts);
 		}
 
 		return keys;
@@ -1256,11 +1251,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				},
 			};
 
-			if (opts.bypassEmitAction) {
-				opts.bypassEmitAction(actionEvent);
-			} else {
-				emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context);
-			}
+			await emitActionEvents([actionEvent], opts);
 		}
 
 		return keys;

--- a/packages/types/src/items.ts
+++ b/packages/types/src/items.ts
@@ -55,7 +55,14 @@ export type MutationOptions = {
 	 * To bypass the emitting of action events if emitEvents is enabled
 	 * Can be used to queue up the nested events from item service's create, update and delete
 	 */
-	bypassEmitAction?: ((params: ActionEventParams) => void) | undefined;
+	bypassEmitAction?: ((params: ActionEventParams) => void) | ((params: ActionEventParams) => Promise<void>) | undefined;
+
+	/**
+	 * Await the mutation's action hooks before resolving, instead of firing them and forgetting.
+	 * Off by default (action hooks stay fire-and-forget); opt in when a client reads back a side
+	 * effect an action handler produces and would otherwise race it.
+	 */
+	awaitActionHooks?: boolean | undefined;
 
 	/**
 	 * To bypass limits so that functions would work as intended


### PR DESCRIPTION
Fork-permanent, bottom of the items.ts stack (base hhh-v11-base). Cherry-picked from `v11.9.2-hhh-dev` (`1ddb16ee`). Source-of-truth hhh-dev impl **always awaits** action hooks (simpler than v12 #58's opt-in `awaitActionHooks` flag). File-move resolved: the `bypassEmitAction` Promise-variant type moved from the deleted `api/src/types/items.ts` to its v11.10.1 home `packages/types/src/items.ts`.