### PR TITLE
v11.10.1-feat: 02 — fix MariaDB JSON collation error

### DIFF
--- a/.changeset/mariadb-json-collation.md
+++ b/.changeset/mariadb-json-collation.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Stopped the database charset validation from warning about MariaDB JSON columns. MariaDB has no native JSON type and stores JSON as `LONGTEXT` with the `utf8mb4_bin` collation, which the validator previously reported as a collation mismatch on every startup. The MySQL schema helper now detects MariaDB via `VERSION()` and excludes that expected `LONGTEXT`/`utf8mb4_bin` pairing.

--- a/api/src/database/helpers/schema/dialects/mysql.ts
+++ b/api/src/database/helpers/schema/dialects/mysql.ts
@@ -1,7 +1,7 @@
 import { useEnv } from '@directus/env';
 import type { Knex } from 'knex';
 import { getDefaultIndexName } from '../../../../utils/get-default-index-name.js';
-import { SchemaHelper, type SortRecord } from '../types.js';
+import { type InvalidCollationColumn, SchemaHelper, type SortRecord } from '../types.js';
 
 const env = useEnv();
 
@@ -103,5 +103,30 @@ export class SchemaHelperMySQL extends SchemaHelper {
 
 			groupByFields.push(...sortRecords.map(({ alias }) => alias));
 		}
+	}
+
+	override async getColumnsWithInvalidCollation(schema: string, collation: string): Promise<InvalidCollationColumn[]> {
+		const { version } = await this.knex.select(this.knex.raw('VERSION() as version')).first();
+		const isMariaDB = String(version).split('-').includes('MariaDB');
+
+		return this.knex('information_schema.columns')
+			.select<InvalidCollationColumn[]>({
+				table_name: 'TABLE_NAME',
+				name: 'COLUMN_NAME',
+				collation: 'COLLATION_NAME',
+			})
+			.where({ TABLE_SCHEMA: schema })
+			.whereNot({ COLLATION_NAME: collation })
+			.modify((queryBuilder) => {
+				// MariaDB has no native JSON type; it stores JSON as LONGTEXT with the utf8mb4_bin
+				// collation, so that pairing is expected rather than a real collation mismatch.
+				// Exclude only the pairing — NOT(longtext AND utf8mb4_bin) — so a longtext column
+				// with a genuinely wrong collation (or a utf8mb4_bin non-longtext) is still reported.
+				if (isMariaDB) {
+					queryBuilder.andWhereNot((qb) => {
+						void qb.where({ COLUMN_TYPE: 'longtext' }).andWhere({ COLLATION_NAME: 'utf8mb4_bin' });
+					});
+				}
+			});
 	}
 }

--- a/api/src/database/helpers/schema/invalid-collation.test.ts
+++ b/api/src/database/helpers/schema/invalid-collation.test.ts
@@ -1,0 +1,70 @@
+import type { Knex } from 'knex';
+import knex from 'knex';
+import { createTracker, MockClient, type Tracker } from 'knex-mock-client';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+// Break the schema/types.ts -> database/index.ts -> schema/index.ts -> dialects circular import,
+// which otherwise leaves SchemaHelper undefined when a dialect is imported directly under vitest.
+vi.mock('../../index.js', () => ({ default: vi.fn(), getDatabaseClient: vi.fn(() => 'postgres') }));
+
+import { SchemaHelperMySQL } from './dialects/mysql.js';
+import { SchemaHelperPostgres } from './dialects/postgres.js';
+
+describe('getColumnsWithInvalidCollation', () => {
+	let db: Knex;
+	let tracker: Tracker;
+
+	beforeAll(() => {
+		db = knex.default({ client: MockClient });
+		tracker = createTracker(db);
+	});
+
+	afterEach(() => {
+		tracker.reset();
+	});
+
+	function columnsQuery() {
+		return tracker.history.select.find((s) => /information_schema.*columns/i.test(s.sql));
+	}
+
+	it('base helper queries information_schema.columns with no dialect special-casing', async () => {
+		tracker.on.select(/information_schema/i).response([]);
+
+		const helper = new SchemaHelperPostgres(db);
+		await helper.getColumnsWithInvalidCollation('mydb', 'utf8');
+
+		const q = columnsQuery();
+		expect(q).toBeDefined();
+		// No VERSION() probe and no MariaDB longtext/utf8mb4_bin carve-out on the base path.
+		expect(q!.sql.toLowerCase()).not.toContain('column_type');
+	});
+
+	it('mysql: reports columns whose collation differs from the DB default, no MariaDB carve-out', async () => {
+		tracker.on.select(/version\(\)/i).response([{ version: '8.0.36' }]);
+
+		tracker.on.select(/information_schema/i).response([{ table_name: 't', name: 'c', collation: 'latin1_swedish_ci' }]);
+
+		const helper = new SchemaHelperMySQL(db);
+		const rows = await helper.getColumnsWithInvalidCollation('mydb', 'utf8mb4_general_ci');
+
+		expect(rows).toEqual([{ table_name: 't', name: 'c', collation: 'latin1_swedish_ci' }]);
+		// Plain MySQL → no longtext/utf8mb4_bin exclusion.
+		expect(columnsQuery()!.sql.toLowerCase()).not.toContain('column_type');
+	});
+
+	it('mariadb: excludes the expected longtext + utf8mb4_bin JSON pairing', async () => {
+		tracker.on.select(/version\(\)/i).response([{ version: '10.11.6-MariaDB' }]);
+		tracker.on.select(/information_schema/i).response([]);
+
+		const helper = new SchemaHelperMySQL(db);
+		await helper.getColumnsWithInvalidCollation('mydb', 'utf8mb4_general_ci');
+
+		const sql = columnsQuery()!.sql.toLowerCase();
+		const bindings = columnsQuery()!.bindings.map(String);
+		// NOT(longtext AND utf8mb4_bin): a nested negated group on column_type + collation_name.
+		expect(sql).toContain('column_type');
+		expect(sql).toContain('not (');
+		expect(bindings).toContain('longtext');
+		expect(bindings).toContain('utf8mb4_bin');
+	});
+});

--- a/api/src/database/helpers/schema/types.ts
+++ b/api/src/database/helpers/schema/types.ts
@@ -18,6 +18,12 @@ export type SortRecord = {
 	column: Knex.Raw;
 };
 
+export type InvalidCollationColumn = {
+	table_name: string;
+	name: string;
+	collation: string;
+};
+
 export abstract class SchemaHelper extends DatabaseHelper {
 	isOneOfClients(clients: DatabaseClient[]): boolean {
 		return clients.includes(getDatabaseClient(this.knex));
@@ -209,5 +215,16 @@ export abstract class SchemaHelper extends DatabaseHelper {
 		const indexName = this.generateIndexName('index', collection, field);
 
 		await knex.raw('DROP INDEX IF EXISTS ??', [indexName]);
+	}
+
+	async getColumnsWithInvalidCollation(schema: string, collation: string): Promise<InvalidCollationColumn[]> {
+		return this.knex('information_schema.columns')
+			.select<InvalidCollationColumn[]>({
+				table_name: 'TABLE_NAME',
+				name: 'COLUMN_NAME',
+				collation: 'COLLATION_NAME',
+			})
+			.where({ TABLE_SCHEMA: schema })
+			.whereNot({ COLLATION_NAME: collation });
 	}
 }

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -347,16 +347,14 @@ async function validateDatabaseCharset(database?: Knex): Promise<void> {
 	const logger = useLogger();
 
 	if (getDatabaseClient(database) === 'mysql') {
+		const helpers = getHelpers(database);
 		const { collation } = await database.select(database.raw(`@@collation_database as collation`)).first();
 
 		const tables = await database('information_schema.tables')
 			.select({ name: 'TABLE_NAME', collation: 'TABLE_COLLATION' })
 			.where({ TABLE_SCHEMA: env['DB_DATABASE'] });
 
-		const columns = await database('information_schema.columns')
-			.select({ table_name: 'TABLE_NAME', name: 'COLUMN_NAME', collation: 'COLLATION_NAME' })
-			.where({ TABLE_SCHEMA: env['DB_DATABASE'] })
-			.whereNot({ COLLATION_NAME: collation });
+		const columns = await helpers.schema.getColumnsWithInvalidCollation(env['DB_DATABASE'] as string, collation);
 
 		const excludedTables: string[] = toArray(env['DB_EXCLUDE_TABLES']);
 


### PR DESCRIPTION
**Upstream-draft (v12):** #54 — the MSCL v12 implementation this BSL v11.10.1 feature is re-derived from.

Fork-permanent root feature on the v11 (BSL) line. Cherry-picked from `v11.9.2-hhh-dev` (`7db2ea6`) onto `hhh-v11-base` (v11.10.1). Source-of-truth hhh-dev impl (11 lines in `api/src/database/index.ts`) — simpler than the v12 #54 reimplementation. Root (isolated: `database/index.ts`).

---
_Recreated from #83 after the branch rename to the version-namespaced scheme (`v11.10.1-feat/*` on `upstream-v11.10.1`)._