### PR TITLE
fork-feat: 06 — skip no-op item updates + single-key where

### DIFF
--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -75,10 +75,24 @@ describe('Integration Tests', () => {
 		});
 
 		describe('updateMany', () => {
-			it('should validate user count if requested', async () => {
-				await service.updateMany([1], {}, { userIntegrityCheckFlags: UserIntegrityCheckFlag.All });
+			it('should validate user count for a non-empty payload', async () => {
+				await service.updateMany([1], { name: 'test' }, { userIntegrityCheckFlags: UserIntegrityCheckFlag.All });
 
 				expect(validateUserCountIntegrity).toHaveBeenCalled();
+			});
+
+			it('should skip and not validate user count when the payload is empty', async () => {
+				const keys = await service.updateMany([1], {}, { userIntegrityCheckFlags: UserIntegrityCheckFlag.All });
+
+				expect(keys).toEqual([]);
+				expect(validateUserCountIntegrity).not.toHaveBeenCalled();
+			});
+
+			it('should skip when the payload only contains the primary key', async () => {
+				const keys = await service.updateMany([1], { id: 1 }, { userIntegrityCheckFlags: UserIntegrityCheckFlag.All });
+
+				expect(keys).toEqual([]);
+				expect(validateUserCountIntegrity).not.toHaveBeenCalled();
 			});
 		});
 

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -1,4 +1,4 @@
-import { Action } from '@directus/constants';
+import { Action, ALTERATIONS_KEYS } from '@directus/constants';
 import { useEnv } from '@directus/env';
 import { ErrorCode, ForbiddenError, InvalidPayloadError, isDirectusError } from '@directus/errors';
 import { isSystemCollection } from '@directus/system-data';
@@ -7,6 +7,7 @@ import type {
 	AbstractServiceOptions,
 	Accountability,
 	ActionEventParams,
+	Alterations,
 	Item as AnyItem,
 	MutationTracker,
 	MutationOptions,
@@ -18,7 +19,7 @@ import type {
 import { UserIntegrityCheckFlag } from '@directus/types';
 import type Keyv from 'keyv';
 import type { Knex } from 'knex';
-import { assign, clone, cloneDeep, omit, pick, without } from 'lodash-es';
+import { assign, clone, cloneDeep, isPlainObject, omit, pick, without } from 'lodash-es';
 import { getCache } from '../cache.js';
 import { translateDatabaseError } from '../database/errors/translate.js';
 import { getAstFromQuery } from '../database/get-ast-from-query/get-ast-from-query.js';
@@ -719,6 +720,48 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 						},
 					)
 				: payload;
+
+		if (payloadAfterHooks === null) {
+			// A filter hook cleared the payload to null. Treating that as an explicit, opt-in
+			// cancellation (returning a null per key) is owned by the `allowFilterCancel` mutation
+			// option; on its own a null payload is invalid rather than a silent no-op.
+			throw new InvalidPayloadError({
+				reason: `A filter hook cancelled the update, but this operation requires it`,
+			});
+		}
+
+		const isEmptyAlterations = (value: unknown): boolean => {
+			// A bare `[]` is not empty here: for o2m it removes every existing child (see processO2M),
+			// so only the `{ create, update, delete }` object form can count as no change.
+			if (!isPlainObject(value)) return false;
+
+			const alterations = value as Partial<Alterations>;
+
+			// Guard against a JSON column that merely looks like an alterations object.
+			const isNotAlterationsShaped = Object.keys(alterations).some(
+				(key) => !ALTERATIONS_KEYS.includes(key as keyof Alterations),
+			);
+
+			if (isNotAlterationsShaped) return false;
+
+			// None of create / update / delete carries an item.
+			return ALTERATIONS_KEYS.every((operation) => !alterations[operation]?.length);
+		};
+
+		const changesNothing = (field: string): boolean => {
+			if (field === primaryKeyField) return true;
+			if (aliases.includes(field)) return isEmptyAlterations(payloadAfterHooks![field]);
+			return false;
+		};
+
+		const changedFields = Object.keys(payloadAfterHooks ?? {}).filter((field) => !changesNothing(field));
+
+		if (changedFields.length === 0) {
+			// An empty payload, a PK-only update, or a filter hook that cleared every field to an
+			// empty alterations object leaves nothing to change — skip the transaction,
+			// activity/revision rows and integrity checks.
+			return [];
+		}
 
 		// Sort keys to ensure that the order is maintained
 		keys.sort();

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -3,6 +3,7 @@ export * from './extensions.js';
 export * from './fields.js';
 export * from './files.js';
 export * from './injection.js';
+export * from './items.js';
 export * from './number.js';
 export * from './permissions.js';
 export * from './regex.js';

--- a/packages/constants/src/items.ts
+++ b/packages/constants/src/items.ts
@@ -1,0 +1,5 @@
+/**
+ * Keys of a nested relational mutation input (the `Alterations` type in `@directus/types`):
+ * `create` new children, `update` existing children by primary key, `delete` children by primary key.
+ */
+export const ALTERATIONS_KEYS = ['create', 'update', 'delete'] as const;


### PR DESCRIPTION
Fork-permanent, stacked on `fork-feat/batch-insert`. Cherry-picked from `v11.9.2-hhh-dev` (`776d93c` skip update when hooks yield no fields, `896fe04` use `where` over `whereIn` for single-key to reduce lock); both clean. v12 ref: #50.