### PR TITLE
v11.10.1-feat: 13 — knex.batchInsert for createMany

### DIFF
--- a/.changeset/perf-batch-insert-items.md
+++ b/.changeset/perf-batch-insert-items.md
@@ -1,0 +1,6 @@
+---
+'@directus/api': patch
+'@directus/env': patch
+---
+
+Improved performance of bulk item creation by inserting rows in batched queries instead of running one insert per row

--- a/api/src/database/helpers/capabilities/capabilities.test.ts
+++ b/api/src/database/helpers/capabilities/capabilities.test.ts
@@ -1,0 +1,158 @@
+import type { FieldOverview } from '@directus/types';
+import type { Knex } from 'knex';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { CapabilitiesHelperDefault } from './dialects/default.js';
+import { CapabilitiesHelperMSSQL } from './dialects/mssql.js';
+import { CapabilitiesHelperMySQL } from './dialects/mysql.js';
+import { CapabilitiesHelperOracle } from './dialects/oracle.js';
+import { CapabilitiesHelperPostgres } from './dialects/postgres.js';
+import { CapabilitiesHelperSqlite } from './dialects/sqlite.js';
+
+// vitest hoists vi.hoisted + vi.mock above the imports above, so @directus/env is
+// mocked before mssql.ts captures useEnv() at module load.
+const { mockEnv } = vi.hoisted(() => ({ mockEnv: {} as Record<string, unknown> }));
+
+vi.mock('@directus/env', () => ({
+	useEnv: () => mockEnv,
+}));
+
+const noKnex = {} as unknown as Knex;
+
+function field(overrides: Partial<FieldOverview>): FieldOverview {
+	return { nullable: true, defaultValue: null, ...overrides } as FieldOverview;
+}
+
+describe('CapabilitiesHelper (default)', () => {
+	const helper = new CapabilitiesHelperDefault(noKnex);
+
+	test('does not support column position in GROUP BY', () => {
+		expect(helper.supportsColumnPositionInGroupBy()).toBe(false);
+	});
+
+	test('supports deduplication of parameters', () => {
+		expect(helper.supportsDeduplicationOfParameters()).toBe(true);
+	});
+
+	test('does not preserve insert order in RETURNING', async () => {
+		await expect(helper.preservesInsertOrderInReturning()).resolves.toBe(false);
+	});
+
+	test('padRowsForBatchInsert is a no-op', () => {
+		const rows = [{ id: 1 }, { id: 2 }];
+		expect(helper.padRowsForBatchInsert(rows, { fields: {}, primaryKeyField: 'id' })).toBe(rows);
+	});
+
+	test('insertReturningOptions is undefined', () => {
+		expect(helper.insertReturningOptions()).toBeUndefined();
+	});
+});
+
+describe('CapabilitiesHelperPostgres', () => {
+	const helper = new CapabilitiesHelperPostgres(noKnex);
+
+	test('supports column position in GROUP BY', () => {
+		expect(helper.supportsColumnPositionInGroupBy()).toBe(true);
+	});
+
+	test('does not support deduplication of parameters', () => {
+		expect(helper.supportsDeduplicationOfParameters()).toBe(false);
+	});
+
+	test('preserves insert order in RETURNING', async () => {
+		await expect(helper.preservesInsertOrderInReturning()).resolves.toBe(true);
+	});
+});
+
+describe('CapabilitiesHelperMySQL', () => {
+	const helper = new CapabilitiesHelperMySQL(noKnex);
+
+	test('supports column position in GROUP BY', () => {
+		expect(helper.supportsColumnPositionInGroupBy()).toBe(true);
+	});
+
+	test('does not preserve insert order in RETURNING', async () => {
+		await expect(helper.preservesInsertOrderInReturning()).resolves.toBe(false);
+	});
+});
+
+describe('CapabilitiesHelperOracle', () => {
+	const helper = new CapabilitiesHelperOracle(noKnex);
+
+	test('preserves insert order in RETURNING', async () => {
+		await expect(helper.preservesInsertOrderInReturning()).resolves.toBe(true);
+	});
+});
+
+describe('CapabilitiesHelperMSSQL', () => {
+	const helper = new CapabilitiesHelperMSSQL(noKnex);
+
+	afterEach(() => {
+		delete mockEnv['DB_MSSQL_TRUST_BATCH_RETURNING'];
+	});
+
+	test('preserves insert order only when DB_MSSQL_TRUST_BATCH_RETURNING is set', async () => {
+		mockEnv['DB_MSSQL_TRUST_BATCH_RETURNING'] = true;
+		await expect(helper.preservesInsertOrderInReturning()).resolves.toBe(true);
+
+		mockEnv['DB_MSSQL_TRUST_BATCH_RETURNING'] = false;
+		await expect(helper.preservesInsertOrderInReturning()).resolves.toBe(false);
+	});
+
+	test('always requests trigger modifications on the per-row insert', () => {
+		expect(helper.insertReturningOptions()).toEqual({ includeTriggerModifications: true });
+	});
+});
+
+describe('CapabilitiesHelperSqlite', () => {
+	function createHelper(version: string) {
+		const first = vi.fn().mockResolvedValue({ version });
+		const select = vi.fn().mockReturnValue({ first });
+		const mockKnex = { raw: vi.fn(), select } as unknown as Knex;
+		return { helper: new CapabilitiesHelperSqlite(mockKnex), select };
+	}
+
+	test('preserves insert order on SQLite >= 3.35 (RETURNING support)', async () => {
+		const { helper } = createHelper('3.45.1');
+		await expect(helper.preservesInsertOrderInReturning()).resolves.toBe(true);
+	});
+
+	test('does not preserve insert order on SQLite < 3.35', async () => {
+		const { helper } = createHelper('3.34.0');
+		await expect(helper.preservesInsertOrderInReturning()).resolves.toBe(false);
+	});
+
+	test('treats a missing version row as unsupported', async () => {
+		const first = vi.fn().mockResolvedValue(undefined);
+		const mockKnex = { raw: vi.fn(), select: vi.fn().mockReturnValue({ first }) } as unknown as Knex;
+		const helper = new CapabilitiesHelperSqlite(mockKnex);
+		await expect(helper.preservesInsertOrderInReturning()).resolves.toBe(false);
+	});
+
+	test('probes the SQLite version only once and caches the result', async () => {
+		const { helper, select } = createHelper('3.45.1');
+		await helper.preservesInsertOrderInReturning();
+		await helper.preservesInsertOrderInReturning();
+		expect(select).toHaveBeenCalledTimes(1);
+	});
+
+	test('pads non-nullable fields with their defaults, keeping explicit row values', () => {
+		const { helper } = createHelper('3.45.1');
+
+		const rows = [{ title: 'set' }, {}];
+
+		const padded = helper.padRowsForBatchInsert(rows as Record<string, unknown>[], {
+			primaryKeyField: 'id',
+			fields: {
+				id: field({ nullable: false, defaultValue: 0 }),
+				title: field({ nullable: false, defaultValue: 'untitled' }),
+				note: field({ nullable: true, defaultValue: null }),
+			},
+		});
+
+		// id is the primary key -> never padded; title default fills the gap but the
+		// explicit value wins; nullable note is left out entirely.
+		expect(padded).toEqual([{ title: 'set' }, { title: 'untitled' }]);
+		expect('id' in padded[1]!).toBe(false);
+		expect('note' in padded[1]!).toBe(false);
+	});
+});

--- a/api/src/database/helpers/capabilities/dialects/mssql.ts
+++ b/api/src/database/helpers/capabilities/dialects/mssql.ts
@@ -1,0 +1,51 @@
+import { useEnv } from '@directus/env';
+import { CapabilitiesHelperDefault } from './default.js';
+
+const env = useEnv();
+
+export class CapabilitiesHelperMSSQL extends CapabilitiesHelperDefault {
+	/**
+	 * MSSQL: opt-in via `DB_MSSQL_TRUST_BATCH_RETURNING` (default `false`).
+	 *
+	 * - Why the flag exists (Microsoft vs knex disagree on whether OUTPUT order is safe):
+	 *   - Microsoft says OUTPUT row order isn't guaranteed
+	 *     (https://learn.microsoft.com/sql/t-sql/queries/output-clause-transact-sql).
+	 *   - knex emits `OUTPUT INSERTED.<col> INTO #out; SELECT … FROM #out` with no `ORDER BY`
+	 *     (https://github.com/knex/knex/blob/3.2.10/lib/dialects/mssql/query/mssql-querycompiler.js#L358-L381).
+	 *   - Empirically it stays insertion-ordered because OUTPUT into a temp table forces a
+	 *     serial plan, but that's not contractual.
+	 *   - knex's docs list MSSQL as fully supported and warn only about triggers, silent
+	 *     on ordering (https://knexjs.org/guide/query-builder.html#returning).
+	 *   - Hence the flag: knex says trust, Microsoft says don't.
+	 *   - No SQL Server version, compat level, trace flag, or `OUTPUT ORDERED` clause
+	 *     unlocks a guarantee; only a knex-side row-number passthrough would.
+	 *
+	 * - Caveat for triggered tables (opting in breaks inserts on tables with triggers):
+	 *   - `knex.batchInsert(...).returning(...)` has no signature to thread
+	 *     `{ includeTriggerModifications: true }` through (only the per-row
+	 *     `.insert().returning()` path does).
+	 *   - So the OUTPUT clause is emitted without `INTO`, which SQL Server rejects on any
+	 *     table with an enabled trigger.
+	 *   - Won't be closed without a knex redesign: maintainers consider
+	 *     `batchInsert` a second-class helper that shouldn't gain feature parity
+	 *     with `.insert()` (https://github.com/knex/knex/issues/3590 — open;
+	 *     `includeTriggerModifications` was added for `.insert().returning()` in
+	 *     https://github.com/knex/knex/issues/2446 but never extended to
+	 *     `batchInsert`).
+	 *   - Keep this flag off for trigger-bearing schemas; the default-false per-row dispatch
+	 *     retains trigger support.
+	 */
+	override async preservesInsertOrderInReturning(): Promise<boolean> {
+		return env['DB_MSSQL_TRUST_BATCH_RETURNING'] as boolean;
+	}
+
+	/**
+	 * MSSQL: tables with enabled triggers reject `OUTPUT INSERTED.<col>` unless the
+	 * server is told to redirect OUTPUT into a temp table via knex's
+	 * `includeTriggerModifications` option. Apply it on every per-row insert so
+	 * triggered tables work transparently.
+	 */
+	override insertReturningOptions(): { includeTriggerModifications: true } {
+		return { includeTriggerModifications: true };
+	}
+}

--- a/api/src/database/helpers/capabilities/dialects/mysql.ts
+++ b/api/src/database/helpers/capabilities/dialects/mysql.ts
@@ -7,4 +7,25 @@ export class CapabilitiesHelperMySQL extends CapabilitiesHelper {
 		//   column aliases, or column positions. Column positions are integers and begin with 1:
 		return true;
 	}
+
+	/**
+	 * MySQL: no native `INSERT … RETURNING`.
+	 *
+	 * - MariaDB does support RETURNING since 10.5 (2020-06)
+	 *   (https://mariadb.com/kb/en/insertreturning/), but:
+	 *   - knex treats `.returning()` as a no-op for the mysql dialect and logs
+	 *     `".returning() is not supported by mysql and will not have any effect."`
+	 *   - Tracked upstream at https://github.com/knex/knex/issues/6254.
+	 *   - Both MariaDB and MySQL route through `Client_MySQL2` and surface as
+	 *     `'mysql'` in `getDatabaseClient()`, so we can't dispatch them separately
+	 *     at this layer either.
+	 *
+	 * - Future enablement path: when knex grows MariaDB-aware RETURNING emission
+	 *   and Directus exposes MariaDB as its own `DatabaseClient` value, this method
+	 *   can probe `SELECT VERSION()` for the `-MariaDB` suffix and return `true`
+	 *   for ≥ 10.5.
+	 */
+	override async preservesInsertOrderInReturning(): Promise<boolean> {
+		return false;
+	}
 }

--- a/api/src/database/helpers/capabilities/dialects/oracle.ts
+++ b/api/src/database/helpers/capabilities/dialects/oracle.ts
@@ -1,0 +1,11 @@
+import { CapabilitiesHelperDefault } from './default.js';
+
+export class CapabilitiesHelperOracle extends CapabilitiesHelperDefault {
+	override async preservesInsertOrderInReturning(): Promise<boolean> {
+		// knex's oracledb compiler emits one `INSERT … RETURNING … INTO :bind` per row inside
+		// a single BEGIN…END; block and collects per-row PKs via positional OUT binds, so the
+		// returned array follows JS-array order by construction.
+		// https://github.com/knex/knex/blob/3.2.10/lib/dialects/oracledb/query/oracledb-querycompiler.js
+		return true;
+	}
+}

--- a/api/src/database/helpers/capabilities/dialects/postgres.ts
+++ b/api/src/database/helpers/capabilities/dialects/postgres.ts
@@ -13,4 +13,11 @@ export class CapabilitiesHelperPostgres extends CapabilitiesHelper {
 		// See https://www.postgresql.org/docs/current/sql-prepare.html
 		return false;
 	}
+
+	override async preservesInsertOrderInReturning(): Promise<boolean> {
+		// Postgres's INSERT … RETURNING returns one row per inserted row, in insertion order,
+		// within a single statement. Same semantics inherited by CockroachDB and Redshift.
+		// https://www.postgresql.org/docs/current/sql-insert.html
+		return true;
+	}
 }

--- a/api/src/database/helpers/capabilities/dialects/sqlite.ts
+++ b/api/src/database/helpers/capabilities/dialects/sqlite.ts
@@ -1,0 +1,50 @@
+import type { FieldOverview } from '@directus/types';
+import { CapabilitiesHelperDefault } from './default.js';
+
+/**
+ * SQLite gained `INSERT … RETURNING` in 3.35.0 (2021-03-12). Below that version the only
+ * id available after an insert is `last_insert_rowid()` (the last item only), so the
+ * batch path can't be trusted. Probe the runtime version once per knex client.
+ * https://www.sqlite.org/lang_returning.html
+ */
+const MIN_SQLITE_RETURNING_VERSION: [number, number] = [3, 35];
+
+export class CapabilitiesHelperSqlite extends CapabilitiesHelperDefault {
+	private preservesOrderCache?: boolean;
+
+	override async preservesInsertOrderInReturning(): Promise<boolean> {
+		if (this.preservesOrderCache !== undefined) return this.preservesOrderCache;
+
+		const row = await this.knex.select(this.knex.raw('sqlite_version() as version')).first<{ version?: string }>();
+		const versionStr = String(row?.version ?? '0');
+		const [major = 0, minor = 0] = versionStr.split('.').map(Number);
+		const [minMajor, minMinor] = MIN_SQLITE_RETURNING_VERSION;
+
+		this.preservesOrderCache = major > minMajor || (major === minMajor && minor >= minMinor);
+		return this.preservesOrderCache;
+	}
+
+	/**
+	 * SQLite batchInsert workaround (https://github.com/knex/knex/issues/332):
+	 *
+	 * - knex normalizes columns across all rows in the chunk.
+	 * - Columns missing from a row are bound as `undefined`.
+	 * - The sqlite3 driver translates that to `NULL` and the insert fails for
+	 *   non-nullable columns.
+	 *
+	 * Spread per-column defaults for non-nullable fields first so the payload
+	 * only overrides what it explicitly sets.
+	 */
+	override padRowsForBatchInsert<T extends Record<string, unknown>>(
+		rows: T[],
+		opts: { fields: Record<string, FieldOverview>; primaryKeyField: string },
+	): T[] {
+		const fieldsRequiringValue = Object.fromEntries(
+			Object.entries(opts.fields)
+				.filter(([fieldName, field]) => fieldName !== opts.primaryKeyField && field.nullable === false)
+				.map(([fieldName, field]) => [fieldName, field.defaultValue]),
+		);
+
+		return rows.map((row) => ({ ...fieldsRequiringValue, ...row }));
+	}
+}

--- a/api/src/database/helpers/capabilities/index.ts
+++ b/api/src/database/helpers/capabilities/index.ts
@@ -1,7 +1,7 @@
 export { CapabilitiesHelperPostgres as postgres } from './dialects/postgres.js';
 export { CapabilitiesHelperPostgres as redshift } from './dialects/postgres.js';
 export { CapabilitiesHelperPostgres as cockroachdb } from './dialects/postgres.js';
-export { CapabilitiesHelperDefault as oracle } from './dialects/default.js';
+export { CapabilitiesHelperOracle as oracle } from './dialects/oracle.js';
 export { CapabilitiesHelperMySQL as mysql } from './dialects/mysql.js';
-export { CapabilitiesHelperDefault as mssql } from './dialects/default.js';
-export { CapabilitiesHelperDefault as sqlite } from './dialects/default.js';
+export { CapabilitiesHelperMSSQL as mssql } from './dialects/mssql.js';
+export { CapabilitiesHelperSqlite as sqlite } from './dialects/sqlite.js';

--- a/api/src/database/helpers/capabilities/types.ts
+++ b/api/src/database/helpers/capabilities/types.ts
@@ -1,3 +1,4 @@
+import type { FieldOverview } from '@directus/types';
 import { DatabaseHelper } from '../types.js';
 
 export class CapabilitiesHelper extends DatabaseHelper {
@@ -13,5 +14,44 @@ export class CapabilitiesHelper extends DatabaseHelper {
 	 */
 	supportsDeduplicationOfParameters(): boolean {
 		return true;
+	}
+
+	/**
+	 * Whether `INSERT … RETURNING` (or the dialect equivalent) yields rows in
+	 * insertion order with a contractual guarantee.
+	 *
+	 * - When `true`: `ItemsService.createMany` uses a single multi-row
+	 *   `knex.batchInsert` and maps the returned PKs back positionally.
+	 * - When `false`: it falls back to a per-row insert loop.
+	 *
+	 * Default: `false` — the conservative answer. Override only in dialects where
+	 * both:
+	 * - the underlying RETURNING semantics, AND
+	 * - the knex driver path emitting them
+	 * preserve order.
+	 */
+	async preservesInsertOrderInReturning(): Promise<boolean> {
+		return false;
+	}
+
+	/**
+	 * Pre-process rows before handing them to `knex.batchInsert`. Default is a
+	 * no-op; override in dialects whose driver requires column normalization
+	 * (e.g. SQLite, see its helper for the issue).
+	 */
+	padRowsForBatchInsert<T extends Record<string, unknown>>(
+		rows: T[],
+		_opts: { fields: Record<string, FieldOverview>; primaryKeyField: string },
+	): T[] {
+		return rows;
+	}
+
+	/**
+	 * Options to pass as the second arg of knex's per-row `.insert().returning(pk, ...)`.
+	 * Default `undefined` (no dialect-specific options); override where the driver
+	 * needs a hint (e.g. MSSQL trigger tables — see its helper).
+	 */
+	insertReturningOptions(): { includeTriggerModifications: true } | undefined {
+		return undefined;
 	}
 }

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -48,7 +48,10 @@ export function getDatabase(): Knex {
 		connectionString,
 		pool: poolConfig = {},
 		...connectionConfig
-	} = getConfigFromEnv('DB_', { omitPrefix: 'DB_EXCLUDE_TABLES' });
+	} = getConfigFromEnv('DB_', {
+		omitPrefix: 'DB_EXCLUDE_TABLES',
+		omitKey: ['DB_BATCH_INSERT_CHUNK_SIZE', 'DB_MSSQL_TRUST_BATCH_RETURNING'],
+	});
 
 	const requiredEnvVars = ['DB_CLIENT'];
 

--- a/api/src/services/comments.test.ts
+++ b/api/src/services/comments.test.ts
@@ -81,8 +81,8 @@ describe('Services / Comments', () => {
 		vi.restoreAllMocks();
 	});
 
-	it('should expand a valid @mention into its user preview in the notification message (line 130)', async () => {
-		const superCreateOneSpy = vi.spyOn(ItemsService.prototype, 'createOne').mockResolvedValue('comment-pk-1');
+	it('should expand a valid @mention into its user preview in the notification message (line 137)', async () => {
+		const superCreateManySpy = vi.spyOn(ItemsService.prototype, 'createMany').mockResolvedValue(['comment-pk-1']);
 
 		const service = new CommentsService({ knex: db, schema, accountability });
 
@@ -105,14 +105,16 @@ describe('Services / Comments', () => {
 			{ id: mentionUuid, first_name: 'Jane', last_name: 'Doe', email: 'jane@x.com' },
 		]);
 
-		const result = await service.createOne({
-			comment: `hey @${mentionUuid} please review`,
-			collection: 'articles',
-			item: '42',
-		});
+		const result = await service.createMany([
+			{
+				comment: `hey @${mentionUuid} please review`,
+				collection: 'articles',
+				item: '42',
+			},
+		]);
 
-		expect(result).toBe('comment-pk-1');
-		expect(superCreateOneSpy).toHaveBeenCalledTimes(1);
+		expect(result).toEqual(['comment-pk-1']);
+		expect(superCreateManySpy).toHaveBeenCalledTimes(1);
 
 		expect(NotificationsService.prototype.createOne).toHaveBeenCalledTimes(1);
 
@@ -123,24 +125,26 @@ describe('Services / Comments', () => {
 		expect(notification.collection).toBe('articles');
 		expect(notification.item).toBe('42');
 
-		// line 130: the raw @<uuid> mention is replaced by the <em>userName</em> preview
+		// line 137: the raw @<uuid> mention is replaced by the <em>userName</em> preview
 		expect(notification.message).toContain('<em>Jane Doe</em>');
 		expect(notification.message).not.toContain(`@${mentionUuid}`);
 	});
 
-	it('should early-return without sending a notification when there are no mentions (lines 65-67)', async () => {
-		const superCreateOneSpy = vi.spyOn(ItemsService.prototype, 'createOne').mockResolvedValue('comment-pk-2');
+	it('should early-continue without sending a notification when there are no mentions (lines 68-70)', async () => {
+		const superCreateManySpy = vi.spyOn(ItemsService.prototype, 'createMany').mockResolvedValue(['comment-pk-2']);
 
 		const service = new CommentsService({ knex: db, schema, accountability });
 
-		const result = await service.createOne({
-			comment: 'a plain comment with no mentions',
-			collection: 'articles',
-			item: '7',
-		});
+		const result = await service.createMany([
+			{
+				comment: 'a plain comment with no mentions',
+				collection: 'articles',
+				item: '7',
+			},
+		]);
 
-		expect(result).toBe('comment-pk-2');
-		expect(superCreateOneSpy).toHaveBeenCalledTimes(1);
+		expect(result).toEqual(['comment-pk-2']);
+		expect(superCreateManySpy).toHaveBeenCalledTimes(1);
 		expect(UsersService.prototype.readOne).not.toHaveBeenCalled();
 		expect(NotificationsService.prototype.createOne).not.toHaveBeenCalled();
 	});

--- a/api/src/services/comments.ts
+++ b/api/src/services/comments.ts
@@ -26,117 +26,122 @@ export class CommentsService extends ItemsService {
 		this.usersService = new UsersService({ schema: this.schema });
 	}
 
-	override async createOne(data: Partial<Comment>, opts?: MutationOptions): Promise<PrimaryKey> {
+	override async createMany(data: Partial<Comment>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
 		if (!this.accountability?.user) throw new ForbiddenError();
 
-		if (!data['comment']) {
-			throw new InvalidPayloadError({ reason: `"comment" is required` });
-		}
+		for (const item of data) {
+			if (!item['comment']) {
+				throw new InvalidPayloadError({ reason: `"comment" is required` });
+			}
 
-		if (!data['collection']) {
-			throw new InvalidPayloadError({ reason: `"collection" is required` });
-		}
+			if (!item['collection']) {
+				throw new InvalidPayloadError({ reason: `"collection" is required` });
+			}
 
-		if (!data['item']) {
-			throw new InvalidPayloadError({ reason: `"item" is required` });
-		}
+			if (!item['item']) {
+				throw new InvalidPayloadError({ reason: `"item" is required` });
+			}
 
-		if (this.accountability) {
-			await validateAccess(
-				{
-					accountability: this.accountability,
-					action: 'read',
-					collection: data['collection'],
-					primaryKeys: [data['item']],
-				},
-				{
-					schema: this.schema,
-					knex: this.knex,
-				},
-			);
-		}
-
-		const result = await super.createOne(data, opts);
-
-		const usersRegExp = new RegExp(/@[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}/gi);
-
-		const mentions = uniq(data['comment'].match(usersRegExp) ?? []);
-
-		if (mentions.length === 0) {
-			return result;
-		}
-
-		const sender = await this.usersService.readOne(this.accountability.user, {
-			fields: ['id', 'first_name', 'last_name', 'email'],
-		});
-
-		for (const mention of mentions) {
-			const userID = mention.substring(1);
-
-			const user = await this.usersService.readOne(userID, {
-				fields: ['id', 'first_name', 'last_name', 'email', 'role.id'],
-			});
-
-			const accountability: Accountability = {
-				user: userID,
-				role: user['role']?.id ?? null,
-				admin: false,
-				app: false,
-				roles: await fetchRolesTree(user['role']?.id ?? null, this.knex),
-				ip: null,
-			};
-
-			const userGlobalAccess = await fetchGlobalAccess(accountability, this.knex);
-
-			accountability.admin = userGlobalAccess.admin;
-			accountability.app = userGlobalAccess.app;
-
-			const usersService = new UsersService({ schema: this.schema, accountability });
-
-			try {
+			if (this.accountability) {
 				await validateAccess(
 					{
-						accountability,
+						accountability: this.accountability,
 						action: 'read',
-						collection: data['collection'],
-						primaryKeys: [data['item']],
+						collection: item['collection'],
+						primaryKeys: [item['item']],
 					},
 					{
 						schema: this.schema,
 						knex: this.knex,
 					},
 				);
+			}
+		}
 
-				const templateData = await usersService.readByQuery({
-					fields: ['id', 'first_name', 'last_name', 'email'],
-					filter: { id: { _in: mentions.map((mention) => mention.substring(1)) } },
+		const keys = await super.createMany(data, opts);
+
+		const usersRegExp = new RegExp(/@[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}/gi);
+
+		for (const item of data) {
+			const mentions = uniq(item['comment']!.match(usersRegExp) ?? []);
+
+			if (mentions.length === 0) {
+				continue;
+			}
+
+			// Validated non-null in the pre-insert loop above.
+			const collection = item['collection']!;
+			const itemKey = item['item']!;
+
+			const sender = await this.usersService.readOne(this.accountability.user, {
+				fields: ['id', 'first_name', 'last_name', 'email'],
+			});
+
+			for (const mention of mentions) {
+				const userID = mention.substring(1);
+
+				const user = await this.usersService.readOne(userID, {
+					fields: ['id', 'first_name', 'last_name', 'email', 'role.id'],
 				});
 
-				const userPreviews = templateData.reduce(
-					(acc, user) => {
-						acc[user['id']] = `<em>${userName(user)}</em>`;
-						return acc;
-					},
-					{} as Record<string, string>,
-				);
+				const accountability: Accountability = {
+					user: userID,
+					role: user['role']?.id ?? null,
+					admin: false,
+					app: false,
+					roles: await fetchRolesTree(user['role']?.id ?? null, this.knex),
+					ip: null,
+				};
 
-				let comment = data['comment'];
+				const userGlobalAccess = await fetchGlobalAccess(accountability, this.knex);
 
-				for (const mention of mentions) {
-					const uuid = mention.substring(1);
-					// We only match on UUIDs in the first place. This is just an extra sanity check.
-					if (isValidUuid(uuid) === false) continue;
-					// Literal replace (not a user-built RegExp) avoids regex injection; mention is a literal @<uuid>.
-					comment = comment.replaceAll(mention, userPreviews[uuid] ?? '@Unknown User');
-				}
+				accountability.admin = userGlobalAccess.admin;
+				accountability.app = userGlobalAccess.app;
 
-				comment = `> ${comment.replace(/\n+/gm, '\n> ')}`;
+				const usersService = new UsersService({ schema: this.schema, accountability });
 
-				const href = new Url(env['PUBLIC_URL'] as string)
-					.addPath('admin', 'content', data['collection'], data['item'])
-					.toString();
+				try {
+					await validateAccess(
+						{
+							accountability,
+							action: 'read',
+							collection: collection,
+							primaryKeys: [itemKey],
+						},
+						{
+							schema: this.schema,
+							knex: this.knex,
+						},
+					);
 
-				const message = `
+					const templateData = await usersService.readByQuery({
+						fields: ['id', 'first_name', 'last_name', 'email'],
+						filter: { id: { _in: mentions.map((mention) => mention.substring(1)) } },
+					});
+
+					const userPreviews = templateData.reduce(
+						(acc, user) => {
+							acc[user['id']] = `<em>${userName(user)}</em>`;
+							return acc;
+						},
+						{} as Record<string, string>,
+					);
+
+					let comment = item['comment']!;
+
+					for (const mention of mentions) {
+						const uuid = mention.substring(1);
+						// We only match on UUIDs in the first place. This is just an extra sanity check.
+						if (isValidUuid(uuid) === false) continue;
+						// Literal replace (not a user-built RegExp) avoids regex injection; mention is a literal @<uuid>.
+						comment = comment.replaceAll(mention, userPreviews[uuid] ?? '@Unknown User');
+					}
+
+					comment = `> ${comment.replace(/\n+/gm, '\n> ')}`;
+
+					const href = new Url(env['PUBLIC_URL'] as string).addPath('admin', 'content', collection, itemKey).toString();
+
+					const message = `
 Hello ${userName(user)},
 
 ${userName(sender)} has mentioned you in a comment:
@@ -146,24 +151,25 @@ ${comment}
 <a href="${href}">Click here to view.</a>
 `;
 
-				await this.notificationsService.createOne({
-					recipient: userID,
-					sender: sender['id'],
-					subject: `You were mentioned in ${data['collection']}`,
-					message,
-					collection: data['collection'],
-					item: data['item'],
-				});
-			} catch (err: any) {
-				if (isDirectusError(err, ErrorCode.Forbidden)) {
-					logger.warn(`User ${userID} doesn't have proper permissions to receive notification for this item.`);
-				} else {
-					throw err;
+					await this.notificationsService.createOne({
+						recipient: userID,
+						sender: sender['id'],
+						subject: `You were mentioned in ${collection}`,
+						message,
+						collection: collection,
+						item: itemKey,
+					});
+				} catch (err: any) {
+					if (isDirectusError(err, ErrorCode.Forbidden)) {
+						logger.warn(`User ${userID} doesn't have proper permissions to receive notification for this item.`);
+					} else {
+						throw err;
+					}
 				}
 			}
 		}
 
-		return result;
+		return keys;
 	}
 
 	override updateOne(key: PrimaryKey, data: Partial<Comment>, opts?: MutationOptions): Promise<PrimaryKey> {

--- a/api/src/services/files.test.ts
+++ b/api/src/services/files.test.ts
@@ -37,9 +37,9 @@ describe('Integration Tests', () => {
 	});
 
 	describe('Services / Files', () => {
-		describe('createOne', () => {
+		describe('createMany', () => {
 			let service: FilesService;
-			let superCreateOne: MockInstance;
+			let superCreateMany: MockInstance;
 
 			beforeEach(() => {
 				service = new FilesService({
@@ -47,33 +47,60 @@ describe('Integration Tests', () => {
 					schema: { collections: {}, relations: [] },
 				});
 
-				superCreateOne = vi.spyOn(ItemsService.prototype, 'createOne').mockReturnValue(Promise.resolve(1));
+				superCreateMany = vi.spyOn(ItemsService.prototype, 'createMany').mockReturnValue(Promise.resolve([1]));
 			});
 
 			it('throws InvalidPayloadError when "type" is not provided', async () => {
 				try {
-					await service.createOne({
-						title: 'Test File',
-						storage: 'local',
-						filename_download: 'test_file',
-					});
+					await service.createMany([
+						{
+							title: 'Test File',
+							storage: 'local',
+							filename_download: 'test_file',
+						},
+					]);
 				} catch (err: any) {
 					expect(err).toBeInstanceOf(InvalidPayloadError);
 					expect(err.message).toBe('Invalid payload. "type" is required.');
 				}
 
-				expect(superCreateOne).not.toHaveBeenCalled();
+				expect(superCreateMany).not.toHaveBeenCalled();
 			});
 
 			it('creates a file entry when "type" is provided', async () => {
-				await service.createOne({
-					title: 'Test File',
-					storage: 'local',
-					filename_download: 'test_file',
-					type: 'application/octet-stream',
-				});
+				await service.createMany([
+					{
+						title: 'Test File',
+						storage: 'local',
+						filename_download: 'test_file',
+						type: 'application/octet-stream',
+					},
+				]);
 
-				expect(superCreateOne).toHaveBeenCalled();
+				expect(superCreateMany).toHaveBeenCalled();
+			});
+
+			it('throws InvalidPayloadError when any file in a multi-file payload is missing "type"', async () => {
+				try {
+					await service.createMany([
+						{ type: 'application/octet-stream', filename_download: 'good.txt' },
+						{ storage: 'local', filename_download: 'no-type.txt' },
+					]);
+				} catch (err: any) {
+					expect(err).toBeInstanceOf(InvalidPayloadError);
+					expect(err.message).toBe('Invalid payload. "type" is required.');
+				}
+
+				expect(superCreateMany).not.toHaveBeenCalled();
+			});
+
+			it('creates multiple file entries when all "type" fields are provided', async () => {
+				await service.createMany([
+					{ type: 'application/octet-stream', filename_download: 'first.txt' },
+					{ type: 'image/jpeg', filename_download: 'second.jpg' },
+				]);
+
+				expect(superCreateMany).toHaveBeenCalled();
 			});
 		});
 

--- a/api/src/services/files.ts
+++ b/api/src/services/files.ts
@@ -266,13 +266,14 @@ export class FilesService extends ItemsService<File> {
 	 * Create a file (only applicable when it is not a multipart/data POST request)
 	 * Useful for associating metadata with existing file in storage
 	 */
-	override async createOne(data: Partial<File>, opts?: MutationOptions): Promise<PrimaryKey> {
-		if (!data.type) {
-			throw new InvalidPayloadError({ reason: `"type" is required` });
+	override async createMany(data: Partial<File>[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
+		for (const item of data) {
+			if (!item.type) {
+				throw new InvalidPayloadError({ reason: `"type" is required` });
+			}
 		}
 
-		const key = await super.createOne(data, opts);
-		return key;
+		return super.createMany(data, opts);
 	}
 
 	/**

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -4,6 +4,7 @@ import { UserIntegrityCheckFlag } from '@directus/types';
 import knex, { type Knex } from 'knex';
 import { MockClient, Tracker, createTracker } from 'knex-mock-client';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+import { getDatabaseClient } from '../database/index.js';
 import emitter from '../emitter.js';
 import { validateUserCountIntegrity } from '../utils/validate-user-count-integrity.js';
 import { ItemsService } from './index.js';
@@ -223,6 +224,18 @@ describe('Integration Tests', () => {
 		});
 
 		describe('createMany', () => {
+			// A schema without relations so batchInsert is the only query path under test.
+			const batchSchema = new SchemaBuilder()
+				.collection('test', (c) => {
+					c.field('id').id();
+					c.field('name').string();
+				})
+				.build();
+
+			function batchService() {
+				return new ItemsService('test', { knex: db, schema: batchSchema });
+			}
+
 			it('should validate user count if requested', async () => {
 				await service.createMany([{}], { userIntegrityCheckFlags: UserIntegrityCheckFlag.All });
 
@@ -237,6 +250,77 @@ describe('Integration Tests', () => {
 				expect(result).toEqual([null, null]);
 
 				filterSpy.mockRestore();
+			});
+
+			it('uses a single batchInsert and maps the returned keys positionally when the dialect preserves RETURNING order', async () => {
+				// postgres preserves insert order in RETURNING -> the batch path is taken for >1 row
+				vi.mocked(getDatabaseClient).mockReturnValue('postgres');
+
+				const batchReturning = vi.fn().mockResolvedValue([{ id: 10 }, { id: 20 }]);
+				const batchInsert = vi.fn().mockReturnValue({ returning: batchReturning });
+
+				const transactionSpy = vi
+					.spyOn(db, 'transaction')
+					.mockImplementation(async (callback) => callback({ ...db, batchInsert } as any));
+
+				const result = await batchService().createMany([{ name: 'a' }, { name: 'b' }]);
+
+				expect(batchInsert).toHaveBeenCalledTimes(1);
+				expect(batchInsert.mock.calls[0]![1]).toEqual([{ name: 'a' }, { name: 'b' }]);
+				expect(result).toEqual([10, 20]);
+
+				transactionSpy.mockRestore();
+			});
+
+			it('falls back to a per-row insert loop when the dialect does not preserve RETURNING order', async () => {
+				// mysql has no order-preserving RETURNING -> each row is inserted individually
+				vi.mocked(getDatabaseClient).mockReturnValue('mysql');
+
+				const returning = vi
+					.fn()
+					.mockResolvedValueOnce([{ id: 1 }])
+					.mockResolvedValueOnce([{ id: 2 }]);
+
+				const into = vi.fn().mockReturnValue({ returning });
+				const insert = vi.fn().mockReturnValue({ into });
+
+				const transactionSpy = vi
+					.spyOn(db, 'transaction')
+					.mockImplementation(async (callback) => callback({ ...db, insert } as any));
+
+				const result = await batchService().createMany([{ name: 'a' }, { name: 'b' }]);
+
+				expect(insert).toHaveBeenCalledTimes(2);
+				expect(result).toEqual([1, 2]);
+
+				transactionSpy.mockRestore();
+			});
+
+			it('returns an empty array without opening a transaction for an empty input', async () => {
+				const transactionSpy = vi.spyOn(db, 'transaction');
+
+				const result = await batchService().createMany([]);
+
+				expect(result).toEqual([]);
+				expect(transactionSpy).not.toHaveBeenCalled();
+
+				transactionSpy.mockRestore();
+			});
+
+			it('throws when batchInsert returns fewer rows than prepared (positional mapping would be wrong)', async () => {
+				vi.mocked(getDatabaseClient).mockReturnValue('postgres');
+
+				// two rows in, only one key back -> the positional row->key mapping is unsafe
+				const batchReturning = vi.fn().mockResolvedValue([{ id: 10 }]);
+				const batchInsert = vi.fn().mockReturnValue({ returning: batchReturning });
+
+				const transactionSpy = vi
+					.spyOn(db, 'transaction')
+					.mockImplementation(async (callback) => callback({ ...db, batchInsert } as any));
+
+				await expect(batchService().createMany([{ name: 'a' }, { name: 'b' }])).rejects.toThrow(/expected 2/);
+
+				transactionSpy.mockRestore();
 			});
 		});
 

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -146,316 +146,17 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 	/**
 	 * Create a single new item.
-	 *
-	 * Resolves to null when a filter hook cancels the create (returns null) and
-	 * `allowFilterCancel` is opted in; otherwise such a cancel is an InvalidPayloadError.
 	 */
 	async createOne(data: Partial<Item>, opts: MutationOptions & { allowFilterCancel: true }): Promise<PrimaryKey | null>;
-
 	async createOne(data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey>;
 	async createOne(data: Partial<Item>, opts: MutationOptions = {}): Promise<PrimaryKey | null> {
-		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
-
-		if (!opts.bypassLimits) {
-			opts.mutationTracker.trackMutations(1);
-		}
-
-		const { ActivityService } = await import('./activity.js');
-		const { RevisionsService } = await import('./revisions.js');
-
-		const primaryKeyField = this.schema.collections[this.collection]!.primary;
-		const fields = Object.keys(this.schema.collections[this.collection]!.fields);
-
-		const aliases = Object.values(this.schema.collections[this.collection]!.fields)
-			.filter((field) => field.alias === true)
-			.map((field) => field.field);
-
-		const payload: AnyItem = cloneDeep(data);
-		let actionHookPayload = payload;
-		let createWasTakenOver = false;
-		const nestedActionEvents: ActionEventParams[] = [];
-
-		/**
-		 * By wrapping the logic in a transaction, we make sure we automatically roll back all the
-		 * changes in the DB if any of the parts contained within throws an error. This also means
-		 * that any errors thrown in any nested relational changes will bubble up and cancel the whole
-		 * update tree
-		 */
-		const primaryKey: PrimaryKey | null = await transaction(this.knex, async (trx) => {
-			// Run all hooks that are attached to this event so the end user has the chance to augment the
-			// item that is about to be saved
-			const payloadAfterHooks: AnyItem | PrimaryKey | null =
-				opts.emitEvents !== false
-					? await emitter.emitFilter<AnyItem, PrimaryKey | null>(
-							this.eventScope === 'items'
-								? ['items.create', `${this.collection}.items.create`]
-								: `${this.eventScope}.create`,
-							payload,
-							{
-								collection: this.collection,
-							},
-							{
-								database: trx,
-								schema: this.schema,
-								accountability: this.accountability,
-							},
-						)
-					: payload;
-
-			if (typeof payloadAfterHooks === 'string' || typeof payloadAfterHooks === 'number') {
-				// A filter hook returned a primary key instead of a payload: it has taken over the
-				// creation, so short-circuit and surface that key. No row was created through this
-				// service, so the items.create action must not fire with the original payload — the
-				// hook that took over owns any events.
-				createWasTakenOver = true;
-				return payloadAfterHooks;
-			}
-
-			if (payloadAfterHooks === null) {
-				// A filter hook nulled the payload to cancel the create. With allowFilterCancel the
-				// caller opted into a null result; otherwise a null payload is a hard error. Either way
-				// no row is created, so suppress the items.create action (reuse the take-over guard).
-				createWasTakenOver = true;
-
-				if (opts.allowFilterCancel) {
-					return null;
-				}
-
-				throw new InvalidPayloadError({ reason: 'Item creation was cancelled by a filter hook' });
-			}
-
-			const payloadWithPresets = this.accountability
-				? await processPayload(
-						{
-							accountability: this.accountability,
-							action: 'create',
-							collection: this.collection,
-							payload: payloadAfterHooks,
-							nested: this.nested,
-						},
-						{
-							knex: trx,
-							schema: this.schema,
-						},
-					)
-				: payloadAfterHooks;
-
-			if (opts.preMutationError) {
-				throw opts.preMutationError;
-			}
-
-			// Ensure the action hook payload has the post filter hook + preset changes
-			actionHookPayload = payloadWithPresets;
-
-			// We're creating new services instances so they can use the transaction as their Knex interface
-			const payloadService = new PayloadService(this.collection, {
-				accountability: this.accountability,
-				knex: trx,
-				schema: this.schema,
-				nested: this.nested,
-			});
-
-			const {
-				payload: payloadWithM2O,
-				revisions: revisionsM2O,
-				nestedActionEvents: nestedActionEventsM2O,
-				userIntegrityCheckFlags: userIntegrityCheckFlagsM2O,
-			} = await payloadService.processM2O(payloadWithPresets, opts);
-
-			const {
-				payload: payloadWithA2O,
-				revisions: revisionsA2O,
-				nestedActionEvents: nestedActionEventsA2O,
-				userIntegrityCheckFlags: userIntegrityCheckFlagsA2O,
-			} = await payloadService.processA2O(payloadWithM2O, opts);
-
-			const payloadWithoutAliases = pick(payloadWithA2O, without(fields, ...aliases));
-			const payloadWithTypeCasting = await payloadService.processValues('create', payloadWithoutAliases);
-
-			// The primary key can already exist in the payload.
-			// In case of manual string / UUID primary keys it's always provided at this point.
-			// In case of an (big) integer primary key, it might be provided as the user can specify the value manually.
-			let primaryKey: undefined | PrimaryKey = payloadWithTypeCasting[primaryKeyField];
-
-			if (primaryKey) {
-				validateKeys(this.schema, this.collection, primaryKeyField, primaryKey);
-			}
-
-			// If a PK of type number was provided, although the PK is set the auto_increment,
-			// depending on the database, the sequence might need to be reset to protect future PK collisions.
-			let autoIncrementSequenceNeedsToBeReset = false;
-
-			const pkField = this.schema.collections[this.collection]!.fields[primaryKeyField];
-
-			if (
-				primaryKey &&
-				pkField &&
-				!opts.bypassAutoIncrementSequenceReset &&
-				['integer', 'bigInteger'].includes(pkField.type) &&
-				pkField.defaultValue === 'AUTO_INCREMENT'
-			) {
-				autoIncrementSequenceNeedsToBeReset = true;
-			}
-
-			try {
-				const result = await trx
-					.insert(payloadWithoutAliases)
-					.into(this.collection)
-					.returning(primaryKeyField)
-					.then((result) => result[0]);
-
-				const returnedKey = typeof result === 'object' ? result[primaryKeyField] : result;
-
-				if (pkField!.type === 'uuid') {
-					primaryKey = getHelpers(trx).schema.formatUUID(primaryKey ?? returnedKey);
-				} else {
-					primaryKey = primaryKey ?? returnedKey;
-				}
-			} catch (err: any) {
-				const dbError = await translateDatabaseError(err, data);
-
-				if (isDirectusError(dbError, ErrorCode.RecordNotUnique) && dbError.extensions.primaryKey) {
-					// This is a MySQL specific thing we need to handle here, since MySQL does not return the field name
-					// if the unique constraint is the primary key
-					dbError.extensions.field = pkField?.field ?? null;
-
-					delete dbError.extensions.primaryKey;
-				}
-
-				throw dbError;
-			}
-
-			// Most database support returning, those who don't tend to return the PK anyways
-			// (MySQL/SQLite). In case the primary key isn't know yet, we'll do a best-attempt at
-			// fetching it based on the last inserted row
-			if (!primaryKey) {
-				// Fetching it with max should be safe, as we're in the context of the current transaction
-				const result = await trx.max(primaryKeyField, { as: 'id' }).from(this.collection).first();
-				primaryKey = result.id;
-
-				// Set the primary key on the input item, in order for the "after" event hook to be able
-				// to read from it
-				actionHookPayload[primaryKeyField] = primaryKey;
-			}
-
-			// At this point, the primary key is guaranteed to be set.
-			primaryKey = primaryKey as PrimaryKey;
-
-			const {
-				revisions: revisionsO2M,
-				nestedActionEvents: nestedActionEventsO2M,
-				userIntegrityCheckFlags: userIntegrityCheckFlagsO2M,
-			} = await payloadService.processO2M(payloadWithPresets, primaryKey, opts);
-
-			nestedActionEvents.push(...nestedActionEventsM2O);
-			nestedActionEvents.push(...nestedActionEventsA2O);
-			nestedActionEvents.push(...nestedActionEventsO2M);
-
-			const userIntegrityCheckFlags =
-				(opts.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None) |
-				userIntegrityCheckFlagsM2O |
-				userIntegrityCheckFlagsA2O |
-				userIntegrityCheckFlagsO2M;
-
-			if (userIntegrityCheckFlags) {
-				if (opts.onRequireUserIntegrityCheck) {
-					opts.onRequireUserIntegrityCheck(userIntegrityCheckFlags);
-				} else {
-					await validateUserCountIntegrity({ flags: userIntegrityCheckFlags, knex: trx });
-				}
-			}
-
-			// If this is an authenticated action, and accountability tracking is enabled, save activity row
-			if (this.accountability && this.schema.collections[this.collection]!.accountability !== null) {
-				const activityService = new ActivityService({
-					knex: trx,
-					schema: this.schema,
-				});
-
-				const activity = await activityService.createOne({
-					action: Action.CREATE,
-					user: this.accountability!.user,
-					collection: this.collection,
-					ip: this.accountability!.ip,
-					user_agent: this.accountability!.userAgent,
-					origin: this.accountability!.origin,
-					item: primaryKey,
-				});
-
-				// If revisions are tracked, create revisions record
-				if (this.schema.collections[this.collection]!.accountability === 'all') {
-					const revisionsService = new RevisionsService({
-						knex: trx,
-						schema: this.schema,
-					});
-
-					const revisionDelta = await payloadService.prepareDelta(payloadAfterHooks);
-
-					const revision = await revisionsService.createOne({
-						activity: activity,
-						collection: this.collection,
-						item: primaryKey,
-						data: revisionDelta,
-						delta: revisionDelta,
-					});
-
-					// Make sure to set the parent field of the child-revision rows
-					const childrenRevisions = [...revisionsM2O, ...revisionsA2O, ...revisionsO2M];
-
-					if (childrenRevisions.length > 0) {
-						await revisionsService.updateMany(childrenRevisions, { parent: revision });
-					}
-
-					if (opts.onRevisionCreate) {
-						opts.onRevisionCreate(revision);
-					}
-				}
-			}
-
-			if (autoIncrementSequenceNeedsToBeReset) {
-				await getHelpers(trx).sequence.resetAutoIncrementSequence(this.collection, primaryKeyField);
-			}
-
-			return primaryKey;
-		});
-
-		// A filter hook cancelled the creation: nothing was inserted, so skip the action hooks entirely.
-		if (primaryKey === null) {
-			return null;
-		}
-
-		if (opts.emitEvents !== false && !createWasTakenOver) {
-			const actionEvent = {
-				event:
-					this.eventScope === 'items'
-						? ['items.create', `${this.collection}.items.create`]
-						: `${this.eventScope}.create`,
-				meta: {
-					payload: actionHookPayload,
-					key: primaryKey,
-					collection: this.collection,
-				},
-				context: {
-					database: getDatabase(),
-					schema: this.schema,
-					accountability: this.accountability,
-				},
-			};
-
-			await emitActionEvents([actionEvent, ...nestedActionEvents], opts);
-		}
-
-		if (shouldClearCache(this.cache, opts, this.collection)) {
-			await this.cache.clear();
-		}
-
-		return primaryKey;
+		const [primaryKey] = await this.createMany([data], opts);
+		return primaryKey ?? null;
 	}
 
 	/**
-	 * Create multiple new items at once. Inserts all provided records sequentially wrapped in a transaction.
-	 *
-	 * Uses `this.createOne` under the hood.
+	 * Create one or more new items at once, wrapped in a transaction. Uses a single batchInsert
+	 * where the vendor preserves RETURNING order, otherwise falls back to per-row inserts.
 	 */
 	async createMany(
 		data: Partial<Item>[],
@@ -466,61 +167,408 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	async createMany(data: Partial<Item>[], opts: MutationOptions = {}): Promise<(PrimaryKey | null)[]> {
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
 
-		const { primaryKeys, nestedActionEvents } = await transaction(this.knex, async (knex) => {
-			const service = this.fork({ knex });
+		if (data.length === 0) {
+			return [];
+		}
 
-			let userIntegrityCheckFlags = opts.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None;
+		if (!opts.bypassLimits) {
+			opts.mutationTracker.trackMutations(data.length);
+		}
 
-			const primaryKeys: (PrimaryKey | null)[] = [];
+		const primaryKeyField = this.schema.collections[this.collection]!.primary;
+		const fields = Object.keys(this.schema.collections[this.collection]!.fields);
+
+		const aliases = Object.values(this.schema.collections[this.collection]!.fields)
+			.filter((field) => field.alias === true)
+			.map((field) => field.field);
+
+		const pkField = this.schema.collections[this.collection]!.fields[primaryKeyField];
+
+		// Index-aligned results: a filter hook can take over a row (returns its own PK) or cancel
+		// it (returns null), in which case that row is never inserted but still occupies its slot.
+		const results: (PrimaryKey | null)[] = new Array(data.length);
+
+		type ActionPayload = { primaryKey: PrimaryKey; actionHookPayload: AnyItem };
+
+		const { nestedActionEvents, actionPayloads } = await transaction(this.knex, async (trx) => {
 			const nestedActionEvents: ActionEventParams[] = [];
+			let userIntegrityCheckFlags = opts.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None;
+			let autoIncrementSequenceNeedsToBeReset = false;
 
-			const pkField = this.schema.collections[this.collection]!.primary;
+			type PreparedRow = {
+				index: number;
+				actionHookPayload: AnyItem;
+				payloadAfterHooks: AnyItem;
+				payloadWithPresets: AnyItem;
+				payloadWithoutAliases: Record<string, unknown>;
+				primaryKey: PrimaryKey | undefined;
+				revisionsM2O: Awaited<ReturnType<PayloadService['processM2O']>>['revisions'];
+				revisionsA2O: Awaited<ReturnType<PayloadService['processA2O']>>['revisions'];
+				nestedActionEventsM2O: ActionEventParams[];
+				nestedActionEventsA2O: ActionEventParams[];
+				userIntegrityCheckFlagsM2O: UserIntegrityCheckFlag;
+				userIntegrityCheckFlagsA2O: UserIntegrityCheckFlag;
+				payloadService: PayloadService;
+			};
 
-			for (const [index, payload] of data.entries()) {
-				let bypassAutoIncrementSequenceReset = true;
+			const prepared: PreparedRow[] = [];
 
-				// the auto_increment sequence needs to be reset if the current item contains a manual PK and
-				// if it's the last item of the batch or if the next item doesn't include a PK and hence one needs to be generated
-				if (payload[pkField] && (index === data.length - 1 || !data[index + 1]?.[pkField])) {
-					bypassAutoIncrementSequenceReset = false;
+			for (const [index, payloadInput] of data.entries()) {
+				const payload: AnyItem = cloneDeep(payloadInput);
+
+				// Run all hooks that are attached to this event so the end user has the chance to augment the
+				// item that is about to be saved
+				const payloadAfterHooks =
+					opts.emitEvents !== false
+						? await emitter.emitFilter<AnyItem, PrimaryKey | null>(
+								this.eventScope === 'items'
+									? ['items.create', `${this.collection}.items.create`]
+									: `${this.eventScope}.create`,
+								payload,
+								{ collection: this.collection },
+								{
+									database: trx,
+									schema: this.schema,
+									accountability: this.accountability,
+								},
+							)
+						: payload;
+
+				if (typeof payloadAfterHooks === 'string' || typeof payloadAfterHooks === 'number') {
+					// A filter hook returned a primary key instead of a payload: it has taken over the
+					// creation of this row. Surface that key, insert nothing, and let the hook that took
+					// over own the action event.
+					results[index] = payloadAfterHooks;
+					continue;
 				}
 
-				// `allowFilterCancel` is propagated via `opts`; the overload resolves to the non-null
-				// signature, but a cancelling filter can still return null at runtime — hence the guard.
-				const primaryKey: PrimaryKey | null = await service.createOne(payload, {
-					...(opts || {}),
-					autoPurgeCache: false,
-					onRequireUserIntegrityCheck: (flags) => (userIntegrityCheckFlags |= flags),
-					bypassEmitAction: (params) => nestedActionEvents.push(params),
-					mutationTracker: opts.mutationTracker,
-					bypassAutoIncrementSequenceReset,
+				if (payloadAfterHooks === null) {
+					if (!opts.allowFilterCancel) {
+						throw new InvalidPayloadError({
+							reason: `A filter hook cancelled the creation, but this operation requires a created item`,
+						});
+					}
+
+					// The filter cancelled this row: nothing is inserted; the null slot keeps the result
+					// index-aligned with the input.
+					results[index] = null;
+					continue;
+				}
+
+				const payloadWithPresets = this.accountability
+					? await processPayload(
+							{
+								accountability: this.accountability,
+								action: 'create',
+								collection: this.collection,
+								payload: payloadAfterHooks,
+								nested: this.nested,
+							},
+							{ knex: trx, schema: this.schema },
+						)
+					: payloadAfterHooks;
+
+				if (opts.preMutationError) {
+					throw opts.preMutationError;
+				}
+
+				// Ensure the action hook payload has the post filter hook + preset changes
+				const actionHookPayload = payloadWithPresets;
+
+				// We're creating new services instances so they can use the transaction as their Knex interface
+				const payloadService = new PayloadService(this.collection, {
+					accountability: this.accountability,
+					knex: trx,
+					schema: this.schema,
+					nested: this.nested,
 				});
 
-				// A filter hook may cancel an individual create by returning null; the null is kept in
-				// place so the result stays index-aligned with the input (mirrors createOne).
-				primaryKeys.push(primaryKey);
+				const {
+					payload: payloadWithM2O,
+					revisions: revisionsM2O,
+					nestedActionEvents: nestedActionEventsM2O,
+					userIntegrityCheckFlags: userIntegrityCheckFlagsM2O,
+				} = await payloadService.processM2O(payloadWithPresets, opts);
+
+				const {
+					payload: payloadWithA2O,
+					revisions: revisionsA2O,
+					nestedActionEvents: nestedActionEventsA2O,
+					userIntegrityCheckFlags: userIntegrityCheckFlagsA2O,
+				} = await payloadService.processA2O(payloadWithM2O, opts);
+
+				const payloadWithoutAliases = pick(payloadWithA2O, without(fields, ...aliases));
+				const payloadWithTypeCasting = await payloadService.processValues('create', payloadWithoutAliases);
+
+				// The primary key can already exist in the payload.
+				// In case of manual string / UUID primary keys it's always provided at this point.
+				// In case of an (big) integer primary key, it might be provided as the user can specify the value manually.
+				const primaryKey: PrimaryKey | undefined = payloadWithTypeCasting[primaryKeyField];
+
+				if (primaryKey) {
+					validateKeys(this.schema, this.collection, primaryKeyField, primaryKey);
+				}
+
+				// If a PK of type number was provided, although the PK is set the auto_increment,
+				// depending on the database, the sequence might need to be reset to protect future PK collisions.
+				if (
+					primaryKey &&
+					pkField &&
+					!opts.bypassAutoIncrementSequenceReset &&
+					['integer', 'bigInteger'].includes(pkField.type) &&
+					pkField.defaultValue === 'AUTO_INCREMENT'
+				) {
+					autoIncrementSequenceNeedsToBeReset = true;
+				}
+
+				prepared.push({
+					index,
+					actionHookPayload,
+					payloadAfterHooks,
+					payloadWithPresets,
+					payloadWithoutAliases,
+					primaryKey,
+					revisionsM2O,
+					revisionsA2O,
+					nestedActionEventsM2O,
+					nestedActionEventsA2O,
+					userIntegrityCheckFlagsM2O,
+					userIntegrityCheckFlagsA2O,
+					payloadService,
+				});
+			}
+
+			const useBatchInsert =
+				prepared.length > 1 && (await getHelpers(trx).capabilities.preservesInsertOrderInReturning());
+
+			try {
+				if (useBatchInsert) {
+					const chunkSize = env['DB_BATCH_INSERT_CHUNK_SIZE'] as number | undefined;
+
+					const rowsToInsert = getHelpers(trx).capabilities.padRowsForBatchInsert(
+						prepared.map((p) => p.payloadWithoutAliases),
+						{
+							fields: this.schema.collections[this.collection]!.fields,
+							primaryKeyField,
+						},
+					);
+
+					const insertedRows = (await trx
+						.batchInsert(this.collection, rowsToInsert, chunkSize)
+						.returning(primaryKeyField)) as unknown as Array<Record<string, unknown> | PrimaryKey>;
+
+					if (insertedRows.length !== prepared.length) {
+						throw new Error(`batchInsert returned ${insertedRows.length} rows but expected ${prepared.length}`);
+					}
+
+					for (let i = 0; i < prepared.length; i++) {
+						const row = insertedRows[i]!;
+						const p = prepared[i]!;
+
+						const returnedKey =
+							typeof row === 'object' && row !== null ? (row as Record<string, unknown>)[primaryKeyField] : row;
+
+						if (pkField?.type === 'uuid') {
+							p.primaryKey = getHelpers(trx).schema.formatUUID((p.primaryKey ?? (returnedKey as string)) as string);
+						} else {
+							p.primaryKey = (p.primaryKey ?? returnedKey) as PrimaryKey;
+						}
+
+						p.actionHookPayload[primaryKeyField] = p.primaryKey;
+					}
+				} else {
+					const returningOptions = getHelpers(trx).capabilities.insertReturningOptions();
+
+					for (const p of prepared) {
+						const result = await trx
+							.insert(p.payloadWithoutAliases)
+							.into(this.collection)
+							.returning(primaryKeyField, returningOptions)
+							.then((rows) => rows[0]);
+
+						const returnedKey =
+							typeof result === 'object' && result !== null
+								? (result as Record<string, unknown>)[primaryKeyField]
+								: result;
+
+						if (pkField?.type === 'uuid') {
+							p.primaryKey = getHelpers(trx).schema.formatUUID((p.primaryKey ?? (returnedKey as string)) as string);
+						} else {
+							p.primaryKey = (p.primaryKey ?? returnedKey) as PrimaryKey;
+						}
+
+						// Most database support returning, those who don't tend to return the PK anyways
+						// (MySQL/SQLite). In case the primary key isn't know yet, we'll do a best-attempt at
+						// fetching it based on the last inserted row
+						if (!p.primaryKey) {
+							// Fetching it with max should be safe, as we're in the context of the current transaction
+							const maxResult = await trx.max(primaryKeyField, { as: 'id' }).from(this.collection).first();
+
+							p.primaryKey = maxResult?.id;
+						}
+
+						// Set the primary key on the input item, in order for the "after" event hook to be able
+						// to read from it
+						p.actionHookPayload[primaryKeyField] = p.primaryKey;
+					}
+				}
+			} catch (err: any) {
+				const dbError = await translateDatabaseError(err, data);
+
+				if (isDirectusError(dbError, ErrorCode.RecordNotUnique) && dbError.extensions.primaryKey) {
+					// This is a MySQL specific thing we need to handle here, since MySQL does not return the field name
+					// if the unique constraint is the primary key
+					dbError.extensions.field = pkField?.field ?? null;
+					delete dbError.extensions.primaryKey;
+				}
+
+				throw dbError;
+			}
+
+			type PostRow = PreparedRow & {
+				primaryKey: PrimaryKey;
+				revisionsO2M: Awaited<ReturnType<PayloadService['processO2M']>>['revisions'];
+				nestedActionEventsO2M: ActionEventParams[];
+			};
+
+			const postPrepared: PostRow[] = [];
+
+			for (const p of prepared) {
+				// At this point, the primary key is guaranteed to be set.
+				const primaryKey = p.primaryKey as PrimaryKey;
+
+				const {
+					revisions: revisionsO2M,
+					nestedActionEvents: nestedActionEventsO2M,
+					userIntegrityCheckFlags: userIntegrityCheckFlagsO2M,
+				} = await p.payloadService.processO2M(p.payloadWithPresets, primaryKey, opts);
+
+				userIntegrityCheckFlags |=
+					p.userIntegrityCheckFlagsM2O | p.userIntegrityCheckFlagsA2O | userIntegrityCheckFlagsO2M;
+
+				nestedActionEvents.push(...p.nestedActionEventsM2O, ...p.nestedActionEventsA2O, ...nestedActionEventsO2M);
+
+				postPrepared.push({
+					...p,
+					primaryKey,
+					revisionsO2M,
+					nestedActionEventsO2M,
+				});
 			}
 
 			if (userIntegrityCheckFlags) {
 				if (opts.onRequireUserIntegrityCheck) {
 					opts.onRequireUserIntegrityCheck(userIntegrityCheckFlags);
 				} else {
-					await validateUserCountIntegrity({ flags: userIntegrityCheckFlags, knex });
+					await validateUserCountIntegrity({
+						flags: userIntegrityCheckFlags,
+						knex: trx,
+					});
 				}
 			}
 
-			return { primaryKeys, nestedActionEvents };
+			// If this is an authenticated action, and accountability tracking is enabled, save activity row
+			if (this.accountability && this.schema.collections[this.collection]!.accountability !== null) {
+				const { ActivityService } = await import('./activity.js');
+				const { RevisionsService } = await import('./revisions.js');
+
+				const activityService = new ActivityService({ knex: trx, schema: this.schema });
+
+				const activityIds = await activityService.createMany(
+					postPrepared.map((p) => ({
+						action: Action.CREATE,
+						user: this.accountability!.user,
+						collection: this.collection,
+						ip: this.accountability!.ip,
+						user_agent: this.accountability!.userAgent,
+						origin: this.accountability!.origin,
+						item: p.primaryKey,
+					})),
+				);
+
+				// If revisions are tracked, create revisions record
+				if (this.schema.collections[this.collection]!.accountability === 'all') {
+					const revisionsService = new RevisionsService({ knex: trx, schema: this.schema });
+
+					const revisionInputs = await Promise.all(
+						postPrepared.map(async (p, index) => {
+							const revisionPayload = await p.payloadService.prepareDelta(p.payloadAfterHooks);
+
+							return {
+								activity: activityIds[index]!,
+								collection: this.collection,
+								item: p.primaryKey,
+								data: revisionPayload,
+								delta: revisionPayload,
+							};
+						}),
+					);
+
+					const revisionIds = await revisionsService.createMany(revisionInputs);
+
+					for (let i = 0; i < postPrepared.length; i++) {
+						const p = postPrepared[i]!;
+						const revisionId = revisionIds[i]!;
+						// Make sure to set the parent field of the child-revision rows
+						const childrenRevisions = [...p.revisionsM2O, ...p.revisionsA2O, ...p.revisionsO2M];
+
+						if (childrenRevisions.length > 0) {
+							await revisionsService.updateMany(childrenRevisions, { parent: revisionId });
+						}
+
+						if (opts.onRevisionCreate) {
+							opts.onRevisionCreate(revisionId);
+						}
+					}
+				}
+			}
+
+			if (autoIncrementSequenceNeedsToBeReset) {
+				await getHelpers(trx).sequence.resetAutoIncrementSequence(this.collection, primaryKeyField);
+			}
+
+			// Fill the index-aligned result with the keys of the rows that were actually inserted;
+			// taken-over / cancelled slots were already set in the prepare loop.
+			for (const p of postPrepared) {
+				results[p.index] = p.primaryKey;
+			}
+
+			return {
+				nestedActionEvents,
+				actionPayloads: postPrepared.map(
+					(p): ActionPayload => ({ primaryKey: p.primaryKey, actionHookPayload: p.actionHookPayload }),
+				),
+			};
 		});
 
 		if (opts.emitEvents !== false) {
-			await emitActionEvents(nestedActionEvents, opts);
+			const eventName =
+				this.eventScope === 'items' ? ['items.create', `${this.collection}.items.create`] : `${this.eventScope}.create`;
+
+			const actionEvents: ActionEventParams[] = actionPayloads.map(({ primaryKey, actionHookPayload }) => ({
+				event: eventName,
+				meta: {
+					payload: actionHookPayload,
+					key: primaryKey,
+					collection: this.collection,
+				},
+				context: {
+					database: getDatabase(),
+					schema: this.schema,
+					accountability: this.accountability,
+				},
+			}));
+
+			// Route through emitActionEvents so the create path honours `awaitActionHooks` (#58) and
+			// `bypassEmitAction` (nested mutations), instead of an un-awaited raw emit.
+			await emitActionEvents([...actionEvents, ...nestedActionEvents], opts);
 		}
 
 		if (shouldClearCache(this.cache, opts, this.collection)) {
 			await this.cache.clear();
 		}
 
-		return primaryKeys;
+		return results;
 	}
 
 	/**

--- a/api/src/services/notifications.ts
+++ b/api/src/services/notifications.ts
@@ -17,12 +17,14 @@ export class NotificationsService extends ItemsService {
 		super('directus_notifications', options);
 	}
 
-	override async createOne(data: Partial<Notification>, opts?: MutationOptions): Promise<PrimaryKey> {
-		const response = await super.createOne(data, opts);
+	override async createMany(data: Partial<Notification>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
+		const primaryKeys = await super.createMany(data, opts);
 
-		await this.sendEmail(data);
+		for (const notification of data) {
+			await this.sendEmail(notification);
+		}
 
-		return response;
+		return primaryKeys;
 	}
 
 	async sendEmail(data: Partial<Notification>) {

--- a/api/src/services/operations.ts
+++ b/api/src/services/operations.ts
@@ -7,8 +7,8 @@ export class OperationsService extends ItemsService<OperationRaw> {
 		super('directus_operations', options);
 	}
 
-	override async createOne(data: Partial<Item>, opts?: MutationOptions): Promise<PrimaryKey> {
-		const result = await super.createOne(data, opts);
+	override async createMany(data: Partial<Item>[], opts?: MutationOptions): Promise<PrimaryKey[]> {
+		const result = await super.createMany(data, opts);
 
 		const flowManager = getFlowManager();
 		await flowManager.reload();

--- a/api/src/services/policies.ts
+++ b/api/src/services/policies.ts
@@ -46,13 +46,15 @@ export class PoliciesService extends ItemsService<Policy> {
 		}
 	}
 
-	override async createOne(data: Partial<Policy>, opts: MutationOptions = {}): Promise<PrimaryKey> {
-		this.assertValidIpAccess(data);
+	override async createMany(data: Partial<Policy>[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
+		for (const item of data) {
+			this.assertValidIpAccess(item);
+		}
 
 		// A policy has been created, but the attachment to a user/role happens in the AccessService,
 		// so no need to check user integrity
 
-		const result = await super.createOne(data, opts);
+		const result = await super.createMany(data, opts);
 
 		// TODO is this necessary? Since the attachment should be handled in the AccessService
 		// A new policy has created, clear the permissions cache

--- a/packages/env/src/constants/defaults.ts
+++ b/packages/env/src/constants/defaults.ts
@@ -18,6 +18,7 @@ export const DEFAULTS = {
 	TEMP_PATH: './node_modules/.directus',
 
 	DB_EXCLUDE_TABLES: 'spatial_ref_sys,sysdiagrams',
+	DB_MSSQL_TRUST_BATCH_RETURNING: false,
 
 	STORAGE_LOCATIONS: 'local',
 	STORAGE_LOCAL_DRIVER: 'local',

--- a/packages/env/src/constants/type-map.ts
+++ b/packages/env/src/constants/type-map.ts
@@ -15,6 +15,8 @@ export const TYPE_MAP: Record<string, EnvType> = {
 	DB_PORT: 'number',
 
 	DB_EXCLUDE_TABLES: 'array',
+	DB_BATCH_INSERT_CHUNK_SIZE: 'number',
+	DB_MSSQL_TRUST_BATCH_RETURNING: 'boolean',
 
 	CACHE_SKIP_ALLOWED: 'boolean',
 	CACHE_AUTO_PURGE_IGNORE_LIST: 'array',

--- a/tests/blackbox/extensions/env-inject/index.mjs
+++ b/tests/blackbox/extensions/env-inject/index.mjs
@@ -1,0 +1,16 @@
+export default (router, { env }) => {
+	router.post('/set', (req, res) => {
+		if (!env) {
+			return res.status(500).json({ errors: [{ message: 'env not provided in extension context' }] });
+		}
+
+		const { key, value } = req.body ?? {};
+
+		if (typeof key !== 'string' || key.length === 0) {
+			return res.status(400).json({ errors: [{ message: 'missing string "key"' }] });
+		}
+
+		env[key] = value;
+		res.json({ data: { key, value } });
+	});
+};

--- a/tests/blackbox/extensions/env-inject/package.json
+++ b/tests/blackbox/extensions/env-inject/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "env-inject",
+	"version": "0.0.0",
+	"private": true,
+	"directus:extension": {
+		"type": "endpoint",
+		"path": "index.mjs",
+		"source": "index.mjs",
+		"host": "^10.10.0"
+	}
+}

--- a/tests/blackbox/extensions/query-counter/index.mjs
+++ b/tests/blackbox/extensions/query-counter/index.mjs
@@ -1,0 +1,37 @@
+const MAX = 5000;
+const buffer = [];
+
+function recordQuery(q) {
+	const bindings = Array.isArray(q?.bindings) ? q.bindings.map((b) => (b === null ? '' : String(b))).join(' ') : '';
+
+	buffer.push({ sql: q?.sql ?? '', bindings, t: Date.now() });
+
+	if (buffer.length > MAX) {
+		buffer.shift();
+	}
+}
+
+export default (router, { database }) => {
+	if (!database.__queryCounterAttached) {
+		database.on('query', recordQuery);
+		database.__queryCounterAttached = true;
+	}
+
+	router.get('/queries', (req, res) => {
+		const containsBinding = typeof req.query.containsBinding === 'string' ? req.query.containsBinding : '';
+		const containsSql = typeof req.query.containsSql === 'string' ? req.query.containsSql.toLowerCase() : '';
+
+		const matches = buffer.filter((entry) => {
+			if (containsBinding && !entry.bindings.includes(containsBinding)) return false;
+			if (containsSql && !entry.sql.toLowerCase().includes(containsSql)) return false;
+			return true;
+		});
+
+		res.json({ data: matches, total: buffer.length });
+	});
+
+	router.post('/reset', (_req, res) => {
+		buffer.length = 0;
+		res.json({ data: { reset: true } });
+	});
+};

--- a/tests/blackbox/extensions/query-counter/package.json
+++ b/tests/blackbox/extensions/query-counter/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "query-counter",
+	"version": "0.0.0",
+	"private": true,
+	"directus:extension": {
+		"type": "endpoint",
+		"path": "index.mjs",
+		"source": "index.mjs",
+		"host": "^10.10.0"
+	}
+}

--- a/tests/blackbox/tests/db/routes/items/batch-insert.test.ts
+++ b/tests/blackbox/tests/db/routes/items/batch-insert.test.ts
@@ -1,0 +1,382 @@
+import { randomUUID } from 'node:crypto';
+import { getUrl } from '@common/config';
+import vendors, { type Vendor } from '@common/get-dbs-to-test';
+import type { PrimaryKeyType } from '@common/types';
+import { PRIMARY_KEY_TYPES, USER } from '@common/variables';
+import { setDirectusEnv } from '@utils/set-directus-env';
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+import { collectionArtists } from './no-relation.seed';
+
+// Vendors where ItemsService.createMany emits a single multi-row INSERT … RETURNING
+// (the "reliable batch" path in api/src/services/items.ts).
+//
+// - All other vendors fall through the per-row loop and emit one INSERT per item.
+// - Both paths must produce the same observable result (count, distinct PKs, fields
+//   round-trip, explicit PKs preserved) — only the expected number of INSERT
+//   statements differs.
+// - sqlite3 is included because it sits on top of SQLite ≥ 3.35, where INSERT …
+//   RETURNING is supported natively; ItemsService probes the version at runtime and
+//   falls back to the loop path on older builds
+//   (https://www.sqlite.org/lang_returning.html).
+const RETURNING_VENDORS = [
+	'postgres',
+	'postgres10',
+	'cockroachdb',
+	'oracle',
+	'sqlite3',
+	// mssql is opt-in only via DB_MSSQL_TRUST_BATCH_RETURNING (see
+	// api/src/database/helpers/capabilities/dialects/mssql.ts). When the env var
+	// isn't set — which is the case in CI by default — mssql falls through the
+	// per-row loop bucket and emits N INSERTs.
+] as const satisfies readonly Vendor[];
+
+function isReliableBatchVendor(vendor: Vendor): boolean {
+	return (RETURNING_VENDORS as readonly Vendor[]).includes(vendor);
+}
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Response ordering note:
+//
+// - POST /items returns `data` via `service.readMany(savedKeys)`.
+// - With the DB_DEFAULT_ORDER_READS_BY_PK default in readByQuery, responses for
+//   collections with an integer / bigInteger PK are `ORDER BY <primary key> ASC`
+//   (unless the caller passes an explicit `sort`); UUID / string PK collections
+//   remain plan-dependent.
+// - Tests below sort both `expected` and `got` by `name` before deep-equal:
+//   - `name` is a stable semantic key across every pkType.
+//   - Keeps assertions resilient if the default ordering changes or is turned off
+//     (e.g. DB_DEFAULT_ORDER_READS_BY_PK=false).
+
+type Artist = {
+	id?: number | string;
+	name: string;
+	company: string;
+};
+
+function buildArtist(
+	pkType: PrimaryKeyType,
+	index: number,
+	nonce: string,
+	opts: { explicitId?: boolean } = {},
+): Artist {
+	const artist: Artist = {
+		name: `batch-${index}-${nonce}`,
+		company: `co-${index}-${nonce}`,
+	};
+
+	if (pkType === 'string') {
+		artist.id = `artist-${nonce}-${index}`;
+	} else if (opts.explicitId) {
+		if (pkType === 'uuid') {
+			artist.id = randomUUID();
+		} else if (pkType === 'integer') {
+			// 1B+ offset stays above per-table AUTO_INCREMENT in fresh test DBs;
+			// nonce hash makes consecutive runs use disjoint ranges.
+			const nonceNum = parseInt(nonce.replace(/-/g, '').slice(0, 8), 16);
+			artist.id = 1_000_000_000 + (nonceNum % 100_000_000) + index;
+		}
+	}
+
+	return artist;
+}
+
+async function resetQueryCounter(vendor: Vendor) {
+	await request(getUrl(vendor)).post('/query-counter/reset').set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+}
+
+const sortByName = (x: { name: string }, y: { name: string }) => x.name.localeCompare(y.name);
+
+async function fetchInsertQueriesForNonce(vendor: Vendor, nonce: string, collection: string) {
+	const response = await request(getUrl(vendor))
+		.get(`/query-counter/queries`)
+		.query({ containsBinding: nonce, containsSql: `insert into` })
+		.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+	const data = (response.body.data ?? []) as Array<{ sql: string; bindings: string }>;
+	return data.filter((q) => q.sql.toLowerCase().includes(collection.toLowerCase()));
+}
+
+describe.each(PRIMARY_KEY_TYPES)('/items batch-insert', (pkType) => {
+	const localCollectionArtists = `${collectionArtists}_${pkType}`;
+
+	describe(`pkType: ${pkType}`, () => {
+		describe('createMany short-circuits on empty input', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const nonce = randomUUID();
+
+				await resetQueryCounter(vendor);
+
+				const response = await request(getUrl(vendor))
+					.post(`/items/${localCollectionArtists}`)
+					.send([])
+					.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+				expect(response.statusCode).toBe(200);
+				expect(response.body.data).toEqual([]);
+
+				const inserts = await fetchInsertQueriesForNonce(vendor, nonce, localCollectionArtists);
+				expect(inserts).toHaveLength(0);
+			});
+		});
+
+		describe('createMany returns N items with distinct PKs, fields round-trip', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const N = 5;
+				const nonce = randomUUID();
+				const artists = Array.from({ length: N }, (_, i) => buildArtist(pkType, i, nonce));
+
+				await resetQueryCounter(vendor);
+
+				// Narrow response to the columns this test owns. The shared `no-relation.seed`
+				// collection carries additional fields (group, date_published) on upstream
+				// that this test doesn't seed and doesn't care about; without fields= the
+				// strict `toEqual` below would tip over on those extra props.
+				const response = await request(getUrl(vendor))
+					.post(`/items/${localCollectionArtists}`)
+					.query({ fields: 'id,name,company' })
+					.send(artists)
+					.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+				expect(response.statusCode).toBe(200);
+
+				const expected = artists.map((a) => ({
+					id: a.id ?? (pkType === 'integer' ? expect.any(Number) : expect.stringMatching(UUID_REGEX)),
+					name: a.name,
+					company: a.company,
+				}));
+
+				const got = response.body.data as Array<{ id: number | string; name: string; company: string }>;
+
+				if (pkType === 'integer') {
+					// Integer-PK collections get DB_DEFAULT_ORDER_READS_BY_PK = ORDER BY pk ASC.
+					//
+					// - Auto-increment IDs are assigned in insertion order, so PK ASC == input order.
+					// - Comparing without any sort actively pins that the default ordering kicked in.
+					// - If DB_DEFAULT_ORDER_READS_BY_PK gets disabled or the integer-PK branch in
+					//   readByQuery regresses, this assertion fails.
+					expect(got).toEqual(expected);
+				} else {
+					// UUID / string PKs are intentionally excluded from the default sort, so
+					// the response is in plan-dependent order. Sort both sides by `name` to
+					// compare order-independently.
+					expect([...got].sort(sortByName)).toEqual([...expected].sort(sortByName));
+				}
+
+				// Engine UNIQUE prevents row-level PK dups; this pins that createMany's
+				// PK reassignment reports them back distinctly — catches off-by-one or
+				// shuffle regressions in the insertedRows → itemsToInsert mapping at
+				// items.ts:430-449.
+				expect(new Set(got.map((g) => g.id)).size).toBe(N);
+
+				// Query-count is the only branch: reliable vendors emit one multi-row INSERT,
+				// loop-bucket vendors emit one INSERT per row.
+				const inserts = await fetchInsertQueriesForNonce(vendor, nonce, localCollectionArtists);
+				expect(inserts).toHaveLength(isReliableBatchVendor(vendor) ? 1 : N);
+			});
+		});
+
+		describe('createOne (single-object POST) returns one item via createMany([one])', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const nonce = randomUUID();
+				const artist = buildArtist(pkType, 0, nonce);
+
+				await resetQueryCounter(vendor);
+
+				const response = await request(getUrl(vendor))
+					.post(`/items/${localCollectionArtists}`)
+					.send(artist)
+					.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+				expect(response.statusCode).toBe(200);
+				expect(response.body.data).toMatchObject({ name: artist.name, company: artist.company });
+
+				const inserts = await fetchInsertQueriesForNonce(vendor, nonce, localCollectionArtists);
+				expect(inserts).toHaveLength(1);
+			});
+		});
+
+		if (pkType === 'string') {
+			return;
+		}
+
+		describe('createMany preserves explicit PKs (homogeneous-explicit batch)', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const N = 3;
+				const nonce = randomUUID();
+
+				const artists = Array.from({ length: N }, (_, i) => buildArtist(pkType, i, nonce, { explicitId: true }));
+
+				await resetQueryCounter(vendor);
+
+				const response = await request(getUrl(vendor))
+					.post(`/items/${localCollectionArtists}`)
+					.query({ fields: 'id,name,company' })
+					.send(artists)
+					.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+				// MSSQL: inserting explicit values into an IDENTITY-typed integer PK requires
+				// SET IDENTITY_INSERT ON.
+				//
+				// - Neither knex's mssql querycompiler nor Directus's createMany emits the toggle.
+				// - The INSERT fails with SQL Server error 544 ("Cannot insert explicit value for
+				//   identity column ... when IDENTITY_INSERT is set to OFF").
+				// - We pin the failure here so a future fix (e.g. an mssql override in
+				//   api/src/database/helpers/sequence/dialects/) lights up this test.
+				if (pkType === 'integer' && vendor === 'mssql') {
+					expect(response.statusCode).toBeGreaterThanOrEqual(400);
+					expect(Array.isArray(response.body.errors)).toBe(true);
+					expect(response.body.errors.length).toBeGreaterThan(0);
+					return;
+				}
+
+				expect(response.statusCode).toBe(200);
+
+				const expected = artists.map((a) => ({
+					// MSSQL's UNIQUEIDENTIFIER column round-trips UUIDs uppercase
+					// (Directus's mssql schema helper does .toUpperCase() in formatUUID);
+					// our explicit randomUUID() values are lowercase, so adjust expected
+					// to match.
+					id: pkType === 'uuid' && vendor === 'mssql' ? (a.id as string).toUpperCase() : a.id,
+					name: a.name,
+					company: a.company,
+				}));
+
+				const got = response.body.data as Array<{ id: string | number; name: string; company: string }>;
+
+				if (pkType === 'integer') {
+					// Explicit integer IDs are monotonically ascending (1B + nonceHash + index),
+					// so PK ASC (DB_DEFAULT_ORDER_READS_BY_PK) puts `got` in the same order as
+					// `expected` (input order). Comparing without any sort actively pins that
+					// the default ordering kicked in.
+					expect(got).toEqual(expected);
+				} else {
+					// UUID PKs are intentionally excluded from the default sort; response
+					// order is plan-dependent. Sort both sides by `name` to compare
+					// order-independently.
+					expect([...got].sort(sortByName)).toEqual([...expected].sort(sortByName));
+				}
+
+				const inserts = await fetchInsertQueriesForNonce(vendor, nonce, localCollectionArtists);
+				expect(inserts).toHaveLength(isReliableBatchVendor(vendor) ? 1 : N);
+			});
+		});
+
+		describe('createMany preserves explicit PKs and auto-generates the rest (mixed batch)', () => {
+			it.each(vendors)('%s', async (vendor) => {
+				const N = 5;
+				const nonce = randomUUID();
+				const explicitIndices = new Set([0, 2, 4]);
+
+				const artists: Artist[] = Array.from({ length: N }, (_, i) =>
+					buildArtist(pkType, i, nonce, { explicitId: explicitIndices.has(i) }),
+				);
+
+				// MSSQL's UNIQUEIDENTIFIER round-trips UUIDs uppercase (Directus's mssql
+				// formatUUID does .toUpperCase()); our explicit randomUUID() values are
+				// lowercase. Normalize both `expected` and `explicitIds` through this
+				// helper so the assertions below match what the server returns.
+				const explicitIdFor = (a: Artist) =>
+					pkType === 'uuid' && vendor === 'mssql' ? (a.id as string).toUpperCase() : a.id;
+
+				const explicitIds = new Set([...explicitIndices].map((i) => explicitIdFor(artists[i]!)!));
+
+				await resetQueryCounter(vendor);
+
+				const response = await request(getUrl(vendor))
+					.post(`/items/${localCollectionArtists}`)
+					.query({ fields: 'id,name,company' })
+					.send(artists)
+					.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+				// Same IDENTITY_INSERT limitation as the homogeneous-explicit block —
+				// mssql + integer PK can't accept explicit values without the toggle
+				// that Directus doesn't emit. Pin the failure.
+				if (pkType === 'integer' && vendor === 'mssql') {
+					expect(response.statusCode).toBeGreaterThanOrEqual(400);
+					expect(Array.isArray(response.body.errors)).toBe(true);
+					expect(response.body.errors.length).toBeGreaterThan(0);
+					return;
+				}
+
+				expect(response.statusCode).toBe(200);
+
+				const autoIdMatcher = pkType === 'integer' ? expect.any(Number) : expect.stringMatching(UUID_REGEX);
+
+				const expected = artists
+					.map((a, i) => ({
+						id: explicitIndices.has(i) ? explicitIdFor(a) : autoIdMatcher,
+						name: a.name,
+						company: a.company,
+					}))
+					.sort(sortByName);
+
+				// PK ASC is dialect-dependent for a mixed-integer batch (postgres/oracle
+				// put auto-row small IDs before explicit 1B+ IDs; mysql/maria/sqlite bump
+				// AUTO_INCREMENT past explicits so the auto IDs interleave). UUID mixed
+				// has random PK order. Either way response order isn't a meaningful
+				// invariant to pin here — sort by `name` and compare order-independently.
+				const got = [...(response.body.data as Array<{ id: string | number; name: string; company: string }>)].sort(
+					sortByName,
+				);
+
+				expect(got).toEqual(expected);
+
+				// Engine UNIQUE prevents row-level PK dups; these pin that createMany's
+				// PK reassignment reports them back distinctly AND keeps explicit IDs
+				// disjoint from auto-gen ones — catches off-by-one or shuffle regressions
+				// in the insertedRows → itemsToInsert mapping at items.ts:430-449.
+				const allIds = new Set(got.map((g) => g.id));
+				expect(allIds.size).toBe(N);
+				expect([...allIds].filter((id) => explicitIds.has(id))).toHaveLength(explicitIndices.size);
+
+				const inserts = await fetchInsertQueriesForNonce(vendor, nonce, localCollectionArtists);
+				expect(inserts).toHaveLength(isReliableBatchVendor(vendor) ? 1 : N);
+			});
+		});
+	});
+});
+
+// MSSQL is opt-in for the batch bucket (see DB_MSSQL_TRUST_BATCH_RETURNING in
+// api/src/database/helpers/capabilities/dialects/mssql.ts). The blocks above
+// cover the default (loop-bucket) behavior; this block flips the env var via
+// the `env-inject` test extension to verify the opt-in path emits one
+// multi-row INSERT instead of N per-row ones — on the SAME spawned Directus
+// instance, without a restart. See setDirectusEnv() for how that works.
+if ((vendors as readonly Vendor[]).includes('mssql')) {
+	describe('/items batch-insert: mssql DB_MSSQL_TRUST_BATCH_RETURNING=true (opt-in batch bucket)', () => {
+		const vendor: Vendor = 'mssql';
+		const localCollectionArtists = `${collectionArtists}_integer`;
+
+		it('createMany emits one multi-row INSERT', async () => {
+			// Scope the env flip tightly to this test: setting it in beforeAll keeps
+			// trust-batch=true on the shared mssql Directus instance for the entire
+			// describe lifecycle, which races against any other test file running
+			// concurrently against the same instance (they'd unexpectedly hit the
+			// batch path). try/finally narrows the window to this test's body only.
+			await setDirectusEnv(vendor, 'DB_MSSQL_TRUST_BATCH_RETURNING', 'true');
+
+			try {
+				const N = 5;
+				const nonce = randomUUID();
+				const artists = Array.from({ length: N }, (_, i) => buildArtist('integer', i, nonce));
+
+				await resetQueryCounter(vendor);
+
+				const response = await request(getUrl(vendor))
+					.post(`/items/${localCollectionArtists}`)
+					.send(artists)
+					.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+				expect(response.statusCode).toBe(200);
+				expect(response.body.data).toHaveLength(N);
+
+				const inserts = await fetchInsertQueriesForNonce(vendor, nonce, localCollectionArtists);
+				expect(inserts).toHaveLength(1);
+			} finally {
+				await setDirectusEnv(vendor, 'DB_MSSQL_TRUST_BATCH_RETURNING', '');
+			}
+		});
+	});
+}

--- a/tests/blackbox/utils/set-directus-env.ts
+++ b/tests/blackbox/utils/set-directus-env.ts
@@ -1,0 +1,25 @@
+import { getUrl } from '@common/config';
+import type { Vendor } from '@common/get-dbs-to-test';
+import { USER } from '@common/variables';
+import request from 'supertest';
+
+/**
+ * Mutates a single key on the running Directus's cached env object via the
+ * `env-inject` test extension. Lets a test flip a runtime-checked env var
+ * (e.g. DB_MSSQL_TRUST_BATCH_RETURNING) on the SAME spawned Directus
+ * instance, without restarting it.
+ *
+ * Only effective for env vars that are re-read on each access via the `env`
+ * reference returned by useEnv() — env vars captured into a const at module
+ * load are unaffected.
+ */
+export async function setDirectusEnv(vendor: Vendor, key: string, value: string): Promise<void> {
+	const response = await request(getUrl(vendor))
+		.post('/env-inject/set')
+		.send({ key, value })
+		.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+	if (response.statusCode !== 200) {
+		throw new Error(`env-inject set ${key} failed (${response.statusCode}): ${JSON.stringify(response.body)}`);
+	}
+}


### PR DESCRIPTION
**Upstream-draft (v12):** #46 — the MSCL v12 implementation this BSL v11.10.1 feature is re-derived from.

Fork-permanent, stacked on `fork-feat/cancel-create`. Cherry-picked from `v11.9.2-hhh-dev` (6 commits: `1d7d86c` batchInsert support → `7311d5c` store activity+revision batched). All items.ts; clean on the small v11.9.2→v11.10.1 drift. v12 ref: #46.

**Known follow-up gap (out of scope here):** two later hhh-dev commits were NOT included because they conflict on the tangled intermediate history:
- `2dd0d12` `fix createMany for MySQL/MariaDB/Sqlite` — the cross-DB returning-clause fix. **Needs the hard merge** (mirrors the v12 items reconcile). Until applied, batchInsert correctness on MySQL/MariaDB/Sqlite is unverified (pg/sqlite api unit tests still pass).
- `bc36dfd` hide console.logs + CI cockroach version — cosmetic/CI, dropped.

This PR validates the batchInsert **core** compiles+tests green; `2dd0d12` is the remaining DB-compat work.

---
_Recreated from #86 after the branch rename to the version-namespaced scheme (`v11.10.1-feat/*` on `upstream-v11.10.1`)._