### PR TITLE
v11.10.1-feat: 10 — take over items.create from a filter (return null/PK)

### DIFF
--- a/.changeset/filter-cancel-create.md
+++ b/.changeset/filter-cancel-create.md
@@ -1,0 +1,5 @@
+---
+'@directus/api': minor
+---
+
+Let an `items.create` filter take over the creation by returning a primary key. When a `*.items.create` filter returns a `string`/`number` instead of a payload, `ItemsService.createOne` short-circuits the insert and surfaces that key (e.g. dedupe to an existing row, or hand off to an external store). Builds on the typed filter output (`FilterHandler<TIn, TOut>`); a filter returning a normal payload object inserts exactly as before.

--- a/api/src/services/items.test-d.ts
+++ b/api/src/services/items.test-d.ts
@@ -1,0 +1,13 @@
+import type { PrimaryKey } from '@directus/types';
+import { expectTypeOf, test } from 'vitest';
+import { ItemsService } from './items.js';
+
+const service = {} as ItemsService;
+
+test('createOne resolves to a primary key by default', () => {
+	expectTypeOf(service.createOne({})).toEqualTypeOf<Promise<PrimaryKey>>();
+});
+
+test('createOne may resolve to null when filter cancel is opted in', () => {
+	expectTypeOf(service.createOne({}, { allowFilterCancel: true })).toEqualTypeOf<Promise<PrimaryKey | null>>();
+});

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -1,4 +1,4 @@
-import { ForbiddenError } from '@directus/errors';
+import { ForbiddenError, InvalidPayloadError } from '@directus/errors';
 import { SchemaBuilder } from '@directus/schema-builder';
 import { UserIntegrityCheckFlag } from '@directus/types';
 import knex, { type Knex } from 'knex';
@@ -77,6 +77,81 @@ describe('Integration Tests', () => {
 
 				expect(validateUserCountIntegrity).toHaveBeenCalled();
 			});
+
+			it('should short-circuit and return the key when a create filter returns a primary key', async () => {
+				vi.spyOn(emitter, 'emitFilter').mockResolvedValue(5);
+
+				const insert = vi.fn().mockReturnThis();
+
+				const transactionSpy = vi.spyOn(db, 'transaction').mockImplementation(async (callback) => {
+					return await callback({ ...db, insert } as any);
+				});
+
+				const result = await service.createOne({ name: 'Test' });
+
+				expect(result).toBe(5);
+				expect(insert).not.toHaveBeenCalled();
+
+				transactionSpy.mockRestore();
+			});
+
+			it('should cancel the create and return null when a filter returns null and cancel is allowed', async () => {
+				const filterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(null);
+
+				const insert = vi.fn().mockReturnThis();
+
+				const transactionSpy = vi.spyOn(db, 'transaction').mockImplementation(async (callback) => {
+					return await callback({ ...db, insert } as any);
+				});
+
+				const result = await service.createOne({ name: 'Test' }, { allowFilterCancel: true });
+
+				expect(result).toBeNull();
+				expect(insert).not.toHaveBeenCalled();
+
+				transactionSpy.mockRestore();
+				filterSpy.mockRestore();
+			});
+
+			it('should throw when a filter returns null but cancel is not allowed', async () => {
+				const filterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(null);
+
+				const transactionSpy = vi.spyOn(db, 'transaction').mockImplementation(async (callback) => {
+					return await callback({ ...db } as any);
+				});
+
+				await expect(service.createOne({ name: 'Test' })).rejects.toThrow(InvalidPayloadError);
+
+				transactionSpy.mockRestore();
+				filterSpy.mockRestore();
+			});
+
+			it('should create normally when a filter returns the payload (cancel allowed but not triggered)', async () => {
+				// control: the cancel/take-over guards must only fire on null / a key, never on a payload
+				const filterSpy = vi
+					.spyOn(emitter, 'emitFilter')
+					.mockImplementation(async (_event: any, payload: any) => payload);
+
+				const mockReturning = vi.fn().mockResolvedValue([{ id: 1 }]);
+
+				const mockQuery = {
+					insert: vi.fn().mockReturnThis(),
+					into: vi.fn().mockReturnThis(),
+					returning: mockReturning,
+				};
+
+				const transactionSpy = vi
+					.spyOn(db, 'transaction')
+					.mockImplementation(async (callback) => callback({ ...db, ...mockQuery } as any));
+
+				const result = await service.createOne({ name: 'Test' }, { allowFilterCancel: true });
+
+				expect(mockQuery.insert).toHaveBeenCalled();
+				expect(result).not.toBeNull();
+
+				transactionSpy.mockRestore();
+				filterSpy.mockRestore();
+			});
 		});
 
 		describe('createMany', () => {
@@ -84,6 +159,16 @@ describe('Integration Tests', () => {
 				await service.createMany([{}], { userIntegrityCheckFlags: UserIntegrityCheckFlag.All });
 
 				expect(validateUserCountIntegrity).toHaveBeenCalled();
+			});
+
+			it('should keep cancelled creates as null to stay index-aligned with the input', async () => {
+				const filterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(null);
+
+				const result = await service.createMany([{ name: 'A' }, { name: 'B' }], { allowFilterCancel: true });
+
+				expect(result).toEqual([null, null]);
+
+				filterSpy.mockRestore();
 			});
 		});
 

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -142,6 +142,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 		const payload: AnyItem = cloneDeep(data);
 		let actionHookPayload = payload;
+		let createWasTakenOver = false;
 		const nestedActionEvents: ActionEventParams[] = [];
 
 		/**
@@ -155,7 +156,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			// item that is about to be saved
 			const payloadAfterHooks =
 				opts.emitEvents !== false
-					? await emitter.emitFilter(
+					? await emitter.emitFilter<AnyItem, PrimaryKey>(
 							this.eventScope === 'items'
 								? ['items.create', `${this.collection}.items.create`]
 								: `${this.eventScope}.create`,
@@ -170,6 +171,15 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 							},
 						)
 					: payload;
+
+			if (typeof payloadAfterHooks === 'string' || typeof payloadAfterHooks === 'number') {
+				// A filter hook returned a primary key instead of a payload: it has taken over the
+				// creation, so short-circuit and surface that key. No row was created through this
+				// service, so the items.create action must not fire with the original payload — the
+				// hook that took over owns any events.
+				createWasTakenOver = true;
+				return payloadAfterHooks;
+			}
 
 			const payloadWithPresets = this.accountability
 				? await processPayload(
@@ -366,7 +376,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			return primaryKey;
 		});
 
-		if (opts.emitEvents !== false) {
+		if (opts.emitEvents !== false && !createWasTakenOver) {
 			const actionEvent = {
 				event:
 					this.eventScope === 'items'

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -122,8 +122,17 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 	/**
 	 * Create a single new item.
+	 *
+	 * Resolves to null when a filter hook cancels the create (returns null) and
+	 * `allowFilterCancel` is opted in; otherwise such a cancel is an InvalidPayloadError.
 	 */
-	async createOne(data: Partial<Item>, opts: MutationOptions = {}): Promise<PrimaryKey> {
+	async createOne(
+		data: Partial<Item>,
+		opts: MutationOptions & { allowFilterCancel: true },
+	): Promise<PrimaryKey | null>;
+
+	async createOne(data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey>;
+	async createOne(data: Partial<Item>, opts: MutationOptions = {}): Promise<PrimaryKey | null> {
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
 
 		if (!opts.bypassLimits) {
@@ -151,10 +160,10 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		 * that any errors thrown in any nested relational changes will bubble up and cancel the whole
 		 * update tree
 		 */
-		const primaryKey: PrimaryKey = await transaction(this.knex, async (trx) => {
+		const primaryKey: PrimaryKey | null = await transaction(this.knex, async (trx) => {
 			// Run all hooks that are attached to this event so the end user has the chance to augment the
 			// item that is about to be saved
-			const payloadAfterHooks =
+			const payloadAfterHooks: AnyItem | PrimaryKey | null =
 				opts.emitEvents !== false
 					? await emitter.emitFilter<AnyItem, PrimaryKey>(
 							this.eventScope === 'items'
@@ -179,6 +188,19 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				// hook that took over owns any events.
 				createWasTakenOver = true;
 				return payloadAfterHooks;
+			}
+
+			if (payloadAfterHooks === null) {
+				// A filter hook nulled the payload to cancel the create. With allowFilterCancel the
+				// caller opted into a null result; otherwise a null payload is a hard error. Either way
+				// no row is created, so suppress the items.create action (reuse the take-over guard).
+				createWasTakenOver = true;
+
+				if (opts.allowFilterCancel) {
+					return null;
+				}
+
+				throw new InvalidPayloadError({ reason: 'Item creation was cancelled by a filter hook' });
 			}
 
 			const payloadWithPresets = this.accountability

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -126,10 +126,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	 * Resolves to null when a filter hook cancels the create (returns null) and
 	 * `allowFilterCancel` is opted in; otherwise such a cancel is an InvalidPayloadError.
 	 */
-	async createOne(
-		data: Partial<Item>,
-		opts: MutationOptions & { allowFilterCancel: true },
-	): Promise<PrimaryKey | null>;
+	async createOne(data: Partial<Item>, opts: MutationOptions & { allowFilterCancel: true }): Promise<PrimaryKey | null>;
 
 	async createOne(data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey>;
 	async createOne(data: Partial<Item>, opts: MutationOptions = {}): Promise<PrimaryKey | null> {

--- a/packages/types/src/items.ts
+++ b/packages/types/src/items.ts
@@ -72,6 +72,12 @@ export type MutationOptions = {
 	 */
 	preMutationError?: DirectusError | undefined;
 
+	/**
+	 * Allow a filter hook to cancel the mutation by returning null. When set, the mutation
+	 * resolves to null instead of throwing; otherwise a nulling filter is an InvalidPayloadError.
+	 */
+	allowFilterCancel?: boolean | undefined;
+
 	bypassAutoIncrementSequenceReset?: boolean;
 
 	/**


### PR DESCRIPTION
**Upstream-draft (v12):** #51 — the MSCL v12 implementation this BSL v11.10.1 feature is re-derived from.

Fork-permanent, stacked on `fork-feat/await-action`. Cherry-picked from `v11.9.2-hhh-dev` (`4c07cca`); clean. A `items.create` filter returning null / a primary key short-circuits creation. Source-of-truth hhh-dev impl (returns the filter value directly; simpler than v12 #51/#52 allowFilterCancel overloads). v12 ref: #51.

---
_Recreated from #85 after the branch rename to the version-namespaced scheme (`v11.10.1-feat/*` on `upstream-v11.10.1`)._