### PR TITLE
fork-feat: 09 — typed filter output FilterHandler<TIn, TOut>

### DIFF
--- a/.changeset/filter-output-types.md
+++ b/.changeset/filter-output-types.md
@@ -1,0 +1,6 @@
+---
+'@directus/types': minor
+'@directus/api': minor
+---
+
+Allow a filter hook to declare a different output type than its input. `FilterHandler<TIn, TOut = TIn>` now carries a separate output type and returns `TIn | TOut`, threaded through `emitFilter`, `onFilter`/`offFilter`, and the `register.filter` hook registration. `emitFilter` additionally exposes the untouched input as `meta.originalPayload`. `TOut` defaults to `TIn`, so every existing filter keeps its exact signature — no caller changes.

--- a/api/src/emitter.test-d.ts
+++ b/api/src/emitter.test-d.ts
@@ -1,0 +1,62 @@
+import type { FilterHandler, RegisterFunctions } from '@directus/types';
+import { expectTypeOf, test } from 'vitest';
+import emitter from './emitter.js';
+
+type Item = { a: number };
+
+test('FilterHandler defaults TOut to TIn (backward compatible)', () => {
+	expectTypeOf<FilterHandler<Item>>().toEqualTypeOf<FilterHandler<Item, Item>>();
+});
+
+test('FilterHandler keeps the input type on its payload parameter', () => {
+	expectTypeOf<Parameters<FilterHandler<Item, number>>[0]>().toEqualTypeOf<Item>();
+});
+
+test('FilterHandler widens its return to TIn | TOut', () => {
+	expectTypeOf<ReturnType<FilterHandler<Item, number>>>().toEqualTypeOf<Item | number | Promise<Item | number>>();
+});
+
+test('a filter may return the output type instead of the payload', () => {
+	const cancel: FilterHandler<Item, number> = (payload) => {
+		expectTypeOf(payload).toEqualTypeOf<Item>();
+		return 5;
+	};
+
+	expectTypeOf(cancel).toEqualTypeOf<FilterHandler<Item, number>>();
+});
+
+test('emitFilter surfaces the output type alongside the input', () => {
+	const result = emitter.emitFilter<Item, number>('items.create', { a: 1 }, {});
+	expectTypeOf(result).toEqualTypeOf<Promise<Item | number>>();
+});
+
+test('emitFilter defaults the output type to the input type', () => {
+	const result = emitter.emitFilter<Item>('items.update', { a: 1 }, {});
+	expectTypeOf(result).toEqualTypeOf<Promise<Item>>();
+});
+
+test('onFilter accepts a handler whose output type differs from its input', () => {
+	emitter.onFilter<Item, number>('items.create', (payload) => {
+		expectTypeOf(payload).toEqualTypeOf<Item>();
+		return 5;
+	});
+});
+
+test('register.filter plumbs the output type so a hook can return a primary key', () => {
+	const register = {} as RegisterFunctions;
+
+	register.filter<Item, number>('items.create', (payload) => {
+		expectTypeOf(payload).toEqualTypeOf<Item>();
+		return 5;
+	});
+});
+
+test('offFilter accepts the same typed handler shape as onFilter', () => {
+	const handler: FilterHandler<Item, number> = (payload) => {
+		expectTypeOf(payload).toEqualTypeOf<Item>();
+		return 5;
+	};
+
+	emitter.onFilter<Item, number>('items.create', handler);
+	emitter.offFilter<Item, number>('items.create', handler);
+});

--- a/api/src/emitter.test.ts
+++ b/api/src/emitter.test.ts
@@ -1,0 +1,43 @@
+import type { EventContext } from '@directus/types';
+import { afterEach, describe, expect, it } from 'vitest';
+import emitter from './emitter.js';
+
+const context = {} as EventContext;
+
+describe('emitFilter', () => {
+	afterEach(() => {
+		emitter.offAll();
+	});
+
+	it('chains: each filter receives the previous filter output', async () => {
+		emitter.onFilter<number>('test.event', (payload) => payload + 1);
+		emitter.onFilter<number>('test.event', (payload) => payload * 10);
+
+		// second filter sees 2 (not the original 1), so 2 * 10 = 20
+		expect(await emitter.emitFilter('test.event', 1, {}, context)).toBe(20);
+	});
+
+	it('swallows undefined: payload is unchanged when a filter returns undefined', async () => {
+		emitter.onFilter('test.event', () => undefined);
+
+		expect(await emitter.emitFilter('test.event', { a: 1 }, {}, context)).toEqual({ a: 1 });
+	});
+
+	it('exposes the untouched input as meta.originalPayload after chaining', async () => {
+		emitter.onFilter('test.event', (payload: any) => ({ ...payload, step: 1 }));
+		emitter.onFilter('test.event', (_payload, meta) => meta['originalPayload']);
+
+		// the second filter recovers the original input despite the first having mutated the payload
+		expect(await emitter.emitFilter('test.event', { a: 1 }, {}, context)).toEqual({ a: 1 });
+	});
+
+	it('takes over: a filter returning a primary key surfaces that key', async () => {
+		emitter.onFilter<object, number>('test.event', () => 42);
+
+		expect(await emitter.emitFilter<object, number>('test.event', { a: 1 }, {}, context)).toBe(42);
+	});
+
+	it('returns the payload untouched when no filter is registered', async () => {
+		expect(await emitter.emitFilter('test.event', { a: 1 }, {}, context)).toEqual({ a: 1 });
+	});
+});

--- a/api/src/emitter.ts
+++ b/api/src/emitter.ts
@@ -31,24 +31,28 @@ export class Emitter {
 		};
 	}
 
-	public async emitFilter<T>(
+	public async emitFilter<TIn = unknown, TOut = TIn>(
 		event: string | string[],
-		payload: T,
+		payload: TIn,
 		meta: Record<string, any>,
 		context: EventContext | null = null,
-	): Promise<T> {
+	): Promise<TIn | TOut> {
 		const events = Array.isArray(event) ? event : [event];
 
 		const eventListeners = events.map((event) => ({
 			event,
-			listeners: this.filterEmitter.listeners(event) as FilterHandler<T>[],
+			listeners: this.filterEmitter.listeners(event) as FilterHandler<TIn, TOut>[],
 		}));
 
-		let updatedPayload = payload;
+		let updatedPayload: TIn | TOut = payload;
 
 		for (const { event, listeners } of eventListeners) {
 			for (const listener of listeners) {
-				const result = await listener(updatedPayload, { event, ...meta }, context ?? this.getDefaultContext());
+				const result = await listener(
+					updatedPayload as TIn,
+					{ event, ...meta, originalPayload: payload },
+					context ?? this.getDefaultContext(),
+				);
 
 				if (result !== undefined) {
 					updatedPayload = result;
@@ -82,7 +86,7 @@ export class Emitter {
 		}
 	}
 
-	public onFilter<T = unknown>(event: string, handler: FilterHandler<T>): void {
+	public onFilter<TIn = unknown, TOut = TIn>(event: string, handler: FilterHandler<TIn, TOut>): void {
 		this.filterEmitter.on(event, handler);
 	}
 
@@ -94,7 +98,7 @@ export class Emitter {
 		this.initEmitter.on(event, handler);
 	}
 
-	public offFilter<T = unknown>(event: string, handler: FilterHandler<T>): void {
+	public offFilter<TIn = unknown, TOut = TIn>(event: string, handler: FilterHandler<TIn, TOut>): void {
 		this.filterEmitter.off(event, handler);
 	}
 

--- a/api/src/extensions/manager.ts
+++ b/api/src/extensions/manager.ts
@@ -823,7 +823,7 @@ export class ExtensionManager {
 		const unregisterFunctions: PromiseCallback[] = [];
 
 		const hookRegistrationContext = {
-			filter: <T = unknown>(event: string, handler: FilterHandler<T>) => {
+			filter: <TIn = unknown, TOut = TIn>(event: string, handler: FilterHandler<TIn, TOut>) => {
 				emitter.onFilter(event, handler);
 
 				unregisterFunctions.push(() => {

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -9,11 +9,11 @@ export type EventContext = {
 	accountability: Accountability | null;
 };
 
-export type FilterHandler<T = unknown> = (
-	payload: T,
+export type FilterHandler<TIn = unknown, TOut = TIn> = (
+	payload: TIn,
 	meta: Record<string, any>,
 	context: EventContext,
-) => T | Promise<T>;
+) => TIn | TOut | Promise<TIn | TOut>;
 export type ActionHandler = (meta: Record<string, any>, context: EventContext) => void;
 export type InitHandler = (meta: Record<string, any>) => void;
 export type ScheduleHandler = PromiseCallback;

--- a/packages/types/src/extensions/hooks.ts
+++ b/packages/types/src/extensions/hooks.ts
@@ -6,7 +6,7 @@ export type HookExtensionContext = ApiExtensionContext & {
 };
 
 export type RegisterFunctions = {
-	filter: <T = unknown>(event: string, handler: FilterHandler<T>) => void;
+	filter: <TIn = unknown, TOut = TIn>(event: string, handler: FilterHandler<TIn, TOut>) => void;
 	action: (event: string, handler: ActionHandler) => void;
 	init: (event: string, handler: InitHandler) => void;
 	schedule: (cron: string, handler: ScheduleHandler) => void;


### PR DESCRIPTION
Fork-permanent, stacked on `fork-feat/db-errors-filterable`. Cherry-picked from `v11.9.2-hhh-dev` (set A: `3a91f6a`,`3b1438df`,`5167cf2`,`caf83e6`,`bbcb58f`; the botched-rebase dup set B skipped). emitter `emitFilter/onFilter/offFilter` generic <TIn,TOut> + `FilterHandler<TIn,TOut>`. The manager.ts `hookRegistrationContext: RegisterFunctions` typing refactor deferred (v11.10.1 import reshuffle conflict; non-core completeness). v12 ref: #59.