### PR TITLE
fork-feat: 10 — take over items.create from a filter (return null/PK)

### DIFF
--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -142,6 +142,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 		const payload: AnyItem = cloneDeep(data);
 		let actionHookPayload = payload;
+		let createWasTakenOver = false;
 		const nestedActionEvents: ActionEventParams[] = [];
 
 		/**
@@ -155,7 +156,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			// item that is about to be saved
 			const payloadAfterHooks =
 				opts.emitEvents !== false
-					? await emitter.emitFilter(
+					? await emitter.emitFilter<AnyItem, PrimaryKey>(
 							this.eventScope === 'items'
 								? ['items.create', `${this.collection}.items.create`]
 								: `${this.eventScope}.create`,
@@ -170,6 +171,15 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 							},
 						)
 					: payload;
+
+			if (typeof payloadAfterHooks === 'string' || typeof payloadAfterHooks === 'number') {
+				// A filter hook returned a primary key instead of a payload: it has taken over the
+				// creation, so short-circuit and surface that key. No row was created through this
+				// service, so the items.create action must not fire with the original payload — the
+				// hook that took over owns any events.
+				createWasTakenOver = true;
+				return payloadAfterHooks;
+			}
 
 			const payloadWithPresets = this.accountability
 				? await processPayload(
@@ -366,7 +376,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			return primaryKey;
 		});
 
-		if (opts.emitEvents !== false) {
+		if (opts.emitEvents !== false && !createWasTakenOver) {
 			const actionEvent = {
 				event:
 					this.eventScope === 'items'


### PR DESCRIPTION
Fork-permanent, stacked on `fork-feat/await-action`. Cherry-picked from `v11.9.2-hhh-dev` (`4c07cca`); clean. A `items.create` filter returning null / a primary key short-circuits creation. Source-of-truth hhh-dev impl (returns the filter value directly; simpler than v12 #51/#52 allowFilterCancel overloads). v12 ref: #51.