### PR TITLE
v11.10.1-feat: 11 — cancel any mutation via filter

### DIFF
--- a/.changeset/filter-cancel-mutations.md
+++ b/.changeset/filter-cancel-mutations.md
@@ -1,0 +1,11 @@
+---
+'@directus/types': minor
+'@directus/api': minor
+---
+
+Let a filter hook cancel a create, update or delete by returning `null`, gated by a new `allowFilterCancel` mutation option.
+
+- When a `*.items.create` / `*.items.update` / `*.items.delete` filter returns `null` and the caller passed `{ allowFilterCancel: true }`, the service skips the mutation. `createOne` resolves to `null`; the batch variants keep the cancelled slots as `null` so the result stays index-aligned with the input (`createMany` returns a `null` per cancelled item, `updateMany`/`deleteMany` return a `null` per key on a batch cancel) — `(PrimaryKey | null)[]` under the opt-in overload. Without the opt-in, a `null` return throws `InvalidPayloadError`, so the default signatures (and all existing callers) are unchanged.
+- The public endpoints opt in, so an extension hook can cancel a create/update/delete for any user collection through REST, GraphQL and WebSocket. A cancelled single create responds with `{ data: null }`; a cancelled update reads back the unchanged item; a cancelled delete leaves the item in place.
+
+Builds on the `FilterHandler<TIn, TOut>` output type. Internal/system mutations keep the strict default. Upsert-create cancellation is out of scope.

--- a/api/src/controllers/items.ts
+++ b/api/src/controllers/items.ts
@@ -34,20 +34,28 @@ router.post(
 		const savedKeys: PrimaryKey[] = [];
 
 		if (Array.isArray(req.body)) {
-			const keys = await service.createMany(req.body);
-			savedKeys.push(...keys);
+			const keys = await service.createMany(req.body, { allowFilterCancel: true });
+			// Cancelled creates come back as null; drop them before reading the created items.
+			savedKeys.push(...keys.filter((key): key is PrimaryKey => key !== null));
 		} else {
-			const key = await service.createOne(req.body);
-			savedKeys.push(key);
+			const key = await service.createOne(req.body, { allowFilterCancel: true });
+
+			if (key !== null) {
+				// A filter hook may cancel the creation by returning null; nothing to read back then.
+				savedKeys.push(key);
+			}
 		}
 
 		try {
 			if (Array.isArray(req.body)) {
 				const result = await service.readMany(savedKeys, req.sanitizedQuery);
 				res.locals['payload'] = { data: result || null };
-			} else {
+			} else if (savedKeys.length > 0) {
 				const result = await service.readOne(savedKeys[0]!, req.sanitizedQuery);
 				res.locals['payload'] = { data: result || null };
+			} else {
+				// The single create was cancelled by a filter hook: no item to return.
+				res.locals['payload'] = { data: null };
 			}
 		} catch (error: any) {
 			if (isDirectusError(error, ErrorCode.Forbidden)) {
@@ -150,19 +158,24 @@ router.patch(
 			return next();
 		}
 
-		let keys: PrimaryKey[] = [];
+		let keys: (PrimaryKey | null)[] = [];
 
 		if (Array.isArray(req.body)) {
-			keys = await service.updateBatch(req.body);
+			keys = await service.updateBatch(req.body, { allowFilterCancel: true });
 		} else if (req.body.keys) {
-			keys = await service.updateMany(req.body.keys, req.body.data);
+			keys = await service.updateMany(req.body.keys, req.body.data, { allowFilterCancel: true });
 		} else {
 			const sanitizedQuery = await sanitizeQuery(req.body.query, req.schema, req.accountability);
-			keys = await service.updateByQuery(sanitizedQuery, req.body.data);
+			keys = await service.updateByQuery(sanitizedQuery, req.body.data, { allowFilterCancel: true });
 		}
 
 		try {
-			const result = await service.readMany(keys, req.sanitizedQuery);
+			// Cancelled updates come back as null; drop them before reading the affected items.
+			const result = await service.readMany(
+				keys.filter((key): key is PrimaryKey => key !== null),
+				req.sanitizedQuery,
+			);
+
 			res.locals['payload'] = { data: result };
 		} catch (error: any) {
 			if (isDirectusError(error, ErrorCode.Forbidden)) {
@@ -195,7 +208,7 @@ router.patch(
 			schema: req.schema,
 		});
 
-		const updatedPrimaryKey = await service.updateOne(req.params['pk']!, req.body);
+		const updatedPrimaryKey = await service.updateOne(req.params['pk']!, req.body, { allowFilterCancel: true });
 
 		try {
 			const result = await service.readOne(updatedPrimaryKey, req.sanitizedQuery);
@@ -229,12 +242,12 @@ router.delete(
 		});
 
 		if (Array.isArray(req.body)) {
-			await service.deleteMany(req.body);
+			await service.deleteMany(req.body, { allowFilterCancel: true });
 		} else if (req.body.keys) {
-			await service.deleteMany(req.body.keys);
+			await service.deleteMany(req.body.keys, { allowFilterCancel: true });
 		} else {
 			const sanitizedQuery = await sanitizeQuery(req.body.query, req.schema, req.accountability);
-			await service.deleteByQuery(sanitizedQuery);
+			await service.deleteByQuery(sanitizedQuery, { allowFilterCancel: true });
 		}
 
 		return next();
@@ -256,7 +269,7 @@ router.delete(
 			schema: req.schema,
 		});
 
-		await service.deleteOne(req.params['pk']!);
+		await service.deleteOne(req.params['pk']!, { allowFilterCancel: true });
 		return next();
 	}),
 	respond,

--- a/api/src/services/graphql/resolvers/mutation.ts
+++ b/api/src/services/graphql/resolvers/mutation.ts
@@ -46,17 +46,18 @@ export async function resolveMutation(
 	try {
 		if (single) {
 			if (action === 'create') {
-				const key = await service.createOne(args['data']);
-				return hasQuery ? await service.readOne(key, query) : true;
+				const key = await service.createOne(args['data'], { allowFilterCancel: true });
+				// A filter hook may cancel the create (null key); there is then no item to read back.
+				return hasQuery && key !== null ? await service.readOne(key, query) : true;
 			}
 
 			if (action === 'update') {
-				const key = await service.updateOne(args['id'], args['data']);
+				const key = await service.updateOne(args['id'], args['data'], { allowFilterCancel: true });
 				return hasQuery ? await service.readOne(key, query) : true;
 			}
 
 			if (action === 'delete') {
-				await service.deleteOne(args['id']);
+				await service.deleteOne(args['id'], { allowFilterCancel: true });
 				return { id: args['id'] };
 			}
 
@@ -73,14 +74,18 @@ export async function resolveMutation(
 				if (batchUpdate) {
 					keys.push(...(await service.updateBatch(args['data'])));
 				} else {
-					keys.push(...(await service.updateMany(args['ids'], args['data'])));
+					keys.push(
+						...(await service.updateMany(args['ids'], args['data'], { allowFilterCancel: true })).filter(
+							(key): key is PrimaryKey => key !== null,
+						),
+					);
 				}
 
 				return hasQuery ? await service.readMany(keys, query) : true;
 			}
 
 			if (action === 'delete') {
-				const keys = await service.deleteMany(args['ids']);
+				const keys = await service.deleteMany(args['ids'], { allowFilterCancel: true });
 				return { ids: keys };
 			}
 

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -289,6 +289,42 @@ describe('Integration Tests', () => {
 
 				emitFilterSpy.mockRestore();
 			});
+
+			it('should cancel the update and return a null per key when a filter returns null and cancel is allowed', async () => {
+				const filterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(null);
+				const transactionSpy = vi.spyOn(db, 'transaction');
+
+				const result = await service.updateMany([1], { name: 'Test' }, { allowFilterCancel: true });
+
+				expect(result).toEqual([null]);
+				expect(transactionSpy).not.toHaveBeenCalled();
+
+				filterSpy.mockRestore();
+			});
+
+			it('should throw when an update filter returns null but cancel is not allowed', async () => {
+				const filterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(null);
+
+				await expect(service.updateMany([1], { name: 'Test' })).rejects.toThrow(InvalidPayloadError);
+
+				filterSpy.mockRestore();
+			});
+
+			it('should run the update normally when a filter returns a non-null payload', async () => {
+				const filterSpy = vi
+					.spyOn(emitter, 'emitFilter')
+					.mockImplementation(async (_event: any, payload: any) => payload);
+
+				const transactionSpy = vi.spyOn(db, 'transaction');
+
+				const result = await service.updateMany([1], { name: 'Test' }, { allowFilterCancel: true });
+
+				expect(transactionSpy).toHaveBeenCalled();
+				expect(result).toEqual([1]);
+
+				transactionSpy.mockRestore();
+				filterSpy.mockRestore();
+			});
 		});
 
 		describe('deleteMany', () => {
@@ -296,6 +332,42 @@ describe('Integration Tests', () => {
 				await service.deleteMany([1], { userIntegrityCheckFlags: UserIntegrityCheckFlag.All });
 
 				expect(validateUserCountIntegrity).toHaveBeenCalled();
+			});
+
+			it('should cancel the deletion and return a null per key when a filter returns null and cancel is allowed', async () => {
+				const filterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(null);
+				const transactionSpy = vi.spyOn(db, 'transaction');
+
+				const result = await service.deleteMany([1], { allowFilterCancel: true });
+
+				expect(result).toEqual([null]);
+				expect(transactionSpy).not.toHaveBeenCalled();
+
+				filterSpy.mockRestore();
+			});
+
+			it('should throw when a delete filter returns null but cancel is not allowed', async () => {
+				const filterSpy = vi.spyOn(emitter, 'emitFilter').mockResolvedValue(null);
+
+				await expect(service.deleteMany([1])).rejects.toThrow(InvalidPayloadError);
+
+				filterSpy.mockRestore();
+			});
+
+			it('should run the deletion normally when a filter returns a non-null payload', async () => {
+				const filterSpy = vi
+					.spyOn(emitter, 'emitFilter')
+					.mockImplementation(async (_event: any, payload: any) => payload);
+
+				const transactionSpy = vi.spyOn(db, 'transaction');
+
+				const result = await service.deleteMany([1], { allowFilterCancel: true });
+
+				expect(transactionSpy).toHaveBeenCalled();
+				expect(result).toEqual([1]);
+
+				transactionSpy.mockRestore();
+				filterSpy.mockRestore();
 			});
 		});
 	});

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -162,7 +162,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			// item that is about to be saved
 			const payloadAfterHooks: AnyItem | PrimaryKey | null =
 				opts.emitEvents !== false
-					? await emitter.emitFilter<AnyItem, PrimaryKey>(
+					? await emitter.emitFilter<AnyItem, PrimaryKey | null>(
 							this.eventScope === 'items'
 								? ['items.create', `${this.collection}.items.create`]
 								: `${this.eventScope}.create`,
@@ -395,6 +395,11 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			return primaryKey;
 		});
 
+		// A filter hook cancelled the creation: nothing was inserted, so skip the action hooks entirely.
+		if (primaryKey === null) {
+			return null;
+		}
+
 		if (opts.emitEvents !== false && !createWasTakenOver) {
 			const actionEvent = {
 				event:
@@ -440,7 +445,13 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	 *
 	 * Uses `this.createOne` under the hood.
 	 */
-	async createMany(data: Partial<Item>[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
+	async createMany(
+		data: Partial<Item>[],
+		opts: MutationOptions & { allowFilterCancel: true },
+	): Promise<(PrimaryKey | null)[]>;
+
+	async createMany(data: Partial<Item>[], opts?: MutationOptions): Promise<PrimaryKey[]>;
+	async createMany(data: Partial<Item>[], opts: MutationOptions = {}): Promise<(PrimaryKey | null)[]> {
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
 
 		const { primaryKeys, nestedActionEvents } = await transaction(this.knex, async (knex) => {
@@ -448,7 +459,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 			let userIntegrityCheckFlags = opts.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None;
 
-			const primaryKeys: PrimaryKey[] = [];
+			const primaryKeys: (PrimaryKey | null)[] = [];
 			const nestedActionEvents: ActionEventParams[] = [];
 
 			const pkField = this.schema.collections[this.collection]!.primary;
@@ -462,7 +473,9 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					bypassAutoIncrementSequenceReset = false;
 				}
 
-				const primaryKey = await service.createOne(payload, {
+				// `allowFilterCancel` is propagated via `opts`; the overload resolves to the non-null
+				// signature, but a cancelling filter can still return null at runtime — hence the guard.
+				const primaryKey: PrimaryKey | null = await service.createOne(payload, {
 					...(opts || {}),
 					autoPurgeCache: false,
 					onRequireUserIntegrityCheck: (flags) => (userIntegrityCheckFlags |= flags),
@@ -471,6 +484,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					bypassAutoIncrementSequenceReset,
 				});
 
+				// A filter hook may cancel an individual create by returning null; the null is kept in
+				// place so the result stays index-aligned with the input (mirrors createOne).
 				primaryKeys.push(primaryKey);
 			}
 
@@ -710,7 +725,18 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	/**
 	 * Update many items by primary key, setting all items to the same change.
 	 */
-	async updateMany(keys: PrimaryKey[], data: Partial<Item>, opts: MutationOptions = {}): Promise<PrimaryKey[]> {
+	async updateMany(
+		keys: PrimaryKey[],
+		data: Partial<Item>,
+		opts: MutationOptions & { allowFilterCancel: true },
+	): Promise<(PrimaryKey | null)[]>;
+
+	async updateMany(keys: PrimaryKey[], data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey[]>;
+	async updateMany(
+		keys: PrimaryKey[],
+		data: Partial<Item>,
+		opts: MutationOptions = {},
+	): Promise<(PrimaryKey | null)[]> {
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
 
 		if (!opts.bypassLimits) {
@@ -736,7 +762,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		// item that is about to be saved
 		const payloadAfterHooks =
 			opts.emitEvents !== false
-				? await emitter.emitFilter(
+				? await emitter.emitFilter<Partial<AnyItem>, null>(
 						this.eventScope === 'items'
 							? ['items.update', `${this.collection}.items.update`]
 							: `${this.eventScope}.update`,
@@ -754,12 +780,18 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				: payload;
 
 		if (payloadAfterHooks === null) {
-			// A filter hook cleared the payload to null. Treating that as an explicit, opt-in
-			// cancellation (returning a null per key) is owned by the `allowFilterCancel` mutation
-			// option; on its own a null payload is invalid rather than a silent no-op.
-			throw new InvalidPayloadError({
-				reason: `A filter hook cancelled the update, but this operation requires it`,
-			});
+			if (!opts.allowFilterCancel) {
+				// A filter hook cleared the payload to null. Treating that as an explicit, opt-in
+				// cancellation (returning a null per key) is owned by the `allowFilterCancel` mutation
+				// option; on its own a null payload is invalid rather than a silent no-op.
+				throw new InvalidPayloadError({
+					reason: `A filter hook cancelled the update, but this operation requires it`,
+				});
+			}
+
+			// The filter cancelled the update: nothing is written; return a null per key so the
+			// result stays index-aligned with the input keys.
+			return keys.map(() => null);
 		}
 
 		const isEmptyAlterations = (value: unknown): boolean => {
@@ -1094,7 +1126,13 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	/**
 	 * Delete multiple items by primary key.
 	 */
-	async deleteMany(keys: PrimaryKey[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
+	async deleteMany(
+		keys: PrimaryKey[],
+		opts: MutationOptions & { allowFilterCancel: true },
+	): Promise<(PrimaryKey | null)[]>;
+
+	async deleteMany(keys: PrimaryKey[], opts?: MutationOptions): Promise<PrimaryKey[]>;
+	async deleteMany(keys: PrimaryKey[], opts: MutationOptions = {}): Promise<(PrimaryKey | null)[]> {
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
 
 		if (!opts.bypassLimits) {
@@ -1105,6 +1143,36 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 		const primaryKeyField = this.schema.collections[this.collection]!.primary;
 		validateKeys(this.schema, this.collection, primaryKeyField, keys);
+
+		const keysAfterHooks =
+			opts.emitEvents !== false
+				? await emitter.emitFilter<PrimaryKey[], null>(
+						this.eventScope === 'items'
+							? ['items.delete', `${this.collection}.items.delete`]
+							: `${this.eventScope}.delete`,
+						keys,
+						{
+							collection: this.collection,
+						},
+						{
+							database: this.knex,
+							schema: this.schema,
+							accountability: this.accountability,
+						},
+					)
+				: keys;
+
+		if (keysAfterHooks === null) {
+			if (!opts.allowFilterCancel) {
+				throw new InvalidPayloadError({
+					reason: `A filter hook cancelled the deletion, but this operation requires it`,
+				});
+			}
+
+			// The filter cancelled the deletion: nothing is deleted; return a null per key so the
+			// result stays index-aligned with the input keys.
+			return keys.map(() => null);
+		}
 
 		if (this.accountability) {
 			await validateAccess(

--- a/api/src/websocket/handlers/items.test.ts
+++ b/api/src/websocket/handlers/items.test.ts
@@ -118,7 +118,9 @@ describe('WebSocket heartbeat handler', () => {
 		// do mocking
 		(getSchema as Mock).mockImplementation(() => ({ collections: { test: [] } }));
 
-		const createMany = vi.fn(),
+		// A filter hook may cancel an individual create, leaving a null in place; the handler
+		// must drop those before reading back, so the read only sees the surviving key.
+		const createMany = vi.fn().mockResolvedValue([1, null]),
 			readMany = vi.fn();
 
 		(ItemsService as Mock).mockImplementation(() => ({ createMany, readMany }));
@@ -137,7 +139,7 @@ describe('WebSocket heartbeat handler', () => {
 		await vi.runAllTimersAsync(); // flush promises to make sure the event is handled
 		// expect service functions
 		expect(createMany).toBeCalled();
-		expect(readMany).toBeCalled();
+		expect(readMany).toBeCalledWith([1], expect.anything());
 		expect(fakeClient.send).toBeCalled();
 	});
 
@@ -198,7 +200,9 @@ describe('WebSocket heartbeat handler', () => {
 		// do mocking
 		(getSchema as Mock).mockImplementation(() => ({ collections: { test: [] } }));
 
-		const updateMany = vi.fn(),
+		// A filter hook may cancel an individual update, leaving a null in place; the handler
+		// must drop those before reading back, so the read only sees the surviving key.
+		const updateMany = vi.fn().mockResolvedValue([1, null]),
 			readMany = vi.fn();
 
 		(ItemsService as Mock).mockImplementation(() => ({ updateMany, readMany }));
@@ -220,7 +224,7 @@ describe('WebSocket heartbeat handler', () => {
 		// expect service functions
 		expect(updateMany).toBeCalled();
 		expect(getMetaForQuery).toBeCalled();
-		expect(readMany).toBeCalled();
+		expect(readMany).toBeCalledWith([1], expect.anything());
 		expect(fakeClient.send).toBeCalled();
 	});
 

--- a/api/src/websocket/handlers/items.ts
+++ b/api/src/websocket/handlers/items.ts
@@ -1,3 +1,4 @@
+import type { PrimaryKey } from '@directus/types';
 import emitter from '../../emitter.js';
 import { ItemsService, MetaService } from '../../services/index.js';
 import { getSchema } from '../../utils/get-schema.js';
@@ -49,11 +50,16 @@ export class ItemsHandler {
 			const query = await sanitizeQuery(message?.query ?? {}, schema, accountability);
 
 			if (Array.isArray(message.data)) {
-				const keys = await service.createMany(message.data);
-				result = await service.readMany(keys, query);
+				const keys = await service.createMany(message.data, { allowFilterCancel: true });
+
+				result = await service.readMany(
+					keys.filter((key): key is PrimaryKey => key !== null),
+					query,
+				);
 			} else {
-				const key = await service.createOne(message.data);
-				result = await service.readOne(key, query);
+				const key = await service.createOne(message.data, { allowFilterCancel: true });
+				// A filter hook may cancel the create (null key); there is then no item to read back.
+				result = key !== null ? await service.readOne(key, query) : null;
 			}
 		}
 
@@ -77,12 +83,16 @@ export class ItemsHandler {
 			const query = await sanitizeQuery(message.query ?? {}, schema, accountability);
 
 			if (message.id) {
-				const key = await service.updateOne(message.id, message.data);
+				const key = await service.updateOne(message.id, message.data, { allowFilterCancel: true });
 				result = await service.readOne(key);
 			} else if (message.ids) {
-				const keys = await service.updateMany(message.ids, message.data);
+				const keys = await service.updateMany(message.ids, message.data, { allowFilterCancel: true });
 				meta = await metaService.getMetaForQuery(message.collection, query);
-				result = await service.readMany(keys, query);
+
+				result = await service.readMany(
+					keys.filter((key): key is PrimaryKey => key !== null),
+					query,
+				);
 			} else if (isSingleton) {
 				await service.upsertSingleton(message.data);
 				result = await service.readSingleton(query);
@@ -91,7 +101,7 @@ export class ItemsHandler {
 				meta = await metaService.getMetaForQuery(message.collection, query);
 				result = await service.readMany(keys, query);
 			} else {
-				const keys = await service.updateByQuery(query, message.data);
+				const keys = await service.updateByQuery(query, message.data, { allowFilterCancel: true });
 				meta = await metaService.getMetaForQuery(message.collection, query);
 				result = await service.readMany(keys, query);
 			}
@@ -99,14 +109,14 @@ export class ItemsHandler {
 
 		if (message.action === 'delete') {
 			if (message.id) {
-				await service.deleteOne(message.id);
+				await service.deleteOne(message.id, { allowFilterCancel: true });
 				result = message.id;
 			} else if (message.ids) {
-				await service.deleteMany(message.ids);
+				await service.deleteMany(message.ids, { allowFilterCancel: true });
 				result = message.ids;
 			} else if (message.query) {
 				const query = await sanitizeQuery(message.query, schema, accountability);
-				result = await service.deleteByQuery(query);
+				result = await service.deleteByQuery(query, { allowFilterCancel: true });
 			} else {
 				throw new WebSocketError(
 					'items',


### PR DESCRIPTION
**Upstream-draft (v12):** #52 — the MSCL v12 implementation this BSL v11.10.1 feature is re-derived from.

Isolated mirror (v12 #52), stacked on cancel-create.

---
_Recreated from #94 after the branch rename to the version-namespaced scheme (`v11.10.1-feat/*` on `upstream-v11.10.1`)._