### PR TITLE
v11.10.1-feat: 07 — reasons on ForbiddenErrors (#33)

### DIFF
--- a/.changeset/forbidden-error-reasons.md
+++ b/.changeset/forbidden-error-reasons.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': patch
+---
+
+Give a large set of `ForbiddenError`s a human-readable `reason`, so `403` responses say _why_ access was denied instead of the generic "You don't have permission to access this." Covers guards across the `collections`, `fields`, `relations` and `users` services (auth, token-type, public-registration, TFA), the `schema` service, `server health`, `getItemPermissions`, share `invite`, `ItemsService.readOne` not-found, primary-key validation, import/export, O2M payload resolution, and the `extensions` / `metrics` / `permissions` / `policies` / `roles` / `users` controllers. Uses the existing `ForbiddenError({ reason })` field — status stays `403`, no behavioural change beyond the message text.

--- a/api/src/controllers/extensions.ts
+++ b/api/src/controllers/extensions.ts
@@ -48,7 +48,9 @@ router.get(
 	'/registry',
 	asyncHandler(async (req, res, next) => {
 		if (req.accountability && req.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${req.accountability?.user}' does not have permission to access registry`,
+			});
 		}
 
 		const { search, limit, offset, sort, filter } = req.sanitizedQuery;
@@ -83,7 +85,7 @@ router.get(
 
 			if (type) {
 				if (isIn(type, EXTENSION_TYPES) === false) {
-					throw new ForbiddenError();
+					throw new ForbiddenError(); // InvalidPayload ? 404 ?
 				}
 
 				query.type = type;
@@ -158,13 +160,15 @@ router.post(
 	'/registry/install',
 	asyncHandler(async (req, _res, next) => {
 		if (req.accountability && req.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${req.accountability?.user}' does not have permission to access registry/install`,
+			});
 		}
 
 		const { version, extension } = req.body;
 
 		if (!version || !extension) {
-			throw new ForbiddenError();
+			throw new ForbiddenError(); // InvalidPayload ?
 		}
 
 		const service = new ExtensionsService({
@@ -182,13 +186,15 @@ router.post(
 	'/registry/reinstall',
 	asyncHandler(async (req, _res, next) => {
 		if (req.accountability && req.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${req.accountability?.user}' does not have permission to access registry/reinstall`,
+			});
 		}
 
 		const { extension } = req.body;
 
 		if (!extension) {
-			throw new ForbiddenError();
+			throw new ForbiddenError(); // InvalidPayload ?
 		}
 
 		const service = new ExtensionsService({
@@ -206,13 +212,15 @@ router.delete(
 	`/registry/uninstall/:pk(${UUID_REGEX})`,
 	asyncHandler(async (req, _res, next) => {
 		if (req.accountability && req.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${req.accountability?.user}' does not have permission to access registry/uninstall`,
+			});
 		}
 
 		const pk = req.params['pk'];
 
 		if (typeof pk !== 'string') {
-			throw new ForbiddenError();
+			throw new ForbiddenError(); // InvalidPayload ?
 		}
 
 		const service = new ExtensionsService({
@@ -230,11 +238,13 @@ router.patch(
 	`/:pk(${UUID_REGEX})`,
 	asyncHandler(async (req, res, next) => {
 		if (req.accountability && req.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${req.accountability?.user}' cannot update extension`,
+			});
 		}
 
 		if (typeof req.params['pk'] !== 'string') {
-			throw new ForbiddenError();
+			throw new ForbiddenError(); // InvalidPayload
 		}
 
 		const service = new ExtensionsService({
@@ -268,7 +278,9 @@ router.delete(
 	`/:pk(${UUID_REGEX})`,
 	asyncHandler(async (req, _res, next) => {
 		if (req.accountability && req.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${req.accountability?.user}' can't delete extension`,
+			});
 		}
 
 		const service = new ExtensionsService({
@@ -279,7 +291,7 @@ router.delete(
 		const pk = req.params['pk'];
 
 		if (typeof pk !== 'string') {
-			throw new ForbiddenError();
+			throw new ForbiddenError(); // InvalidPayload
 		}
 
 		await service.deleteOne(pk);

--- a/api/src/controllers/items.ts
+++ b/api/src/controllers/items.ts
@@ -17,7 +17,10 @@ router.post(
 	'/:collection',
 	collectionExists,
 	asyncHandler(async (req, res, next) => {
-		if (isSystemCollection(req.params['collection']!)) throw new ForbiddenError();
+		if (isSystemCollection(req.params['collection']!))
+			throw new ForbiddenError({
+				reason: 'Forbidden access to directus_* collections',
+			});
 
 		if (req.singleton) {
 			throw new RouteNotFoundError({ path: req.path });
@@ -60,7 +63,10 @@ router.post(
 );
 
 const readHandler = asyncHandler(async (req, res, next) => {
-	if (isSystemCollection(req.params['collection']!)) throw new ForbiddenError();
+	if (isSystemCollection(req.params['collection']!))
+		throw new ForbiddenError({
+			reason: 'Forbidden access to directus_* collections',
+		});
 
 	const service = new ItemsService(req.collection, {
 		accountability: req.accountability,
@@ -99,7 +105,10 @@ router.get(
 	'/:collection/:pk',
 	collectionExists,
 	asyncHandler(async (req, res, next) => {
-		if (isSystemCollection(req.params['collection']!)) throw new ForbiddenError();
+		if (isSystemCollection(req.params['collection']!))
+			throw new ForbiddenError({
+				reason: 'Forbidden access to directus_* collections',
+			});
 
 		const service = new ItemsService(req.collection, {
 			accountability: req.accountability,
@@ -123,7 +132,10 @@ router.patch(
 	collectionExists,
 	validateBatch('update'),
 	asyncHandler(async (req, res, next) => {
-		if (isSystemCollection(req.params['collection']!)) throw new ForbiddenError();
+		if (isSystemCollection(req.params['collection']!))
+			throw new ForbiddenError({
+				reason: 'Forbidden access to directus_* collections',
+			});
 
 		const service = new ItemsService(req.collection, {
 			accountability: req.accountability,
@@ -169,7 +181,10 @@ router.patch(
 	'/:collection/:pk',
 	collectionExists,
 	asyncHandler(async (req, res, next) => {
-		if (isSystemCollection(req.params['collection']!)) throw new ForbiddenError();
+		if (isSystemCollection(req.params['collection']!))
+			throw new ForbiddenError({
+				reason: 'Forbidden access to directus_* collections',
+			});
 
 		if (req.singleton) {
 			throw new RouteNotFoundError({ path: req.path });
@@ -203,7 +218,10 @@ router.delete(
 	collectionExists,
 	validateBatch('delete'),
 	asyncHandler(async (req, _res, next) => {
-		if (isSystemCollection(req.params['collection']!)) throw new ForbiddenError();
+		if (isSystemCollection(req.params['collection']!))
+			throw new ForbiddenError({
+				reason: 'Forbidden access to directus_* collections',
+			});
 
 		const service = new ItemsService(req.collection, {
 			accountability: req.accountability,
@@ -228,7 +246,10 @@ router.delete(
 	'/:collection/:pk',
 	collectionExists,
 	asyncHandler(async (req, _res, next) => {
-		if (isSystemCollection(req.params['collection']!)) throw new ForbiddenError();
+		if (isSystemCollection(req.params['collection']!))
+			throw new ForbiddenError({
+				reason: 'Forbidden access to directus_* collections',
+			});
 
 		const service = new ItemsService(req.collection, {
 			accountability: req.accountability,

--- a/api/src/controllers/metrics.ts
+++ b/api/src/controllers/metrics.ts
@@ -19,20 +19,26 @@ router.get(
 		const metricTokens = env['METRICS_TOKENS'] as string[] | undefined;
 
 		if (!req.headers || !req.headers.authorization || !metricTokens) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `Missing authorization header or missing METRICS_TOKENS env variable`,
+			});
 		}
 
 		const parts = req.headers.authorization.split(' ');
 
 		if (parts.length !== 2 || parts[0]!.toLowerCase() !== 'metrics') {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `Invalid authorization header`,
+			});
 		}
 
 		if (metricTokens.find((mt) => mt.toString() === parts[1]) !== undefined) {
 			return next();
 		}
 
-		throw new ForbiddenError();
+		throw new ForbiddenError({
+			reason: `Invalid metrics authorization token`,
+		});
 	}),
 	asyncHandler(async (_req, res) => {
 		res.set('Content-Type', 'text/plain');

--- a/api/src/controllers/permissions.ts
+++ b/api/src/controllers/permissions.ts
@@ -92,7 +92,9 @@ router.get(
 	'/me',
 	asyncHandler(async (req, res, next) => {
 		if (!req.accountability?.user && !req.accountability?.role && !req.accountability?.share)
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `Can't access /me without being logged in`,
+			});
 
 		const result = await fetchAccountabilityCollectionAccess(req.accountability, {
 			schema: req.schema,

--- a/api/src/controllers/policies.ts
+++ b/api/src/controllers/policies.ts
@@ -86,7 +86,10 @@ router.get(
 	'/me/globals',
 	asyncHandler(async (req, res, next) => {
 		try {
-			if (!req.accountability?.user && !req.accountability?.role) throw new ForbiddenError();
+			if (!req.accountability?.user && !req.accountability?.role)
+				throw new ForbiddenError({
+					reason: `Can't access /me/globals without being logged in`,
+				});
 
 			const result = await fetchAccountabilityPolicyGlobals(req.accountability, {
 				schema: req.schema,

--- a/api/src/controllers/roles.ts
+++ b/api/src/controllers/roles.ts
@@ -76,7 +76,10 @@ router.search('/', validateBatch('read'), readHandler, respond);
 router.get(
 	'/me',
 	asyncHandler(async (req, res, next) => {
-		if (!req.accountability?.user && !req.accountability?.role) throw new ForbiddenError();
+		if (!req.accountability?.user && !req.accountability?.role)
+			throw new ForbiddenError({
+				reason: `Can't access /me without being logged in`,
+			});
 
 		const service = new RolesService({
 			accountability: req.accountability,

--- a/api/src/controllers/users.ts
+++ b/api/src/controllers/users.ts
@@ -419,7 +419,9 @@ router.post(
 		}
 
 		if (!req.accountability.admin || !req.params['pk']) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `You are not allowed to disable TFA for this user`,
+			});
 		}
 
 		const service = new TFAService({

--- a/api/src/services/collections.test.ts
+++ b/api/src/services/collections.test.ts
@@ -1,0 +1,139 @@
+import { ForbiddenError } from '@directus/errors';
+import { SchemaBuilder } from '@directus/schema-builder';
+import type { Accountability } from '@directus/types';
+import type { Knex } from 'knex';
+import knex from 'knex';
+import { MockClient, Tracker, createTracker } from 'knex-mock-client';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { CollectionsService } from './collections.js';
+
+vi.mock('directus/version', () => ({ version: '0.0.0' }));
+
+vi.mock('../../src/database/index.js', () => {
+	return { __esModule: true, default: vi.fn(), getDatabaseClient: vi.fn().mockReturnValue('postgres') };
+});
+
+vi.mock('../database/helpers/index.js', () => ({
+	getHelpers: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('@directus/schema', () => ({
+	createInspector: vi.fn().mockReturnValue({}),
+}));
+
+const schema = new SchemaBuilder()
+	.collection('directus_collections', (c) => {
+		c.field('collection').string().primary();
+	})
+	.build();
+
+let db: Knex;
+let tracker: Tracker;
+
+beforeAll(() => {
+	db = knex.default({ client: MockClient });
+	tracker = createTracker(db);
+});
+
+afterEach(() => {
+	tracker.reset();
+	vi.clearAllMocks();
+	vi.restoreAllMocks();
+});
+
+const nonAdmin = { role: 'test', admin: false, user: 'test-user' } as Accountability;
+
+describe('Services / Collections', () => {
+	describe('createOne', () => {
+		it('should throw ForbiddenError for non-admin user', async () => {
+			const service = new CollectionsService({ knex: db, schema, accountability: nonAdmin });
+
+			await expect(service.createOne({ collection: 'x' } as any)).rejects.toThrowError(ForbiddenError);
+
+			await expect(service.createOne({ collection: 'x' } as any)).rejects.toThrowError(
+				`'test-user' can't create the collection 'x' as it's not an admin`,
+			);
+		});
+	});
+
+	describe('updateOne', () => {
+		it('should throw ForbiddenError for non-admin user', async () => {
+			const service = new CollectionsService({ knex: db, schema, accountability: nonAdmin });
+
+			await expect(service.updateOne('x', {})).rejects.toThrowError(ForbiddenError);
+
+			await expect(service.updateOne('x', {})).rejects.toThrowError(
+				`'test-user' does not have permission to update collections`,
+			);
+		});
+	});
+
+	describe('updateBatch', () => {
+		it('should throw ForbiddenError for non-admin user', async () => {
+			const service = new CollectionsService({ knex: db, schema, accountability: nonAdmin });
+
+			await expect(service.updateBatch([])).rejects.toThrowError(ForbiddenError);
+
+			await expect(service.updateBatch([])).rejects.toThrowError(
+				`'test-user' does not have permission to update collections`,
+			);
+		});
+	});
+
+	describe('updateMany', () => {
+		it('should throw ForbiddenError for non-admin user', async () => {
+			const service = new CollectionsService({ knex: db, schema, accountability: nonAdmin });
+
+			await expect(service.updateMany(['x'], {})).rejects.toThrowError(ForbiddenError);
+
+			await expect(service.updateMany(['x'], {})).rejects.toThrowError(
+				`'test-user' does not have permission to update collections`,
+			);
+		});
+	});
+
+	describe('deleteOne', () => {
+		it('should throw ForbiddenError for non-admin user', async () => {
+			const service = new CollectionsService({ knex: db, schema, accountability: nonAdmin });
+
+			await expect(service.deleteOne('x')).rejects.toThrowError(ForbiddenError);
+
+			await expect(service.deleteOne('x')).rejects.toThrowError(
+				`'test-user' does not have permission to delete collections`,
+			);
+		});
+
+		it('should throw ForbiddenError when the collection does not exist (admin)', async () => {
+			const service = new CollectionsService({
+				knex: db,
+				schema,
+				accountability: { role: 'admin', admin: true, user: 'admin-user' } as Accountability,
+			});
+
+			vi.spyOn(CollectionsService.prototype, 'readByQuery').mockResolvedValue([]);
+
+			await expect(service.deleteOne('missing')).rejects.toThrowError(ForbiddenError);
+			await expect(service.deleteOne('missing')).rejects.toThrowError(`Collection to delete 'missing' does not exist`);
+		});
+	});
+
+	describe('deleteMany', () => {
+		it('should throw ForbiddenError for non-admin user', async () => {
+			const service = new CollectionsService({ knex: db, schema, accountability: nonAdmin });
+
+			await expect(service.deleteMany(['x'])).rejects.toThrowError(ForbiddenError);
+			await expect(service.deleteMany(['x'])).rejects.toThrowError(`'test-user' can't delete many collections`);
+		});
+	});
+
+	describe('readOne', () => {
+		it('should throw ForbiddenError when the collection is not found', async () => {
+			const service = new CollectionsService({ knex: db, schema, accountability: nonAdmin });
+
+			vi.spyOn(CollectionsService.prototype, 'readMany').mockResolvedValue([]);
+
+			await expect(service.readOne('missing')).rejects.toThrowError(ForbiddenError);
+			await expect(service.readOne('missing')).rejects.toThrowError(`Collection 'missing' not found`);
+		});
+	});
+});

--- a/api/src/services/collections.ts
+++ b/api/src/services/collections.ts
@@ -61,7 +61,9 @@ export class CollectionsService {
 	 */
 	async createOne(payload: RawCollection, opts?: MutationOptions): Promise<string> {
 		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability.user}' can't create the collection '${payload.collection}' as it's not an admin`,
+			});
 		}
 
 		if (!('collection' in payload)) throw new InvalidPayloadError({ reason: `"collection" is required` });
@@ -381,7 +383,11 @@ export class CollectionsService {
 	async readOne(collectionKey: string): Promise<Collection> {
 		const result = await this.readMany([collectionKey]);
 
-		if (result.length === 0) throw new ForbiddenError();
+		if (result.length === 0) {
+			throw new ForbiddenError({
+				reason: `Collection '${collectionKey}' not found`, // 404 ?
+			});
+		}
 
 		return result[0]!;
 	}
@@ -418,7 +424,9 @@ export class CollectionsService {
 	 */
 	async updateOne(collectionKey: string, data: Partial<Collection>, opts?: MutationOptions): Promise<string> {
 		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability.user}' does not have permission to update collections`,
+			});
 		}
 
 		const nestedActionEvents: ActionEventParams[] = [];
@@ -485,7 +493,9 @@ export class CollectionsService {
 	 */
 	async updateBatch(data: Partial<Collection>[], opts?: MutationOptions): Promise<string[]> {
 		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability.user}' does not have permission to update collections`,
+			});
 		}
 
 		if (!Array.isArray(data)) {
@@ -546,7 +556,9 @@ export class CollectionsService {
 	 */
 	async updateMany(collectionKeys: string[], data: Partial<Collection>, opts?: MutationOptions): Promise<string[]> {
 		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability.user}' does not have permission to update collections`,
+			});
 		}
 
 		const nestedActionEvents: ActionEventParams[] = [];
@@ -595,7 +607,9 @@ export class CollectionsService {
 	 */
 	async deleteOne(collectionKey: string, opts?: MutationOptions): Promise<string> {
 		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability.user}' does not have permission to delete collections`,
+			});
 		}
 
 		const nestedActionEvents: ActionEventParams[] = [];
@@ -606,7 +620,9 @@ export class CollectionsService {
 			const collectionToBeDeleted = collections.find((collection) => collection.collection === collectionKey);
 
 			if (!!collectionToBeDeleted === false) {
-				throw new ForbiddenError();
+				throw new ForbiddenError({
+					reason: `Collection to delete '${collectionKey}' does not exist`, // 404 ?
+				});
 			}
 
 			await transaction(this.knex, async (trx) => {
@@ -778,7 +794,9 @@ export class CollectionsService {
 	 */
 	async deleteMany(collectionKeys: string[], opts?: MutationOptions): Promise<string[]> {
 		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability.user}' can't delete many collections`,
+			});
 		}
 
 		const nestedActionEvents: ActionEventParams[] = [];

--- a/api/src/services/fields.test.ts
+++ b/api/src/services/fields.test.ts
@@ -1,0 +1,94 @@
+import { ForbiddenError } from '@directus/errors';
+import { SchemaBuilder } from '@directus/schema-builder';
+import type { Accountability, RawField } from '@directus/types';
+import knex from 'knex';
+import { MockClient, createTracker } from 'knex-mock-client';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { Knex } from 'knex';
+import type { Tracker } from 'knex-mock-client';
+import { FieldsService } from './fields.js';
+
+vi.mock('../../src/database/index', () => ({
+	default: vi.fn(),
+	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
+}));
+
+const schema = new SchemaBuilder()
+	.collection('test', (c) => {
+		c.field('id').uuid().primary();
+	})
+	.build();
+
+const nonAdmin = { role: 'test', user: 'user-1', admin: false } as Accountability;
+const admin = { role: 'admin', user: 'admin-1', admin: true } as Accountability;
+
+class Client_PG extends MockClient {}
+
+let db: Knex;
+let tracker: Tracker;
+
+beforeAll(() => {
+	db = knex.default({ client: Client_PG });
+	tracker = createTracker(db);
+});
+
+afterEach(() => {
+	tracker.reset();
+	vi.clearAllMocks();
+});
+
+describe('Services / Fields', () => {
+	describe('createField', () => {
+		it('throws ForbiddenError for non-admin user', async () => {
+			const service = new FieldsService({ knex: db, schema, accountability: nonAdmin });
+
+			const promise = service.createField('test', { field: 'foo', type: 'string' });
+
+			await expect(promise).rejects.toThrowError(ForbiddenError);
+
+			await expect(service.createField('test', { field: 'foo', type: 'string' })).rejects.toThrowError(
+				'does not have the permission to create the field',
+			);
+		});
+	});
+
+	describe('updateField', () => {
+		it('throws ForbiddenError for non-admin user', async () => {
+			const service = new FieldsService({ knex: db, schema, accountability: nonAdmin });
+
+			const field = { field: 'foo', type: 'string' } as RawField;
+
+			await expect(service.updateField('test', field)).rejects.toThrowError(ForbiddenError);
+
+			await expect(service.updateField('test', field)).rejects.toThrowError(
+				'does not have the permission to update the field',
+			);
+		});
+	});
+
+	describe('deleteField', () => {
+		it('throws ForbiddenError for non-admin user', async () => {
+			const service = new FieldsService({ knex: db, schema, accountability: nonAdmin });
+
+			await expect(service.deleteField('test', 'foo')).rejects.toThrowError(ForbiddenError);
+
+			await expect(service.deleteField('test', 'foo')).rejects.toThrowError(
+				'does not have the permission to delete the field',
+			);
+		});
+	});
+
+	describe('readOne', () => {
+		it('throws ForbiddenError when schema info cannot be retrieved', async () => {
+			tracker.on.select('directus_fields').response([]);
+
+			const service = new FieldsService({ knex: db, schema, accountability: admin });
+
+			await expect(service.readOne('test', 'nonexistent')).rejects.toThrowError(ForbiddenError);
+
+			await expect(service.readOne('test', 'nonexistent')).rejects.toThrowError(
+				"Can't retrieve the schema info for the column 'nonexistent' of 'test'",
+			);
+		});
+	});
+});

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -245,7 +245,9 @@ export class FieldsService {
 			});
 
 			if (collection && collection in allowedFieldsInCollection === false) {
-				throw new ForbiddenError();
+				throw new ForbiddenError({
+					reason: `'${this.accountability.user}' does not have permission to read fields from '${collection}'.`,
+				});
 			}
 
 			result = result.filter((field) => {
@@ -297,7 +299,9 @@ export class FieldsService {
 			}
 
 			if (!hasAccess) {
-				throw new ForbiddenError();
+				throw new ForbiddenError({
+					reason: `'${this.accountability.user}' does not have permission to read '${collection}.${field}'`,
+				});
 			}
 		}
 
@@ -318,7 +322,12 @@ export class FieldsService {
 			// Do nothing
 		}
 
-		if (!column && !fieldInfo) throw new ForbiddenError();
+		if (!column && !fieldInfo) {
+			// 404 / InvalidPayload / CorruptedSchema?
+			throw new ForbiddenError({
+				reason: `Can't retrieve the schema info for the column '${field}' of '${collection}'`,
+			});
+		}
 
 		const type = getLocalType(column, fieldInfo);
 
@@ -347,7 +356,9 @@ export class FieldsService {
 		opts?: MutationOptions,
 	): Promise<void> {
 		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability.user}' does not have the permission to create the field '${field}' in '${collection}'`,
+			});
 		}
 
 		const runPostColumnChange = await this.helpers.schema.preColumnChange();
@@ -472,7 +483,9 @@ export class FieldsService {
 
 	async updateField(collection: string, field: RawField, opts?: MutationOptions): Promise<string> {
 		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability.user}' does not have the permission to update the field '${field}' in '${collection}'`,
+			});
 		}
 
 		const runPostColumnChange = await this.helpers.schema.preColumnChange();
@@ -660,7 +673,9 @@ export class FieldsService {
 
 	async deleteField(collection: string, field: string, opts?: MutationOptions): Promise<void> {
 		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability.user}' does not have the permission to delete the field '${field}' in '${collection}'`,
+			});
 		}
 
 		const runPostColumnChange = await this.helpers.schema.preColumnChange();

--- a/api/src/services/import-export.ts
+++ b/api/src/services/import-export.ts
@@ -59,7 +59,10 @@ export class ImportService {
 	}
 
 	async import(collection: string, mimetype: string, stream: Readable): Promise<void> {
-		if (this.accountability?.admin !== true && isSystemCollection(collection)) throw new ForbiddenError();
+		if (this.accountability?.admin !== true && isSystemCollection(collection))
+			throw new ForbiddenError({
+				reason: `'${this.accountability?.user}' can't import to '${collection}' as not being an admin`,
+			});
 
 		if (this.accountability) {
 			await validateAccess(

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -1,3 +1,4 @@
+import { ForbiddenError } from '@directus/errors';
 import { SchemaBuilder } from '@directus/schema-builder';
 import { UserIntegrityCheckFlag } from '@directus/types';
 import knex, { type Knex } from 'knex';
@@ -56,6 +57,18 @@ describe('Integration Tests', () => {
 
 		afterEach(() => {
 			vi.clearAllMocks();
+		});
+
+		describe('readOne', () => {
+			it('throws a ForbiddenError with a reason when the item is not found or not accessible', async () => {
+				service.readByQuery = vi.fn(async () => []);
+
+				const error = await service.readOne(999).catch((err) => err);
+
+				expect(error).toBeInstanceOf(ForbiddenError);
+
+				expect(error.message).toBe('No result found for key 999 in test during items.readOne()');
+			});
 		});
 
 		describe('createOne', () => {

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -520,7 +520,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 		// TODO when would this happen?
 		if (records === null) {
-			throw new ForbiddenError();
+			throw new ForbiddenError(); // 404 / InvalidPayload ?
 		}
 
 		const filteredRecords =
@@ -574,7 +574,10 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		const results = await this.readByQuery(queryWithKey, opts);
 
 		if (results.length === 0) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				// 404 / InvalidPayload?
+				reason: `No result found for key ${key} in ${this.collection} during items.readOne()`,
+			});
 		}
 
 		return results[0]!;

--- a/api/src/services/payload.test.ts
+++ b/api/src/services/payload.test.ts
@@ -8,6 +8,7 @@ import { getHelpers } from '../database/helpers/index.js';
 import { PayloadService } from './index.js';
 import { SchemaBuilder } from '@directus/schema-builder';
 import type { Item, Accountability } from '@directus/types';
+import { ForbiddenError } from '@directus/errors';
 
 vi.mock('../../src/database/index', () => ({
 	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
@@ -458,6 +459,39 @@ describe('Integration Tests', () => {
 				);
 
 				expect(result).toMatchObject({ other_string: 'not-redacted', other_hidden: REDACT_STR });
+			});
+		});
+
+		describe('processO2M', () => {
+			const schema = new SchemaBuilder()
+				.collection('country', (c) => {
+					c.field('id').id();
+					c.field('cities').o2m('city', 'country_id');
+				})
+				.collection('city', (c) => {
+					c.field('id').id();
+					c.field('country_id').integer();
+				})
+				.build();
+
+			let service: PayloadService;
+
+			beforeEach(() => {
+				service = new PayloadService('country', {
+					knex: db,
+					schema,
+				});
+			});
+
+			test('throws ForbiddenError when a referenced O2M primary key does not exist', async () => {
+				// The related-record lookup by PK resolves to no row, so the existing-record guard fails.
+				tracker.on.select('city').response([]);
+
+				await expect(service.processO2M({ cities: [99] }, 1)).rejects.toThrowError(ForbiddenError);
+
+				await expect(service.processO2M({ cities: [99] }, 1)).rejects.toThrowError(
+					"Could not find a 'city' record having the primary key 99 while processing O2M relation",
+				);
 			});
 		});
 	});

--- a/api/src/services/payload.ts
+++ b/api/src/services/payload.ts
@@ -726,7 +726,10 @@ export class PayloadService {
 
 					if (typeof relatedRecord === 'string' || typeof relatedRecord === 'number') {
 						if (!existingRecord) {
-							throw new ForbiddenError();
+							// 404 / InvalidPayload?
+							throw new ForbiddenError({
+								reason: `Could not find a '${relation.collection}' record having the primary key ${record} while processing O2M relation`,
+							});
 						}
 
 						// If the related item is already associated to the current item, and there's no

--- a/api/src/services/permissions.ts
+++ b/api/src/services/permissions.ts
@@ -86,7 +86,8 @@ export class PermissionsService extends ItemsService {
 	}
 
 	async getItemPermissions(collection: string, primaryKey?: string): Promise<ItemPermissions> {
-		if (!this.accountability?.user) throw new ForbiddenError();
+		if (!this.accountability?.user)
+			throw new ForbiddenError({ reason: 'You must be authenticated to read item permissions.' });
 
 		if (this.accountability?.admin) {
 			return {

--- a/api/src/services/relations.test.ts
+++ b/api/src/services/relations.test.ts
@@ -1,0 +1,118 @@
+import { ForbiddenError } from '@directus/errors';
+import { SchemaBuilder } from '@directus/schema-builder';
+import type { Accountability } from '@directus/types';
+import knex from 'knex';
+import type { Knex } from 'knex';
+import { MockClient, Tracker, createTracker } from 'knex-mock-client';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { fetchAllowedFields } from '../permissions/modules/fetch-allowed-fields/fetch-allowed-fields.js';
+import { validateAccess } from '../permissions/modules/validate-access/validate-access.js';
+import { ItemsService } from './items.js';
+import { RelationsService } from './relations.js';
+
+vi.mock('../../src/database/index', () => ({
+	default: vi.fn(),
+	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
+}));
+
+vi.mock('../permissions/modules/validate-access/validate-access.js', () => ({
+	validateAccess: vi.fn(),
+}));
+
+vi.mock('../permissions/modules/fetch-allowed-fields/fetch-allowed-fields.js', () => ({
+	fetchAllowedFields: vi.fn(),
+}));
+
+const schema = new SchemaBuilder()
+	.collection('test', (c) => {
+		c.field('id').uuid().primary();
+		c.field('related').m2o('related');
+	})
+	.collection('related', (c) => {
+		c.field('id').uuid().primary();
+	})
+	.build();
+
+const nonAdmin = { role: 'test', admin: false, user: 'test-user' } as Accountability;
+const admin = { role: 'admin', admin: true, user: 'admin-user' } as Accountability;
+
+class Client_PG extends MockClient {}
+
+let db: Knex;
+let tracker: Tracker;
+
+beforeAll(() => {
+	db = knex.default({ client: Client_PG });
+	tracker = createTracker(db);
+});
+
+afterEach(() => {
+	tracker.reset();
+	vi.clearAllMocks();
+});
+
+describe('Services / Relations', () => {
+	describe('createOne', () => {
+		it('should throw ForbiddenError for non-admin user', async () => {
+			const service = new RelationsService({ knex: db, schema, accountability: nonAdmin });
+
+			await expect(service.createOne({ collection: 'test', field: 'related' })).rejects.toThrowError(ForbiddenError);
+
+			await expect(service.createOne({ collection: 'test', field: 'related' })).rejects.toThrowError(
+				`'test-user' is not allowed to create a relation`,
+			);
+		});
+	});
+
+	describe('updateOne', () => {
+		it('should throw ForbiddenError for non-admin user', async () => {
+			const service = new RelationsService({ knex: db, schema, accountability: nonAdmin });
+
+			await expect(service.updateOne('test', 'related', {})).rejects.toThrowError(ForbiddenError);
+
+			await expect(service.updateOne('test', 'related', {})).rejects.toThrowError(
+				`'test-user' is not allowed to update a relation`,
+			);
+		});
+	});
+
+	describe('deleteOne', () => {
+		it('should throw ForbiddenError for non-admin user', async () => {
+			const service = new RelationsService({ knex: db, schema, accountability: nonAdmin });
+
+			await expect(service.deleteOne('test', 'related')).rejects.toThrowError(ForbiddenError);
+
+			await expect(service.deleteOne('test', 'related')).rejects.toThrowError(
+				`'test-user' is not allowed to delete a relation`,
+			);
+		});
+	});
+
+	describe('readOne', () => {
+		it('should throw ForbiddenError when non-admin lacks field read permission', async () => {
+			vi.mocked(validateAccess).mockResolvedValue(undefined);
+			vi.mocked(fetchAllowedFields).mockResolvedValue(['id']);
+
+			const service = new RelationsService({ knex: db, schema, accountability: nonAdmin });
+
+			await expect(service.readOne('test', 'related')).rejects.toThrowError(ForbiddenError);
+
+			await expect(service.readOne('test', 'related')).rejects.toThrowError(
+				`'test-user' has no permission to read the field 'related' of 'test'`,
+			);
+		});
+
+		it('should throw ForbiddenError when no relation is found', async () => {
+			vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([]);
+			vi.spyOn(RelationsService.prototype, 'foreignKeys').mockResolvedValue([]);
+
+			const service = new RelationsService({ knex: db, schema, accountability: admin });
+
+			await expect(service.readOne('test', 'related')).rejects.toThrowError(ForbiddenError);
+
+			await expect(service.readOne('test', 'related')).rejects.toThrowError(
+				`No result found for relation test.related during items.readOne()`,
+			);
+		});
+	});
+});

--- a/api/src/services/relations.ts
+++ b/api/src/services/relations.ts
@@ -151,7 +151,9 @@ export class RelationsService {
 			);
 
 			if (allowedFields.includes('*') === false && allowedFields.includes(field) === false) {
-				throw new ForbiddenError();
+				throw new ForbiddenError({
+					reason: `'${this.accountability.user}' has no permission to read the field '${field}' of '${collection}'`,
+				});
 			}
 		}
 
@@ -179,7 +181,10 @@ export class RelationsService {
 		const results = await this.filterForbidden(stitched);
 
 		if (results.length === 0) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				// 404 / InvalidPayload?
+				reason: `No result found for relation ${collection}.${field} during items.readOne()`,
+			});
 		}
 
 		return results[0]!;
@@ -190,7 +195,9 @@ export class RelationsService {
 	 */
 	async createOne(relation: Partial<Relation>, opts?: MutationOptions): Promise<void> {
 		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability.user}' is not allowed to create a relation`,
+			});
 		}
 
 		if (!relation.collection) {
@@ -318,7 +325,9 @@ export class RelationsService {
 		opts?: MutationOptions,
 	): Promise<void> {
 		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability.user}' is not allowed to update a relation`,
+			});
 		}
 
 		const collectionSchema = this.schema.collections[collection];
@@ -438,7 +447,9 @@ export class RelationsService {
 	 */
 	async deleteOne(collection: string, field: string, opts?: MutationOptions): Promise<void> {
 		if (this.accountability && this.accountability.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability.user}' is not allowed to delete a relation`,
+			});
 		}
 
 		if (collection in this.schema.collections === false) {

--- a/api/src/services/schema.test.ts
+++ b/api/src/services/schema.test.ts
@@ -82,6 +82,7 @@ describe('Services / Schema', () => {
 			const service = new SchemaService({ knex: db, accountability: { role: 'test', admin: false } as Accountability });
 
 			await expect(service.snapshot()).rejects.toThrowError(ForbiddenError);
+			await expect(service.snapshot()).rejects.toThrowError('Only administrators can read a schema snapshot.');
 		});
 
 		it('should return snapshot for admin user', async () => {
@@ -109,6 +110,11 @@ describe('Services / Schema', () => {
 			const service = new SchemaService({ knex: db, accountability: { role: 'test', admin: false } as Accountability });
 
 			await expect(service.apply(snapshotDiffWithHash)).rejects.toThrowError(ForbiddenError);
+
+			await expect(service.apply(snapshotDiffWithHash)).rejects.toThrowError(
+				'Only administrators can apply a schema diff.',
+			);
+
 			expect(vi.mocked(applyDiff)).not.toHaveBeenCalledOnce();
 		});
 
@@ -158,6 +164,10 @@ describe('Services / Schema', () => {
 
 			await expect(service.diff(snapshotToApply, { currentSnapshot: testSnapshot, force: true })).rejects.toThrowError(
 				ForbiddenError,
+			);
+
+			await expect(service.diff(snapshotToApply, { currentSnapshot: testSnapshot, force: true })).rejects.toThrowError(
+				'Only administrators can diff the schema.',
 			);
 		});
 

--- a/api/src/services/schema.ts
+++ b/api/src/services/schema.ts
@@ -26,7 +26,8 @@ export class SchemaService {
 	}
 
 	async snapshot(): Promise<Snapshot> {
-		if (this.accountability?.admin !== true) throw new ForbiddenError();
+		if (this.accountability?.admin !== true)
+			throw new ForbiddenError({ reason: 'Only administrators can read a schema snapshot.' });
 
 		const currentSnapshot = await getSnapshot({ database: this.knex });
 
@@ -34,7 +35,8 @@ export class SchemaService {
 	}
 
 	async apply(payload: SnapshotDiffWithHash): Promise<void> {
-		if (this.accountability?.admin !== true) throw new ForbiddenError();
+		if (this.accountability?.admin !== true)
+			throw new ForbiddenError({ reason: 'Only administrators can apply a schema diff.' });
 
 		const currentSnapshot = await this.snapshot();
 		const snapshotWithHash = this.getHashedSnapshot(currentSnapshot);
@@ -48,7 +50,8 @@ export class SchemaService {
 		snapshot: Snapshot,
 		options?: { currentSnapshot?: Snapshot; force?: boolean },
 	): Promise<SnapshotDiff | null> {
-		if (this.accountability?.admin !== true) throw new ForbiddenError();
+		if (this.accountability?.admin !== true)
+			throw new ForbiddenError({ reason: 'Only administrators can diff the schema.' });
 
 		validateSnapshot(snapshot, options?.force);
 

--- a/api/src/services/shares.test.ts
+++ b/api/src/services/shares.test.ts
@@ -1,0 +1,45 @@
+import { ForbiddenError } from '@directus/errors';
+import { SchemaBuilder } from '@directus/schema-builder';
+import type { Accountability } from '@directus/types';
+import knex, { type Knex } from 'knex';
+import { MockClient, Tracker, createTracker } from 'knex-mock-client';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { SharesService } from './shares.js';
+
+vi.mock('../../src/database/index', () => ({
+	default: vi.fn(),
+	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
+}));
+
+const schema = new SchemaBuilder()
+	.collection('directus_shares', (c) => {
+		c.field('id').id();
+	})
+	.build();
+
+let db: Knex;
+let tracker: Tracker;
+
+beforeAll(() => {
+	db = knex.default({ client: MockClient });
+	tracker = createTracker(db);
+});
+
+afterEach(() => {
+	tracker.reset();
+	vi.clearAllMocks();
+});
+
+describe('Services / Shares', () => {
+	describe('invite', () => {
+		it('should throw ForbiddenError when accountability has no user', async () => {
+			const service = new SharesService({ knex: db, schema, accountability: {} as Accountability });
+
+			await expect(service.invite({ emails: ['test@example.com'], share: 1 })).rejects.toThrowError(ForbiddenError);
+
+			await expect(service.invite({ emails: ['test@example.com'], share: 1 })).rejects.toThrowError(
+				'You must be authenticated to send a share invite.',
+			);
+		});
+	});
+});

--- a/api/src/services/shares.ts
+++ b/api/src/services/shares.ts
@@ -141,7 +141,8 @@ export class SharesService extends ItemsService {
 	 * if you have read access to that particular share
 	 */
 	async invite(payload: { emails: string[]; share: PrimaryKey }) {
-		if (!this.accountability?.user) throw new ForbiddenError();
+		if (!this.accountability?.user)
+			throw new ForbiddenError({ reason: 'You must be authenticated to send a share invite.' });
 
 		const share = await this.readOne(payload.share, { fields: ['collection'] });
 

--- a/api/src/services/users.test.ts
+++ b/api/src/services/users.test.ts
@@ -1,4 +1,4 @@
-import { InvalidPayloadError, RecordNotUniqueError } from '@directus/errors';
+import { ForbiddenError, InvalidPayloadError, RecordNotUniqueError } from '@directus/errors';
 import { SchemaBuilder } from '@directus/schema-builder';
 import type { Accountability, MutationOptions } from '@directus/types';
 import { UserIntegrityCheckFlag } from '@directus/types';
@@ -6,7 +6,9 @@ import knex from 'knex';
 import { MockClient, createTracker } from 'knex-mock-client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { validateRemainingAdminUsers } from '../permissions/modules/validate-remaining-admin/validate-remaining-admin-users.js';
+import { verifyJWT } from '../utils/jwt.js';
 import { ItemsService, MailService, UsersService } from './index.js';
+import { SettingsService } from './settings.js';
 
 vi.mock('../../src/database/index', () => ({
 	default: vi.fn(),
@@ -30,6 +32,14 @@ vi.mock('@directus/env', () => ({
 }));
 
 vi.mock('../permissions/modules/validate-remaining-admin/validate-remaining-admin-users.js');
+
+vi.mock('../utils/jwt.js', () => ({
+	verifyJWT: vi.fn(),
+}));
+
+vi.mock('../utils/stall.js', () => ({
+	stall: vi.fn().mockResolvedValue(undefined),
+}));
 
 const testRoleId = '4ccdb196-14b3-4ed1-b9da-c1978be07ca2';
 
@@ -391,6 +401,137 @@ describe('Integration Tests', () => {
 
 				expect(superUpdateManySpy.mock.lastCall![0]).toEqual([mockUser.id]);
 				expect(superUpdateManySpy.mock.lastCall![1]).toEqual({ role: 'invite-role' });
+			});
+		});
+
+		describe('acceptInvite', () => {
+			it('should reject a token whose scope is not "invite" (users.ts L420)', async () => {
+				vi.mocked(verifyJWT).mockReturnValue({ email: 'user@example.com', scope: 'password-reset' } as any);
+
+				const getUserByEmailSpy = vi.spyOn(UsersService.prototype as any, 'getUserByEmail');
+
+				const promise = service.acceptInvite('bad-token', 'new-password');
+
+				await expect(promise).rejects.toThrowError(ForbiddenError);
+				await expect(promise).rejects.toThrowError('Not an invite token');
+
+				expect(getUserByEmailSpy).not.toBeCalled();
+			});
+		});
+
+		describe('verifyRegistration', () => {
+			it('should reject a token whose scope is not "pending-registration" (users.ts L551)', async () => {
+				vi.mocked(verifyJWT).mockReturnValue({ email: 'user@example.com', scope: 'invite' } as any);
+
+				const getUserByEmailSpy = vi.spyOn(UsersService.prototype as any, 'getUserByEmail');
+
+				const promise = service.verifyRegistration('bad-token');
+
+				await expect(promise).rejects.toThrowError(ForbiddenError);
+				await expect(promise).rejects.toThrowError('Not a pending registration token');
+
+				expect(getUserByEmailSpy).not.toBeCalled();
+			});
+		});
+
+		describe('resetPassword', () => {
+			it('should reject a token whose scope is not "password-reset" (users.ts L625)', async () => {
+				vi.mocked(verifyJWT).mockReturnValue({ email: 'user@example.com', scope: 'invite', hash: 'abc' } as any);
+
+				const promise = service.resetPassword('bad-token', 'new-password');
+
+				await expect(promise).rejects.toThrowError(ForbiddenError);
+				await expect(promise).rejects.toThrowError('Not a password reset token');
+			});
+
+			it('should reject a password-reset token without a hash (users.ts L625)', async () => {
+				vi.mocked(verifyJWT).mockReturnValue({ email: 'user@example.com', scope: 'password-reset', hash: '' } as any);
+
+				const promise = service.resetPassword('bad-token', 'new-password');
+
+				await expect(promise).rejects.toThrowError(ForbiddenError);
+				await expect(promise).rejects.toThrowError('Not a password reset token');
+			});
+
+			it('should reject when the target user is not active (users.ts L640)', async () => {
+				vi.mocked(verifyJWT).mockReturnValue({
+					email: 'user@example.com',
+					scope: 'password-reset',
+					hash: 'some-hash',
+				} as any);
+
+				vi.spyOn(UsersService.prototype as any, 'checkPasswordPolicy').mockResolvedValue(undefined);
+
+				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+					id: 'user-id-reset-1',
+					status: 'suspended',
+					password: 'hashed',
+				});
+
+				const promise = service.resetPassword('reset-token', 'new-password');
+
+				await expect(promise).rejects.toThrowError(ForbiddenError);
+				await expect(promise).rejects.toThrowError('Inactive user');
+			});
+
+			it('should reject when the token hash does not match the user (users.ts L646)', async () => {
+				vi.mocked(verifyJWT).mockReturnValue({
+					email: 'user@example.com',
+					scope: 'password-reset',
+					hash: 'mismatching-hash',
+				} as any);
+
+				vi.spyOn(UsersService.prototype as any, 'checkPasswordPolicy').mockResolvedValue(undefined);
+
+				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+					id: 'user-id-reset-2',
+					status: 'active',
+					password: 'hashed',
+				});
+
+				const promise = service.resetPassword('reset-token', 'new-password');
+
+				await expect(promise).rejects.toThrowError(ForbiddenError);
+				await expect(promise).rejects.toThrowError('Bad user credentials');
+			});
+		});
+
+		describe('requestPasswordReset', () => {
+			it('should reject when the target user is not active (users.ts L575)', async () => {
+				vi.spyOn(UsersService.prototype as any, 'getUserByEmail').mockResolvedValueOnce({
+					id: 'user-id-req-1',
+					status: 'suspended',
+				});
+
+				const promise = service.requestPasswordReset('user@example.com', null);
+
+				await expect(promise).rejects.toThrowError(ForbiddenError);
+				await expect(promise).rejects.toThrowError('Inactive user');
+			});
+		});
+
+		describe('registerUser', () => {
+			it('should reject when public registration is disabled (users.ts L464)', async () => {
+				vi.spyOn(SettingsService.prototype, 'readSingleton').mockResolvedValueOnce({
+					public_registration: false,
+				});
+
+				const promise = service.registerUser({ email: 'user@example.com', password: 'new-password' });
+
+				await expect(promise).rejects.toThrowError(ForbiddenError);
+				await expect(promise).rejects.toThrowError('Public registration is disabled');
+			});
+
+			it('should reject when the email fails the configured email filter (users.ts L489)', async () => {
+				vi.spyOn(SettingsService.prototype, 'readSingleton').mockResolvedValueOnce({
+					public_registration: true,
+					public_registration_email_filter: { email: { _ends_with: '@allowed.com' } },
+				});
+
+				const promise = service.registerUser({ email: 'user@example.com', password: 'new-password' });
+
+				await expect(promise).rejects.toThrowError(ForbiddenError);
+				await expect(promise).rejects.toThrowError('Invalid payload');
 			});
 		});
 	});

--- a/api/src/services/users.ts
+++ b/api/src/services/users.ts
@@ -417,7 +417,10 @@ export class UsersService extends ItemsService {
 			scope: string;
 		};
 
-		if (scope !== 'invite') throw new ForbiddenError();
+		if (scope !== 'invite')
+			throw new ForbiddenError({
+				reason: 'Not an invite token',
+			});
 
 		const user = await this.getUserByEmail(email);
 
@@ -459,7 +462,9 @@ export class UsersService extends ItemsService {
 		});
 
 		if (settings?.['public_registration'] == false) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: 'Public registration is disabled',
+			});
 		}
 
 		const publicRegistrationRole = settings?.['public_registration_role'] ?? null;
@@ -481,7 +486,9 @@ export class UsersService extends ItemsService {
 
 		if (emailFilter && validatePayload(emailFilter, { email: input.email }).length !== 0) {
 			await stall(STALL_TIME, timeStart);
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: 'Invalid payload',
+			});
 		}
 
 		const user = await this.getUserByEmail(input.email);
@@ -541,7 +548,10 @@ export class UsersService extends ItemsService {
 			scope: string;
 		};
 
-		if (scope !== 'pending-registration') throw new ForbiddenError();
+		if (scope !== 'pending-registration')
+			throw new ForbiddenError({
+				reason: 'Not a pending registration token',
+			});
 
 		const user = await this.getUserByEmail(email);
 
@@ -562,7 +572,9 @@ export class UsersService extends ItemsService {
 
 		if (user?.status !== 'active') {
 			await stall(STALL_TIME, timeStart);
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: 'Inactive user',
+			});
 		}
 
 		if (url && isUrlAllowed(url, env['PASSWORD_RESET_URL_ALLOW_LIST'] as string) === false) {
@@ -610,7 +622,10 @@ export class UsersService extends ItemsService {
 			hash: string;
 		};
 
-		if (scope !== 'password-reset' || !hash) throw new ForbiddenError();
+		if (scope !== 'password-reset' || !hash)
+			throw new ForbiddenError({
+				reason: 'Not a password reset token',
+			});
 
 		const opts: MutationOptions = {};
 
@@ -622,8 +637,16 @@ export class UsersService extends ItemsService {
 
 		const user = await this.getUserByEmail(email);
 
-		if (user?.status !== 'active' || hash !== getSimpleHash('' + user.password)) {
-			throw new ForbiddenError();
+		if (user?.status !== 'active') {
+			throw new ForbiddenError({
+				reason: 'Inactive user',
+			});
+		}
+
+		if (hash !== getSimpleHash('' + user.password)) {
+			throw new ForbiddenError({
+				reason: 'Bad user credentials',
+			});
 		}
 
 		// Allow unauthenticated update

--- a/api/src/services/utils.test.ts
+++ b/api/src/services/utils.test.ts
@@ -1,0 +1,76 @@
+import { ForbiddenError } from '@directus/errors';
+import { SchemaBuilder } from '@directus/schema-builder';
+import type { Accountability } from '@directus/types';
+import knex, { type Knex } from 'knex';
+import { MockClient, Tracker, createTracker } from 'knex-mock-client';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { fetchAllowedFields } from '../permissions/modules/fetch-allowed-fields/fetch-allowed-fields.js';
+import { validateAccess } from '../permissions/modules/validate-access/validate-access.js';
+import { UtilsService } from './utils.js';
+
+vi.mock('../../src/database/index', () => ({
+	default: vi.fn(),
+	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
+}));
+
+vi.mock('../permissions/modules/validate-access/validate-access.js');
+vi.mock('../permissions/modules/fetch-allowed-fields/fetch-allowed-fields.js');
+
+const schema = new SchemaBuilder()
+	.collection('test', (c) => {
+		c.field('id').id();
+		c.field('sort').integer();
+	})
+	.build();
+
+let db: Knex;
+let tracker: Tracker;
+
+beforeAll(() => {
+	db = knex.default({ client: MockClient });
+	tracker = createTracker(db);
+});
+
+afterEach(() => {
+	tracker.reset();
+	vi.clearAllMocks();
+});
+
+describe('Services / Utils', () => {
+	describe('sort', () => {
+		it('should throw ForbiddenError when non-admin lacks read permission on the sort field', async () => {
+			tracker.on.select('directus_collections').response({ sort_field: 'sort' });
+
+			vi.mocked(validateAccess).mockResolvedValue(undefined);
+			vi.mocked(fetchAllowedFields).mockResolvedValue(['id']);
+
+			const service = new UtilsService({
+				knex: db,
+				schema,
+				accountability: { user: 'test-user', admin: false } as Accountability,
+			});
+
+			await expect(service.sort('test', { item: 1, to: 2 })).rejects.toThrowError(ForbiddenError);
+
+			await expect(service.sort('test', { item: 1, to: 2 })).rejects.toThrowError(
+				`'test-user' does not have permission to read the sort field 'test.sort'`,
+			);
+		});
+	});
+
+	describe('clearCache', () => {
+		it('should throw ForbiddenError for non-admin user', async () => {
+			const service = new UtilsService({
+				knex: db,
+				schema,
+				accountability: { user: 'test-user', admin: false } as Accountability,
+			});
+
+			await expect(service.clearCache({ system: false })).rejects.toThrowError(ForbiddenError);
+
+			await expect(service.clearCache({ system: false })).rejects.toThrowError(
+				`'test-user' does not have permission to clear the cache as not being an admin`,
+			);
+		});
+	});
+});

--- a/api/src/services/utils.ts
+++ b/api/src/services/utils.ts
@@ -50,7 +50,9 @@ export class UtilsService {
 			);
 
 			if (allowedFields[0] !== '*' && allowedFields.includes(sortField) === false) {
-				throw new ForbiddenError();
+				throw new ForbiddenError({
+					reason: `'${this.accountability.user}' does not have permission to read the sort field '${collection}.${sortField}'`,
+				});
 			}
 		}
 
@@ -158,7 +160,9 @@ export class UtilsService {
 
 	async clearCache({ system }: { system: boolean }): Promise<void> {
 		if (this.accountability?.admin !== true) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `'${this.accountability?.user}' does not have permission to clear the cache as not being an admin`,
+			});
 		}
 
 		const { cache } = getCache();

--- a/api/src/utils/get-service.test.ts
+++ b/api/src/utils/get-service.test.ts
@@ -1,0 +1,29 @@
+import { ForbiddenError } from '@directus/errors';
+import { SchemaBuilder } from '@directus/schema-builder';
+import knex, { type Knex } from 'knex';
+import { MockClient } from 'knex-mock-client';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { getService } from './get-service.js';
+
+vi.mock('../database/index.js', () => ({
+	default: vi.fn(),
+	getDatabaseClient: vi.fn().mockReturnValue('postgres'),
+}));
+
+const schema = new SchemaBuilder().build();
+
+let db: Knex;
+
+beforeAll(() => {
+	db = knex.default({ client: MockClient });
+});
+
+describe('Utils / getService', () => {
+	it('should throw ForbiddenError for an unhandled directus_* collection', () => {
+		expect(() => getService('directus_unknown', { knex: db, schema })).toThrowError(ForbiddenError);
+
+		expect(() => getService('directus_unknown', { knex: db, schema })).toThrowError(
+			'Forbidden access to directus_* collections',
+		);
+	});
+});

--- a/api/src/utils/get-service.ts
+++ b/api/src/utils/get-service.ts
@@ -75,7 +75,10 @@ export function getService(collection: string, opts: AbstractServiceOptions): It
 			return new WebhooksService(opts);
 		default:
 			// Deny usage of other system collections via ItemsService
-			if (collection.startsWith('directus_')) throw new ForbiddenError();
+			if (collection.startsWith('directus_'))
+				throw new ForbiddenError({
+					reason: 'Forbidden access to directus_* collections',
+				});
 
 			return new ItemsService(collection, opts);
 	}

--- a/api/src/utils/validate-keys.test.ts
+++ b/api/src/utils/validate-keys.test.ts
@@ -19,6 +19,12 @@ describe('validate keys', () => {
 			expect(() => validateKeys(schema, 'pk_integer', 'id', NaN)).toThrowError();
 		});
 
+		it('Throws an error with a reason naming the expected integer type', () => {
+			expect(() => validateKeys(schema, 'pk_integer', 'id', 'invalid')).toThrowError(
+				'Primary key of pk_integer must be an integer instead of "invalid"',
+			);
+		});
+
 		it('Throws an error when provided with an array containing an invalid integer key', () => {
 			expect(() => validateKeys(schema, 'pk_integer', 'id', [111, 'invalid', 222])).toThrowError();
 			expect(() => validateKeys(schema, 'pk_integer', 'id', [555, NaN, 666])).toThrowError();
@@ -41,6 +47,12 @@ describe('validate keys', () => {
 			expect(() => validateKeys(schema, 'pk_uuid', 'id', 'invalid')).toThrowError();
 			expect(() => validateKeys(schema, 'pk_uuid', 'id', NaN)).toThrowError();
 			expect(() => validateKeys(schema, 'pk_uuid', 'id', 111)).toThrowError();
+		});
+
+		it('Throws an error with a reason naming the expected uuid type', () => {
+			expect(() => validateKeys(schema, 'pk_uuid', 'id', 'invalid')).toThrowError(
+				'Primary key of pk_uuid must be a uuid instead of "invalid"',
+			);
 		});
 
 		it('Throws an error when provided with an array containing an invalid uuid key', () => {

--- a/api/src/utils/validate-keys.ts
+++ b/api/src/utils/validate-keys.ts
@@ -19,9 +19,14 @@ export function validateKeys(
 		const primaryKeyFieldType = schema.collections[collection]?.fields[keyField]?.type;
 
 		if (primaryKeyFieldType === 'uuid' && !isValidUuid(String(keys))) {
-			throw new ForbiddenError();
+			throw new ForbiddenError({
+				reason: `Primary key of ${collection} must be a uuid instead of ${JSON.stringify(keys, null, 2)}`,
+			});
 		} else if (primaryKeyFieldType === 'integer' && !Number.isInteger(Number(keys))) {
-			throw new ForbiddenError();
+			// Should this be a forbidden error? InvalidPayload?
+			throw new ForbiddenError({
+				reason: `Primary key of ${collection} must be an integer instead of ${JSON.stringify(keys, null, 2)}`,
+			});
 		}
 	}
 }


### PR DESCRIPTION
**Upstream-draft (v12):** #61 — the MSCL v12 implementation this BSL v11.10.1 feature is re-derived from.

Fork-permanent, stacked on `fork-feat/filter-output-types`. Cherry-picked from `v11.9.2-hhh-dev` (`ed18bb1` reason support on forbidden.ts + ~18 throw sites, `6196f77` users.ts reasons). Self-contained (forbidden.ts `reason` field; `api/src/types/collection.ts` still present at v11.10.1). **Deferred:** the env-injection saga (`dc0075d`…`3cf8256` incl. a revert) + `cfdfd67` hide-env — fork env-plumbing, separate hard-merge. v12 ref: #61.

---
_Recreated from #92 after the branch rename to the version-namespaced scheme (`v11.10.1-feat/*` on `upstream-v11.10.1`)._