### PR TITLE
v11.10.1-feat: db.select / db.selected read-path filter events (#32)

### DIFF
--- a/api/src/database/run-ast/run-ast.ts
+++ b/api/src/database/run-ast/run-ast.ts
@@ -12,6 +12,7 @@ import type { RunASTOptions } from './types.js';
 import { applyParentFilters } from './utils/apply-parent-filters.js';
 import { mergeWithParentItems } from './utils/merge-with-parent-items.js';
 import { removeTemporaryFields } from './utils/remove-temporary-fields.js';
+import emitter from '../../emitter.js';
 
 /**
  * Execute a given AST using Knex. Returns array of items based on requested AST.
@@ -71,7 +72,7 @@ export async function runAst(
 		}
 
 		// The actual knex query builder instance. This is a promise that resolves with the raw items from the db
-		const dbQuery = getDBQuery(
+		let dbQuery = getDBQuery(
 			{
 				table: collection,
 				fieldNodes,
@@ -83,7 +84,35 @@ export async function runAst(
 			{ schema, knex },
 		);
 
+		dbQuery = await emitter.emitFilter(
+			['items.db.select', `${collection}.db.select`],
+			dbQuery,
+			{
+				query,
+				collection,
+			},
+			{
+				database: knex,
+				schema,
+				accountability,
+			}
+		)
+
 		const rawItems: Item | Item[] = await dbQuery;
+
+		await emitter.emitFilter(
+			['items.db.selected', `${collection}.db.selected`],
+			rawItems,
+			{
+				query,
+				collection,
+			},
+			{
+				database: knex,
+				schema,
+				accountability,
+			}
+		)
 
 		if (!rawItems) return null;
 

--- a/api/src/database/run-ast/run-ast.ts
+++ b/api/src/database/run-ast/run-ast.ts
@@ -98,9 +98,9 @@ export async function runAst(
 			}
 		)
 
-		const rawItems: Item | Item[] = await dbQuery;
+		let rawItems: Item | Item[] = await dbQuery;
 
-		await emitter.emitFilter(
+		rawItems = await emitter.emitFilter(
 			['items.db.selected', `${collection}.db.selected`],
 			rawItems,
 			{

--- a/api/src/database/run-ast/run-ast.ts
+++ b/api/src/database/run-ast/run-ast.ts
@@ -95,8 +95,8 @@ export async function runAst(
 				database: knex,
 				schema,
 				accountability,
-			}
-		)
+			},
+		);
 
 		let rawItems: Item | Item[] = await dbQuery;
 
@@ -111,8 +111,8 @@ export async function runAst(
 				database: knex,
 				schema,
 				accountability,
-			}
-		)
+			},
+		);
 
 		if (!rawItems) return null;
 

--- a/api/src/emitter.ts
+++ b/api/src/emitter.ts
@@ -59,15 +59,21 @@ export class Emitter {
 		return updatedPayload;
 	}
 
-	public emitAction(event: string | string[], meta: Record<string, any>, context: EventContext | null = null): void {
+	public async emitAction(
+		event: string | string[],
+		meta: Record<string, any>,
+		context: EventContext | null = null,
+	): Promise<void> {
 		const logger = useLogger();
 		const events = Array.isArray(event) ? event : [event];
 
 		for (const event of events) {
-			this.actionEmitter.emitAsync(event, { event, ...meta }, context ?? this.getDefaultContext()).catch((err) => {
-				logger.warn(`An error was thrown while executing action "${event}"`);
-				logger.warn(err);
-			});
+			await this.actionEmitter
+				.emitAsync(event, { event, ...meta }, context ?? this.getDefaultContext())
+				.catch((err) => {
+					logger.warn(`An error was thrown while executing action "${event}"`);
+					logger.warn(err);
+				});
 		}
 	}
 

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -75,8 +75,14 @@ describe('Integration Tests', () => {
 		});
 
 		describe('updateMany', () => {
-			it('should validate user count if requested', async () => {
+			it('should not validate user count when payload is empty', async () => {
 				await service.updateMany([1], {}, { userIntegrityCheckFlags: UserIntegrityCheckFlag.All });
+
+				expect(validateUserCountIntegrity).not.toHaveBeenCalled();
+			});
+
+			it('should validate user count if requested with non-empty payload', async () => {
+				await service.updateMany([1], { name: 'test' }, { userIntegrityCheckFlags: UserIntegrityCheckFlag.All });
 
 				expect(validateUserCountIntegrity).toHaveBeenCalled();
 			});

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -816,7 +816,6 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			const errorReasons = preparedForPostInsertProcessResponses.filter(isRejected)?.map((i) => i.reason);
 
 			if (errorReasons.length) {
-				console.log('errorReasons', errorReasons);
 				throw errorReasons[0];
 				// TODO how to pass all the errors ?
 			}

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -1321,7 +1321,11 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 			if (Object.keys(payloadWithTypeCasting).length > 0) {
 				try {
-					await trx(this.collection).update(payloadWithTypeCasting).whereIn(primaryKeyField, keys);
+					if (keys.length > 1) {
+						await trx(this.collection).update(payloadWithTypeCasting).whereIn(primaryKeyField, keys);
+					} else {
+						await trx(this.collection).update(payloadWithTypeCasting).where(primaryKeyField, keys[0]);
+					}
 				} catch (err: any) {
 					throw await translateDatabaseError(err, data);
 				}

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -123,6 +123,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	 * Create a single new item.
 	 */
 	async createOne(data: Partial<Item>, opts: MutationOptions = {}): Promise<PrimaryKey> {
+		// TODO use createMany here
+
 		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
 
 		if (!opts.bypassLimits) {
@@ -418,66 +420,70 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	 *
 	 * Uses `this.createOne` under the hood.
 	 */
-	async createMany(data: Partial<Item>[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
-		if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
+	async createMany(
+		data: Partial<Item>[],
+		opts: MutationOptions = {}
+	): Promise<PrimaryKey[]> {
+		return await this.createManyAtOnce(data, opts);
+		// if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
 
-		const { primaryKeys, nestedActionEvents } = await transaction(this.knex, async (knex) => {
-			const service = this.fork({ knex });
+		// const { primaryKeys, nestedActionEvents } = await transaction(this.knex, async (knex) => {
+		// 	const service = this.fork({ knex });
 
-			let userIntegrityCheckFlags = opts.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None;
+		// 	let userIntegrityCheckFlags = opts.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None;
 
-			const primaryKeys: PrimaryKey[] = [];
-			const nestedActionEvents: ActionEventParams[] = [];
+		// 	const primaryKeys: PrimaryKey[] = [];
+		// 	const nestedActionEvents: ActionEventParams[] = [];
 
-			const pkField = this.schema.collections[this.collection]!.primary;
+		// 	const pkField = this.schema.collections[this.collection]!.primary;
 
-			for (const [index, payload] of data.entries()) {
-				let bypassAutoIncrementSequenceReset = true;
+		// 	for (const [index, payload] of data.entries()) {
+		// 		let bypassAutoIncrementSequenceReset = true;
 
-				// the auto_increment sequence needs to be reset if the current item contains a manual PK and
-				// if it's the last item of the batch or if the next item doesn't include a PK and hence one needs to be generated
-				if (payload[pkField] && (index === data.length - 1 || !data[index + 1]?.[pkField])) {
-					bypassAutoIncrementSequenceReset = false;
-				}
+		// 		// the auto_increment sequence needs to be reset if the current item contains a manual PK and
+		// 		// if it's the last item of the batch or if the next item doesn't include a PK and hence one needs to be generated
+		// 		if (payload[pkField] && (index === data.length - 1 || !data[index + 1]?.[pkField])) {
+		// 			bypassAutoIncrementSequenceReset = false;
+		// 		}
 
-				const primaryKey = await service.createOne(payload, {
-					...(opts || {}),
-					autoPurgeCache: false,
-					onRequireUserIntegrityCheck: (flags) => (userIntegrityCheckFlags |= flags),
-					bypassEmitAction: (params) => nestedActionEvents.push(params),
-					mutationTracker: opts.mutationTracker,
-					bypassAutoIncrementSequenceReset,
-				});
+		// 		const primaryKey = await service.createOne(payload, {
+		// 			...(opts || {}),
+		// 			autoPurgeCache: false,
+		// 			onRequireUserIntegrityCheck: (flags) => (userIntegrityCheckFlags |= flags),
+		// 			bypassEmitAction: (params) => nestedActionEvents.push(params),
+		// 			mutationTracker: opts.mutationTracker,
+		// 			bypassAutoIncrementSequenceReset,
+		// 		});
 
-				primaryKeys.push(primaryKey);
-			}
+		// 		primaryKeys.push(primaryKey);
+		// 	}
 
-			if (userIntegrityCheckFlags) {
-				if (opts.onRequireUserIntegrityCheck) {
-					opts.onRequireUserIntegrityCheck(userIntegrityCheckFlags);
-				} else {
-					await validateUserCountIntegrity({ flags: userIntegrityCheckFlags, knex });
-				}
-			}
+		// 	if (userIntegrityCheckFlags) {
+		// 		if (opts.onRequireUserIntegrityCheck) {
+		// 			opts.onRequireUserIntegrityCheck(userIntegrityCheckFlags);
+		// 		} else {
+		// 			await validateUserCountIntegrity({ flags: userIntegrityCheckFlags, knex });
+		// 		}
+		// 	}
 
-			return { primaryKeys, nestedActionEvents };
-		});
+		// 	return { primaryKeys, nestedActionEvents };
+		// });
 
-		if (opts.emitEvents !== false) {
-			for (const nestedActionEvent of nestedActionEvents) {
-				if (opts.bypassEmitAction) {
-					await opts.bypassEmitAction(nestedActionEvent);
-				} else {
-					await emitter.emitAction(nestedActionEvent.event, nestedActionEvent.meta, nestedActionEvent.context);
-				}
-			}
-		}
+		// if (opts.emitEvents !== false) {
+		// 	for (const nestedActionEvent of nestedActionEvents) {
+		// 		if (opts.bypassEmitAction) {
+		// 			await opts.bypassEmitAction(nestedActionEvent);
+		// 		} else {
+		// 			await emitter.emitAction(nestedActionEvent.event, nestedActionEvent.meta, nestedActionEvent.context);
+		// 		}
+		// 	}
+		// }
 
-		if (shouldClearCache(this.cache, opts, this.collection)) {
-			await this.cache.clear();
-		}
+		// if (shouldClearCache(this.cache, opts, this.collection)) {
+		// 	await this.cache.clear();
+		// }
 
-		return primaryKeys;
+		// return primaryKeys;
 	}
 
 
@@ -491,7 +497,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		}
 
 		if (! opts.bypassLimits) {
-			opts.mutationTracker.trackMutations(1)
+			opts.mutationTracker.trackMutations(data.length)
 		}
 
 		const { ActivityService } = await import('./activity.js');
@@ -822,12 +828,12 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		})
 
 
-		itemsValues.forEach((itemValues) => {
+		for (const itemValues of itemsValues) {
 			if (opts.emitEvents === false
 				|| typeof itemValues === 'string'
 				|| typeof itemValues === 'number'
 			) {
-				return
+				continue
 			}
 
 			const {
@@ -856,10 +862,10 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			}
 
 			if (opts.bypassEmitAction) {
-				opts.bypassEmitAction(actionEvent)
+				await opts.bypassEmitAction(actionEvent)
 			}
 			else {
-				emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context)
+				await emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context)
 			}
 
 			const nestedActionEvents = [
@@ -870,17 +876,17 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 			for (const nestedActionEvent of nestedActionEvents) {
 				if (opts.bypassEmitAction) {
-					opts.bypassEmitAction(nestedActionEvent)
+					await opts.bypassEmitAction(nestedActionEvent)
 				}
 				else {
-					emitter.emitAction(
+					await emitter.emitAction(
 						nestedActionEvent.event,
 						nestedActionEvent.meta,
 						nestedActionEvent.context
 					)
 				}
 			}
-		})
+		}
 
 		if (shouldClearCache(this.cache, opts, this.collection)) {
 			await this.cache.clear()

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -384,16 +384,16 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			};
 
 			if (opts.bypassEmitAction) {
-				opts.bypassEmitAction(actionEvent);
+				await opts.bypassEmitAction(actionEvent);
 			} else {
-				emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context);
+				await emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context);
 			}
 
 			for (const nestedActionEvent of nestedActionEvents) {
 				if (opts.bypassEmitAction) {
-					opts.bypassEmitAction(nestedActionEvent);
+					await opts.bypassEmitAction(nestedActionEvent);
 				} else {
-					emitter.emitAction(nestedActionEvent.event, nestedActionEvent.meta, nestedActionEvent.context);
+					await emitter.emitAction(nestedActionEvent.event, nestedActionEvent.meta, nestedActionEvent.context);
 				}
 			}
 		}
@@ -458,9 +458,9 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		if (opts.emitEvents !== false) {
 			for (const nestedActionEvent of nestedActionEvents) {
 				if (opts.bypassEmitAction) {
-					opts.bypassEmitAction(nestedActionEvent);
+					await opts.bypassEmitAction(nestedActionEvent);
 				} else {
-					emitter.emitAction(nestedActionEvent.event, nestedActionEvent.meta, nestedActionEvent.context);
+					await emitter.emitAction(nestedActionEvent.event, nestedActionEvent.meta, nestedActionEvent.context);
 				}
 			}
 		}
@@ -540,7 +540,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				: records;
 
 		if (opts?.emitEvents !== false) {
-			emitter.emitAction(
+			await emitter.emitAction(
 				this.eventScope === 'items' ? ['items.read', `${this.collection}.items.read`] : `${this.eventScope}.read`,
 				{
 					payload: filteredRecords,
@@ -915,16 +915,16 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			};
 
 			if (opts.bypassEmitAction) {
-				opts.bypassEmitAction(actionEvent);
+				await opts.bypassEmitAction(actionEvent);
 			} else {
-				emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context);
+				await emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context);
 			}
 
 			for (const nestedActionEvent of nestedActionEvents) {
 				if (opts.bypassEmitAction) {
-					opts.bypassEmitAction(nestedActionEvent);
+					await opts.bypassEmitAction(nestedActionEvent);
 				} else {
-					emitter.emitAction(nestedActionEvent.event, nestedActionEvent.meta, nestedActionEvent.context);
+					await emitter.emitAction(nestedActionEvent.event, nestedActionEvent.meta, nestedActionEvent.context);
 				}
 			}
 		}
@@ -1120,9 +1120,9 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			};
 
 			if (opts.bypassEmitAction) {
-				opts.bypassEmitAction(actionEvent);
+				await opts.bypassEmitAction(actionEvent);
 			} else {
-				emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context);
+				await emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context);
 			}
 		}
 

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -420,10 +420,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 	 *
 	 * Uses `this.createOne` under the hood.
 	 */
-	async createMany(
-		data: Partial<Item>[],
-		opts: MutationOptions = {}
-	): Promise<PrimaryKey[]> {
+	async createMany(data: Partial<Item>[], opts: MutationOptions = {}): Promise<PrimaryKey[]> {
 		return await this.createManyAtOnce(data, opts);
 		// if (!opts.mutationTracker) opts.mutationTracker = this.createMutationTracker();
 
@@ -486,65 +483,64 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		// return primaryKeys;
 	}
 
-
 	async createManyAtOnce<T extends AnyItem>(
 		this: ItemsService,
 		data: Partial<T>[],
-		opts: MutationOptions = {}
+		opts: MutationOptions = {},
 	): Promise<PrimaryKey[]> {
 		if (data.length === 0) {
-			return []
+			return [];
 		}
 
-		if (! opts.mutationTracker) {
-			opts.mutationTracker = this.createMutationTracker()
+		if (!opts.mutationTracker) {
+			opts.mutationTracker = this.createMutationTracker();
 		}
 
-		if (! opts.bypassLimits) {
-			opts.mutationTracker.trackMutations(data.length)
+		if (!opts.bypassLimits) {
+			opts.mutationTracker.trackMutations(data.length);
 		}
 
-		const primaryKeyField = this.schema.collections[this.collection]!.primary
-		const fields = Object.keys(this.schema.collections[this.collection]!.fields)
+		const primaryKeyField = this.schema.collections[this.collection]!.primary;
+		const fields = Object.keys(this.schema.collections[this.collection]!.fields);
 
 		const aliases = Object.values(this.schema.collections[this.collection]!.fields)
-		.filter((field) => field.alias === true)
-		.map((field) => field.field)
+			.filter((field) => field.alias === true)
+			.map((field) => field.field);
 
 		// TODO move it to a lib
 		const isPrimaryKey = (it: unknown): it is PrimaryKey => {
-			return typeof it === 'number' || typeof it === 'string'
-		}
+			return typeof it === 'number' || typeof it === 'string';
+		};
 
 		const isNotPrimaryKey = <T>(it: T): it is T extends PrimaryKey ? never : T => {
-			return ! isPrimaryKey(it)
-		}
-
+			return !isPrimaryKey(it);
+		};
 
 		// By wrapping the logic in a transaction, we make sure we automatically roll back all the
 		// changes in the DB if any of the parts contained within throws an error. This also means
 		// that any errors thrown in any nested relational changes will bubble up and cancel the whole
 		// update tree
-		type ItemValues = PrimaryKey
-		| {
-			primaryKey: PrimaryKey,
+		type ItemValues =
+			| PrimaryKey
+			| {
+					primaryKey: PrimaryKey;
 
-			actionHookPayload: any, // TODO better typing from processPayload()
-			payloadAfterHooks: Partial<typeof data[number]>,
-			payloadWithPresets: Partial<typeof data[number]>,
-			payloadWithoutAliases: Pick<Partial<AnyItem>, string>,
+					actionHookPayload: any; // TODO better typing from processPayload()
+					payloadAfterHooks: Partial<(typeof data)[number]>;
+					payloadWithPresets: Partial<(typeof data)[number]>;
+					payloadWithoutAliases: Pick<Partial<AnyItem>, string>;
 
-			revisionsM2O: Awaited<ReturnType<PayloadService[`processM2O`]>>[`revisions`],
-			revisionsA2O: Awaited<ReturnType<PayloadService[`processA2O`]>>[`revisions`],
-			revisionsO2M?: Awaited<ReturnType<PayloadService[`processO2M`]>>[`revisions`],
+					revisionsM2O: Awaited<ReturnType<PayloadService[`processM2O`]>>[`revisions`];
+					revisionsA2O: Awaited<ReturnType<PayloadService[`processA2O`]>>[`revisions`];
+					revisionsO2M?: Awaited<ReturnType<PayloadService[`processO2M`]>>[`revisions`];
 
-			nestedActionEventsM2O: Awaited<ReturnType<PayloadService[`processM2O`]>>[`nestedActionEvents`],
-			nestedActionEventsA2O: Awaited<ReturnType<PayloadService[`processA2O`]>>[`nestedActionEvents`],
-			nestedActionEventsO2M?: Awaited<ReturnType<PayloadService[`processO2M`]>>[`nestedActionEvents`],
+					nestedActionEventsM2O: Awaited<ReturnType<PayloadService[`processM2O`]>>[`nestedActionEvents`];
+					nestedActionEventsA2O: Awaited<ReturnType<PayloadService[`processA2O`]>>[`nestedActionEvents`];
+					nestedActionEventsO2M?: Awaited<ReturnType<PayloadService[`processO2M`]>>[`nestedActionEvents`];
 
-			userIntegrityCheckFlagsM2O: Awaited<ReturnType<PayloadService[`processM2O`]>>[`userIntegrityCheckFlags`],
-			userIntegrityCheckFlagsA2O: Awaited<ReturnType<PayloadService[`processM2O`]>>[`userIntegrityCheckFlags`],
-		}
+					userIntegrityCheckFlagsM2O: Awaited<ReturnType<PayloadService[`processM2O`]>>[`userIntegrityCheckFlags`];
+					userIntegrityCheckFlagsA2O: Awaited<ReturnType<PayloadService[`processM2O`]>>[`userIntegrityCheckFlags`];
+			  };
 
 		// If a PK of type number was provided, although the PK is set the auto_increment,
 		// depending on the database, the sequence might need to be reset to protect future PK collisions.
@@ -556,44 +552,46 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				accountability: this.accountability,
 				knex: trx,
 				schema: this.schema,
-			})
+			});
 
-			const preparedItems: ItemValues[] = []
+			const preparedItems: ItemValues[] = [];
 
 			for (const payloadToClone of data) {
-				const payload = cloneDeep(payloadToClone)
+				const payload = cloneDeep(payloadToClone);
 
 				// Run all hooks that are attached to this event so the end user has the chance to augment the
 				// item that is about to be saved
 				const payloadAfterHooks =
 					opts.emitEvents !== false
 						? await emitter.emitFilter(
-							this.eventScope === `items`
-								? [`items.create`, `${this.collection}.items.create`]
-								: `${this.eventScope}.create`,
-							payload,
-							{
-								collection: this.collection,
-							},
-							{
-								database: trx,
-								schema: this.schema,
-								accountability: this.accountability,
-							}
-						)
-						: payload
+								this.eventScope === `items`
+									? [`items.create`, `${this.collection}.items.create`]
+									: `${this.eventScope}.create`,
+								payload,
+								{
+									collection: this.collection,
+								},
+								{
+									database: trx,
+									schema: this.schema,
+									accountability: this.accountability,
+								},
+							)
+						: payload;
 
-				if ( payloadAfterHooks === null) { // skip creation
-					continue
+				if (payloadAfterHooks === null) {
+					// skip creation
+					continue;
 				}
 
-				if ( false // eslint-disable-line
-					|| typeof payloadAfterHooks === 'string' // replace new creation by an existing item having a uuid as its primary key
-					|| typeof payloadAfterHooks === 'number' // replace new creation by an existing item having a number as its primary key
+				if (
+					false || // eslint-disable-line
+					typeof payloadAfterHooks === 'string' || // replace new creation by an existing item having a uuid as its primary key
+					typeof payloadAfterHooks === 'number' // replace new creation by an existing item having a number as its primary key
 				) {
-					preparedItems.push(payloadAfterHooks)
+					preparedItems.push(payloadAfterHooks);
 
-					continue
+					continue;
 				}
 
 				const payloadWithPresets = this.accountability
@@ -612,9 +610,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 						)
 					: payloadAfterHooks;
 
-
 				if (opts.preMutationError) {
-					throw opts.preMutationError
+					throw opts.preMutationError;
 				}
 
 				// Ensure the action hook payload has the post filter hook + preset changes
@@ -642,16 +639,15 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					userIntegrityCheckFlags: userIntegrityCheckFlagsA2O,
 				} = await payloadService.processA2O(payloadWithM2O, opts);
 
-				const payloadWithoutAliases = pick(payloadWithA2O, without(fields, ...aliases))
-				const payloadWithTypeCasting = await payloadService.processValues(`create`, payloadWithoutAliases)
+				const payloadWithoutAliases = pick(payloadWithA2O, without(fields, ...aliases));
+				const payloadWithTypeCasting = await payloadService.processValues(`create`, payloadWithoutAliases);
 
 				// In case of manual string / UUID primary keys, the PK already exists in the object we're saving.
-				const primaryKey = payloadWithTypeCasting[primaryKeyField]
+				const primaryKey = payloadWithTypeCasting[primaryKeyField];
 
 				if (primaryKey) {
 					validateKeys(this.schema, this.collection, primaryKeyField, primaryKey);
 				}
-
 
 				const pkField = this.schema.collections[this.collection]!.fields[primaryKeyField];
 
@@ -682,43 +678,41 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 					userIntegrityCheckFlagsM2O,
 					userIntegrityCheckFlagsA2O,
-				})
+				});
 			}
 
-			const itemsToInsert = preparedItems.filter(isNotPrimaryKey)
+			const itemsToInsert = preparedItems.filter(isNotPrimaryKey);
 
 			try {
 				const results = await trx
-				.batchInsert<Exclude<ItemValues, number | string>['payloadWithoutAliases']>(
-					this.collection,
-					itemsToInsert.map((v) => {
-						return v.payloadWithoutAliases
-					})
-				)
-				.returning(primaryKeyField)
+					.batchInsert<Exclude<ItemValues, number | string>['payloadWithoutAliases']>(
+						this.collection,
+						itemsToInsert.map((v) => {
+							return v.payloadWithoutAliases;
+						}),
+					)
+					.returning(primaryKeyField);
 
 				results.forEach((result, index) => {
 					// TODO is insert order respected durting batchInsert ?
-					const preparedValues = itemsToInsert[index]
+					const preparedValues = itemsToInsert[index];
 
-					if (! preparedValues) {
-						throw new Error(`No batchInsert itemInput found for index ${index}`) // Should never happend
+					if (!preparedValues) {
+						throw new Error(`No batchInsert itemInput found for index ${index}`); // Should never happend
 					}
 
-					const returnedKey = typeof result === `object` ? result[primaryKeyField] : result
+					const returnedKey = typeof result === `object` ? result[primaryKeyField] : result;
 
 					if (this.schema.collections[this.collection]!.fields[primaryKeyField]!.type === `uuid`) {
 						preparedValues.primaryKey = getHelpers(trx).schema.formatUUID(
-							(preparedValues.primaryKey ?? returnedKey) as string
-						)
+							(preparedValues.primaryKey ?? returnedKey) as string,
+						);
+					} else {
+						preparedValues.primaryKey = preparedValues.primaryKey ?? returnedKey;
 					}
-					else {
-						preparedValues.primaryKey = preparedValues.primaryKey ?? returnedKey
-					}
-				})
-			}
-			catch (err: any) {
-				throw await translateDatabaseError(err, data)
+				});
+			} catch (err: any) {
+				throw await translateDatabaseError(err, data);
 			}
 
 			// TODO
@@ -735,208 +729,194 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			//   payload[primaryKeyField] = primaryKey
 			// }
 
-
 			// TODO should Promise.allSettled be replaced by a sequential await?
-			const preparedForPostInsertProcessResponses = await Promise.allSettled( itemsToInsert.map(async (
-				preparedItem
-			) => {
-				const {
-					primaryKey,
-					payloadAfterHooks,
-					payloadWithPresets,
-					revisionsM2O,
-					revisionsA2O,
-					userIntegrityCheckFlagsM2O,
-					userIntegrityCheckFlagsA2O,
-				} = preparedItem
+			const preparedForPostInsertProcessResponses = await Promise.allSettled(
+				itemsToInsert.map(async (preparedItem) => {
+					const {
+						primaryKey,
+						payloadAfterHooks,
+						payloadWithPresets,
+						revisionsM2O,
+						revisionsA2O,
+						userIntegrityCheckFlagsM2O,
+						userIntegrityCheckFlagsA2O,
+					} = preparedItem;
 
-				const {
-					revisions: revisionsO2M,
-					nestedActionEvents: nestedActionEventsO2M,
-					userIntegrityCheckFlags: userIntegrityCheckFlagsO2M,
-				} = await payloadService.processO2M(
-					payloadWithPresets,
-					primaryKey,
-					opts
-				)
+					const {
+						revisions: revisionsO2M,
+						nestedActionEvents: nestedActionEventsO2M,
+						userIntegrityCheckFlags: userIntegrityCheckFlagsO2M,
+					} = await payloadService.processO2M(payloadWithPresets, primaryKey, opts);
 
-				const userIntegrityCheckFlags =
-					(opts.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None) |
-					userIntegrityCheckFlagsM2O |
-					userIntegrityCheckFlagsA2O |
-					userIntegrityCheckFlagsO2M;
+					const userIntegrityCheckFlags =
+						(opts.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None) |
+						userIntegrityCheckFlagsM2O |
+						userIntegrityCheckFlagsA2O |
+						userIntegrityCheckFlagsO2M;
 
-				if (userIntegrityCheckFlags) {
-					if (opts.onRequireUserIntegrityCheck) {
-						opts.onRequireUserIntegrityCheck(userIntegrityCheckFlags);
-					} else {
-						await validateUserCountIntegrity({ flags: userIntegrityCheckFlags, knex: trx });
-					}
-				}
-
-
-				const activityInput = this.accountability
-					&& this.schema.collections[this.collection]!.accountability !== null
-				?	{
-					action: Action.CREATE,
-					user: this.accountability!.user,
-					collection: this.collection,
-					ip: this.accountability!.ip,
-					user_agent: this.accountability!.userAgent,
-					origin: this.accountability!.origin,
-					item: primaryKey,
-				}
-				: undefined
-
-
-				const revisionInput = activityInput !== undefined
-					&& this.schema.collections[this.collection]!.accountability === `all`
-				? await (async () => {
-						const revisionDelta = await payloadService.prepareDelta(payloadAfterHooks)
-						return {
-							// activity, // will be added once activity rows are inserted
-							collection: this.collection,
-							item: primaryKey,
-							data: revisionDelta,
-							delta: revisionDelta,
+					if (userIntegrityCheckFlags) {
+						if (opts.onRequireUserIntegrityCheck) {
+							opts.onRequireUserIntegrityCheck(userIntegrityCheckFlags);
+						} else {
+							await validateUserCountIntegrity({ flags: userIntegrityCheckFlags, knex: trx });
 						}
-				})()
-				: undefined
+					}
 
-				let activity: PrimaryKey | undefined
-				let revision: PrimaryKey | undefined
+					const activityInput =
+						this.accountability && this.schema.collections[this.collection]!.accountability !== null
+							? {
+									action: Action.CREATE,
+									user: this.accountability!.user,
+									collection: this.collection,
+									ip: this.accountability!.ip,
+									user_agent: this.accountability!.userAgent,
+									origin: this.accountability!.origin,
+									item: primaryKey,
+								}
+							: undefined;
 
-				return {
-					...preparedItem,
-					nestedActionEventsO2M,
-					activityInput,
-					activity,
-					revisionInput,
-					revision,
-					childrenRevisions: [...revisionsM2O, ...revisionsA2O, ...revisionsO2M],
-				}
-			}))
+					const revisionInput =
+						activityInput !== undefined && this.schema.collections[this.collection]!.accountability === `all`
+							? await (async () => {
+									const revisionDelta = await payloadService.prepareDelta(payloadAfterHooks);
+									return {
+										// activity, // will be added once activity rows are inserted
+										collection: this.collection,
+										item: primaryKey,
+										data: revisionDelta,
+										delta: revisionDelta,
+									};
+								})()
+							: undefined;
 
+					let activity: PrimaryKey | undefined;
+					let revision: PrimaryKey | undefined;
+
+					return {
+						...preparedItem,
+						nestedActionEventsO2M,
+						activityInput,
+						activity,
+						revisionInput,
+						revision,
+						childrenRevisions: [...revisionsM2O, ...revisionsA2O, ...revisionsO2M],
+					};
+				}),
+			);
 
 			// From https://stackoverflow.com/a/69451755
 			const isRejected = (input: PromiseSettledResult<unknown>): input is PromiseRejectedResult => {
-				return input.status === 'rejected'
-			}
+				return input.status === 'rejected';
+			};
 
 			const isFulfilled = <T>(input: PromiseSettledResult<T>): input is PromiseFulfilledResult<T> => {
-				return input.status === 'fulfilled'
-			}
+				return input.status === 'fulfilled';
+			};
 
-			const errorReasons = preparedForPostInsertProcessResponses.filter(isRejected)?.map(i => i.reason)
+			const errorReasons = preparedForPostInsertProcessResponses.filter(isRejected)?.map((i) => i.reason);
 
 			if (errorReasons.length) {
-				console.log('errorReasons', errorReasons)
-				throw errorReasons[0]
+				console.log('errorReasons', errorReasons);
+				throw errorReasons[0];
 				// TODO how to pass all the errors ?
 			}
 
-			const preparedForPostInsert = preparedForPostInsertProcessResponses.filter(isFulfilled)?.map(item => item.value)
+			const preparedForPostInsert = preparedForPostInsertProcessResponses
+				.filter(isFulfilled)
+				?.map((item) => item.value);
 
-
-			const itemsWithActivityInput = preparedForPostInsert
-			.filter(isNotPrimaryKey)
-			.filter((item) => {
-				return item.activityInput !== undefined
-			})
+			const itemsWithActivityInput = preparedForPostInsert.filter(isNotPrimaryKey).filter((item) => {
+				return item.activityInput !== undefined;
+			});
 
 			const { ActivityService } = await import('./activity.js');
 
-			const itemsWithActivity = (await new ActivityService({
-				knex: trx,
-				schema: this.schema,
-			})
-			.createMany(itemsWithActivityInput.map((item) => {
-				return item.activityInput!
-			})))
-			.map((activityPk, index) => {
-				if (! (index in itemsWithActivityInput) || itemsWithActivityInput[index] === undefined) {
-					throw new Error(`Unable to find '${index}' in activitiesItems`)
+			const itemsWithActivity = (
+				await new ActivityService({
+					knex: trx,
+					schema: this.schema,
+				}).createMany(
+					itemsWithActivityInput.map((item) => {
+						return item.activityInput!;
+					}),
+				)
+			).map((activityPk, index) => {
+				if (!(index in itemsWithActivityInput) || itemsWithActivityInput[index] === undefined) {
+					throw new Error(`Unable to find '${index}' in activitiesItems`);
 				}
 
 				return {
 					...itemsWithActivityInput[index],
 					activity: activityPk,
-				}
-			})
+				};
+			});
 
-
-			const itemsWithRevisionInput = itemsWithActivity
-			.filter((item) => {
-				return item.revisionInput !== undefined
-			})
+			const itemsWithRevisionInput = itemsWithActivity.filter((item) => {
+				return item.revisionInput !== undefined;
+			});
 
 			const { RevisionsService } = await import('./revisions.js');
 
 			const revisionsService = new RevisionsService({
 				knex: trx,
 				schema: this.schema,
-			})
+			});
 
-			const itemsWithActivityAndRevision =(await revisionsService.createMany(itemsWithRevisionInput.map((
-				item
-			) => {
-				return {
-					...item.revisionInput,
-					activity: item.activity,
-				}
-			})))
-			.map((revisionPk, index) => {
-				if (! (index in itemsWithRevisionInput) || itemsWithRevisionInput[index] === undefined) {
-					throw new Error(`Unable to find '${index}' in itemsWithRevisionInput`)
+			const itemsWithActivityAndRevision = (
+				await revisionsService.createMany(
+					itemsWithRevisionInput.map((item) => {
+						return {
+							...item.revisionInput,
+							activity: item.activity,
+						};
+					}),
+				)
+			).map((revisionPk, index) => {
+				if (!(index in itemsWithRevisionInput) || itemsWithRevisionInput[index] === undefined) {
+					throw new Error(`Unable to find '${index}' in itemsWithRevisionInput`);
 				}
 
 				return {
 					...itemsWithRevisionInput[index],
 					revision: revisionPk,
-				}
-			})
-
+				};
+			});
 
 			// Make sure to set the parent field of the child-revision rows
-			const updateRevisionsChildrenResponses = await Promise.allSettled( itemsWithActivityAndRevision.map(async (item) => {
-				if (item.childrenRevisions.length > 0) {
-					await revisionsService.updateMany(item.childrenRevisions, { parent: item.revision })
-				}
+			const updateRevisionsChildrenResponses = await Promise.allSettled(
+				itemsWithActivityAndRevision.map(async (item) => {
+					if (item.childrenRevisions.length > 0) {
+						await revisionsService.updateMany(item.childrenRevisions, { parent: item.revision });
+					}
 
-				if (opts.onRevisionCreate) {
-					opts.onRevisionCreate(item.revision)
-				}
-			}))
+					if (opts.onRevisionCreate) {
+						opts.onRevisionCreate(item.revision);
+					}
+				}),
+			);
 
-			const revisionErrorReasons = updateRevisionsChildrenResponses.filter(isRejected)?.map(i => i.reason)
+			const revisionErrorReasons = updateRevisionsChildrenResponses.filter(isRejected)?.map((i) => i.reason);
 
 			if (revisionErrorReasons.length) {
 				// console.log('revisionErrorReasons', revisionErrorReasons)
-				throw revisionErrorReasons[0]
+				throw revisionErrorReasons[0];
 				// TODO how to pass all the errors ?
 			}
-
 
 			if (autoIncrementSequenceNeedsToBeReset) {
 				await getHelpers(trx).sequence.resetAutoIncrementSequence(this.collection, primaryKeyField);
 			}
 
-			return preparedForPostInsert
-		})
-
+			return preparedForPostInsert;
+		});
 
 		for (const itemValues of itemsValues.filter(isNotPrimaryKey)) {
 			if (opts.emitEvents === false) {
-				continue
+				continue;
 			}
 
-			const {
-				primaryKey,
-				actionHookPayload,
-				nestedActionEventsM2O,
-				nestedActionEventsA2O,
-				nestedActionEventsO2M,
-			} = itemValues
+			const { primaryKey, actionHookPayload, nestedActionEventsM2O, nestedActionEventsA2O, nestedActionEventsO2M } =
+				itemValues;
 
 			const actionEvent = {
 				event:
@@ -953,46 +933,36 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					schema: this.schema,
 					accountability: this.accountability,
 				},
-			}
+			};
 
 			if (opts.bypassEmitAction) {
-				await opts.bypassEmitAction(actionEvent)
-			}
-			else {
-				await emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context)
+				await opts.bypassEmitAction(actionEvent);
+			} else {
+				await emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context);
 			}
 
-			const nestedActionEvents = [
-				...nestedActionEventsO2M || [],
-				...nestedActionEventsA2O,
-				...nestedActionEventsM2O,
-			]
+			const nestedActionEvents = [...(nestedActionEventsO2M || []), ...nestedActionEventsA2O, ...nestedActionEventsM2O];
 
 			for (const nestedActionEvent of nestedActionEvents) {
 				if (opts.bypassEmitAction) {
-					await opts.bypassEmitAction(nestedActionEvent)
-				}
-				else {
-					await emitter.emitAction(
-						nestedActionEvent.event,
-						nestedActionEvent.meta,
-						nestedActionEvent.context
-					)
+					await opts.bypassEmitAction(nestedActionEvent);
+				} else {
+					await emitter.emitAction(nestedActionEvent.event, nestedActionEvent.meta, nestedActionEvent.context);
 				}
 			}
 		}
 
 		if (shouldClearCache(this.cache, opts, this.collection)) {
-			await this.cache.clear()
+			await this.cache.clear();
 		}
 
 		return itemsValues.map((itemValues) => {
 			if (isPrimaryKey(itemValues)) {
-				return itemValues
+				return itemValues;
 			}
 
-			return itemValues.primaryKey
-		})
+			return itemValues.primaryKey;
+		});
 	}
 
 	/**
@@ -1244,15 +1214,13 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				: payload;
 
 		// TODO add null to payloadAfterHooks possible types
-		const payloadKeys = Object.keys(payloadAfterHooks ?? {})
+		const payloadKeys = Object.keys(payloadAfterHooks ?? {});
 
-		if ( payloadKeys.length === 0 // payloadAfterHooks == {} || null
-			|| (
-				payloadKeys.length === 1
-				&& payloadKeys[0] === primaryKeyField
-			) // payloadAfterHooks == {id: xxx}
+		if (
+			payloadKeys.length === 0 || // payloadAfterHooks == {} || null
+			(payloadKeys.length === 1 && payloadKeys[0] === primaryKeyField) // payloadAfterHooks == {id: xxx}
 		) {
-			return []
+			return [];
 		}
 
 		// Sort keys to ensure that the order is maintained

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -492,6 +492,10 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		data: Partial<T>[],
 		opts: MutationOptions = {}
 	): Promise<PrimaryKey[]> {
+		if (data.length === 0) {
+			return []
+		}
+
 		if (! opts.mutationTracker) {
 			opts.mutationTracker = this.createMutationTracker()
 		}
@@ -500,15 +504,22 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			opts.mutationTracker.trackMutations(data.length)
 		}
 
-		const { ActivityService } = await import('./activity.js');
-		const { RevisionsService } = await import('./revisions.js');
-
 		const primaryKeyField = this.schema.collections[this.collection]!.primary
 		const fields = Object.keys(this.schema.collections[this.collection]!.fields)
 
 		const aliases = Object.values(this.schema.collections[this.collection]!.fields)
 		.filter((field) => field.alias === true)
 		.map((field) => field.field)
+
+		// TODO move it to a lib
+		const isPrimaryKey = (it: unknown): it is PrimaryKey => {
+			return typeof it === 'number' || typeof it === 'string'
+		}
+
+		const isNotPrimaryKey = <T>(it: T): it is T extends PrimaryKey ? never : T => {
+			return ! isPrimaryKey(it)
+		}
+
 
 		// By wrapping the logic in a transaction, we make sure we automatically roll back all the
 		// changes in the DB if any of the parts contained within throws an error. This also means
@@ -547,7 +558,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				schema: this.schema,
 			})
 
-			const itemsAnalyzingValues: ItemValues[] = []
+			const preparedItems: ItemValues[] = []
 
 			for (const payloadToClone of data) {
 				const payload = cloneDeep(payloadToClone)
@@ -580,7 +591,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					|| typeof payloadAfterHooks === 'string' // replace new creation by an existing item having a uuid as its primary key
 					|| typeof payloadAfterHooks === 'number' // replace new creation by an existing item having a number as its primary key
 				) {
-					itemsAnalyzingValues.push(payloadAfterHooks)
+					preparedItems.push(payloadAfterHooks)
 
 					continue
 				}
@@ -655,7 +666,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				}
 
 				// batchInsertInput.push(payloadWithoutAliases)
-				itemsAnalyzingValues.push({
+				preparedItems.push({
 					primaryKey,
 
 					actionHookPayload,
@@ -674,28 +685,23 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				})
 			}
 
+			const itemsToInsert = preparedItems.filter(isNotPrimaryKey)
+
 			try {
 				const results = await trx
 				.batchInsert<Exclude<ItemValues, number | string>['payloadWithoutAliases']>(
 					this.collection,
-					(itemsAnalyzingValues
-					.filter((v) => {
-						return typeof v !== 'number'
-						|| typeof v !== 'string'
-					}) as Exclude<ItemValues, number | string>[])
-					.map((v) => {
+					itemsToInsert.map((v) => {
 						return v.payloadWithoutAliases
 					})
 				)
 				.returning(primaryKeyField)
 
 				results.forEach((result, index) => {
-					const preparedValues = itemsAnalyzingValues[index]
+					// TODO is insert order respected durting batchInsert ?
+					const preparedValues = itemsToInsert[index]
 
-					if (! preparedValues
-						|| typeof preparedValues === 'string'
-						|| typeof preparedValues === 'number'
-					) {
+					if (! preparedValues) {
 						throw new Error(`No batchInsert itemInput found for index ${index}`) // Should never happend
 					}
 
@@ -729,11 +735,11 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			//   payload[primaryKeyField] = primaryKey
 			// }
 
-			for (const itemsAnalyzingValue of itemsAnalyzingValues) {
-				if (typeof itemsAnalyzingValue === 'number' || typeof itemsAnalyzingValue === 'string') {
-					continue
-				}
 
+			// TODO should Promise.allSettled be replaced by a sequential await?
+			const preparedForPostInsertProcessResponses = await Promise.allSettled( itemsToInsert.map(async (
+				preparedItem
+			) => {
 				const {
 					primaryKey,
 					payloadAfterHooks,
@@ -742,7 +748,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					revisionsA2O,
 					userIntegrityCheckFlagsM2O,
 					userIntegrityCheckFlagsA2O,
-				} = itemsAnalyzingValue
+				} = preparedItem
 
 				const {
 					revisions: revisionsO2M,
@@ -768,71 +774,159 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					}
 				}
 
-				itemsAnalyzingValue.nestedActionEventsO2M = nestedActionEventsO2M
 
-				// If this is an authenticated action, and accountability tracking is enabled, save activity row
-				if (this.accountability
+				const activityInput = this.accountability
 					&& this.schema.collections[this.collection]!.accountability !== null
-				) {
-					const activityService = new ActivityService({
-						knex: trx,
-						schema: this.schema,
-					})
+				?	{
+					action: Action.CREATE,
+					user: this.accountability!.user,
+					collection: this.collection,
+					ip: this.accountability!.ip,
+					user_agent: this.accountability!.userAgent,
+					origin: this.accountability!.origin,
+					item: primaryKey,
+				}
+				: undefined
 
-					const activity = await activityService.createOne({
-						action: Action.CREATE,
-						user: this.accountability!.user,
-						collection: this.collection,
-						ip: this.accountability!.ip,
-						user_agent: this.accountability!.userAgent,
-						origin: this.accountability!.origin,
-						item: primaryKey,
-					})
 
-					// If revisions are tracked, create revisions record
-					if (this.schema.collections[this.collection]!.accountability === `all`) {
-						const revisionsService = new RevisionsService({
-							knex: trx,
-							schema: this.schema,
-						})
-
+				const revisionInput = activityInput !== undefined
+					&& this.schema.collections[this.collection]!.accountability === `all`
+				? await (async () => {
 						const revisionDelta = await payloadService.prepareDelta(payloadAfterHooks)
-
-						const revision = await revisionsService.createOne({
-							activity,
+						return {
+							// activity, // will be added once activity rows are inserted
 							collection: this.collection,
 							item: primaryKey,
 							data: revisionDelta,
 							delta: revisionDelta,
-						})
-
-						// Make sure to set the parent field of the child-revision rows
-						const childrenRevisions = [...revisionsM2O, ...revisionsA2O, ...revisionsO2M]
-
-						if (childrenRevisions.length > 0) {
-							await revisionsService.updateMany(childrenRevisions, { parent: revision })
 						}
+				})()
+				: undefined
 
-						if (opts.onRevisionCreate) {
-							opts.onRevisionCreate(revision)
-						}
-					}
+				let activity: PrimaryKey | undefined
+				let revision: PrimaryKey | undefined
+
+				return {
+					...preparedItem,
+					nestedActionEventsO2M,
+					activityInput,
+					activity,
+					revisionInput,
+					revision,
+					childrenRevisions: [...revisionsM2O, ...revisionsA2O, ...revisionsO2M],
 				}
+			}))
+
+
+			// From https://stackoverflow.com/a/69451755
+			const isRejected = (input: PromiseSettledResult<unknown>): input is PromiseRejectedResult => {
+				return input.status === 'rejected'
 			}
+
+			const isFulfilled = <T>(input: PromiseSettledResult<T>): input is PromiseFulfilledResult<T> => {
+				return input.status === 'fulfilled'
+			}
+
+			const errorReasons = preparedForPostInsertProcessResponses.filter(isRejected)?.map(i => i.reason)
+
+			if (errorReasons.length) {
+				console.log('errorReasons', errorReasons)
+				throw errorReasons[0]
+				// TODO how to pass all the errors ?
+			}
+
+			const preparedForPostInsert = preparedForPostInsertProcessResponses.filter(isFulfilled)?.map(item => item.value)
+
+
+			const itemsWithActivityInput = preparedForPostInsert
+			.filter(isNotPrimaryKey)
+			.filter((item) => {
+				return item.activityInput !== undefined
+			})
+
+			const { ActivityService } = await import('./activity.js');
+
+			const itemsWithActivity = (await new ActivityService({
+				knex: trx,
+				schema: this.schema,
+			})
+			.createMany(itemsWithActivityInput.map((item) => {
+				return item.activityInput!
+			})))
+			.map((activityPk, index) => {
+				if (! (index in itemsWithActivityInput) || itemsWithActivityInput[index] === undefined) {
+					throw new Error(`Unable to find '${index}' in activitiesItems`)
+				}
+
+				return {
+					...itemsWithActivityInput[index],
+					activity: activityPk,
+				}
+			})
+
+
+			const itemsWithRevisionInput = itemsWithActivity
+			.filter((item) => {
+				return item.revisionInput !== undefined
+			})
+
+			const { RevisionsService } = await import('./revisions.js');
+
+			const revisionsService = new RevisionsService({
+				knex: trx,
+				schema: this.schema,
+			})
+
+			const itemsWithActivityAndRevision =(await revisionsService.createMany(itemsWithRevisionInput.map((
+				item
+			) => {
+				return {
+					...item.revisionInput,
+					activity: item.activity,
+				}
+			})))
+			.map((revisionPk, index) => {
+				if (! (index in itemsWithRevisionInput) || itemsWithRevisionInput[index] === undefined) {
+					throw new Error(`Unable to find '${index}' in itemsWithRevisionInput`)
+				}
+
+				return {
+					...itemsWithRevisionInput[index],
+					revision: revisionPk,
+				}
+			})
+
+
+			// Make sure to set the parent field of the child-revision rows
+			const updateRevisionsChildrenResponses = await Promise.allSettled( itemsWithActivityAndRevision.map(async (item) => {
+				if (item.childrenRevisions.length > 0) {
+					await revisionsService.updateMany(item.childrenRevisions, { parent: item.revision })
+				}
+
+				if (opts.onRevisionCreate) {
+					opts.onRevisionCreate(item.revision)
+				}
+			}))
+
+			const revisionErrorReasons = updateRevisionsChildrenResponses.filter(isRejected)?.map(i => i.reason)
+
+			if (revisionErrorReasons.length) {
+				// console.log('revisionErrorReasons', revisionErrorReasons)
+				throw revisionErrorReasons[0]
+				// TODO how to pass all the errors ?
+			}
+
 
 			if (autoIncrementSequenceNeedsToBeReset) {
 				await getHelpers(trx).sequence.resetAutoIncrementSequence(this.collection, primaryKeyField);
 			}
 
-			return itemsAnalyzingValues
+			return preparedForPostInsert
 		})
 
 
-		for (const itemValues of itemsValues) {
-			if (opts.emitEvents === false
-				|| typeof itemValues === 'string'
-				|| typeof itemValues === 'number'
-			) {
+		for (const itemValues of itemsValues.filter(isNotPrimaryKey)) {
+			if (opts.emitEvents === false) {
 				continue
 			}
 
@@ -893,7 +987,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		}
 
 		return itemsValues.map((itemValues) => {
-			if (typeof itemValues === 'string' || typeof itemValues === 'number') {
+			if (isPrimaryKey(itemValues)) {
 				return itemValues
 			}
 

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -689,7 +689,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 				})
 			}
 			catch (err: any) {
-				throw await translateDatabaseError(err, itemsValues)
+				throw await translateDatabaseError(err, data)
 			}
 
 			// TODO

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -508,7 +508,8 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		// changes in the DB if any of the parts contained within throws an error. This also means
 		// that any errors thrown in any nested relational changes will bubble up and cancel the whole
 		// update tree
-		type ItemValues = {
+		type ItemValues = PrimaryKey
+		| {
 			primaryKey: PrimaryKey,
 
 			actionHookPayload: any, // TODO better typing from processPayload()
@@ -565,11 +566,17 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 						)
 						: payload
 
-				if ( payloadAfterHooks === null // skip creation
+				if ( payloadAfterHooks === null) { // skip creation
+					continue
+				}
+
+				if ( false // eslint-disable-line
 					|| typeof payloadAfterHooks === 'string' // replace new creation by an existing item having a uuid as its primary key
 					|| typeof payloadAfterHooks === 'number' // replace new creation by an existing item having a number as its primary key
 				) {
-					return payloadAfterHooks
+					itemsAnalyzingValues.push(payloadAfterHooks)
+
+					continue
 				}
 
 				const payloadWithPresets = this.accountability
@@ -663,28 +670,38 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 			try {
 				const results = await trx
-				.batchInsert(
+				.batchInsert<Exclude<ItemValues, number | string>['payloadWithoutAliases']>(
 					this.collection,
-					itemsAnalyzingValues.map((v) => v.payloadWithoutAliases)
+					(itemsAnalyzingValues
+					.filter((v) => {
+						return typeof v !== 'number'
+						|| typeof v !== 'string'
+					}) as Exclude<ItemValues, number | string>[])
+					.map((v) => {
+						return v.payloadWithoutAliases
+					})
 				)
 				.returning(primaryKeyField)
 
 				results.forEach((result, index) => {
-					if (! itemsAnalyzingValues[index]) {
-						throw new Error(`No batchInsert itemInput found for index ${index}`)
+					const preparedValues = itemsAnalyzingValues[index]
+
+					if (! preparedValues
+						|| typeof preparedValues === 'string'
+						|| typeof preparedValues === 'number'
+					) {
+						throw new Error(`No batchInsert itemInput found for index ${index}`) // Should never happend
 					}
 
 					const returnedKey = typeof result === `object` ? result[primaryKeyField] : result
 
 					if (this.schema.collections[this.collection]!.fields[primaryKeyField]!.type === `uuid`) {
-						itemsAnalyzingValues[index].primaryKey
-						= getHelpers(trx).schema.formatUUID(
-								(itemsAnalyzingValues[index].primaryKey ?? returnedKey) as string
-							)
+						preparedValues.primaryKey = getHelpers(trx).schema.formatUUID(
+							(preparedValues.primaryKey ?? returnedKey) as string
+						)
 					}
 					else {
-						itemsAnalyzingValues[index].primaryKey
-						= itemsAnalyzingValues[index].primaryKey ?? returnedKey
+						preparedValues.primaryKey = preparedValues.primaryKey ?? returnedKey
 					}
 				})
 			}
@@ -707,6 +724,10 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			// }
 
 			for (const itemsAnalyzingValue of itemsAnalyzingValues) {
+				if (typeof itemsAnalyzingValue === 'number' || typeof itemsAnalyzingValue === 'string') {
+					continue
+				}
+
 				const {
 					primaryKey,
 					payloadAfterHooks,
@@ -801,55 +822,62 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		})
 
 
-		itemsValues.forEach(({
-			primaryKey,
-			actionHookPayload,
-			nestedActionEventsM2O,
-			nestedActionEventsA2O,
-			nestedActionEventsO2M,
-		}) => {
-			if (opts.emitEvents !== false) {
-				const actionEvent = {
-					event:
-						this.eventScope === `items`
-							? [`items.create`, `${this.collection}.items.create`]
-							: `${this.eventScope}.create`,
-					meta: {
-						actionHookPayload,
-						key: primaryKey,
-						collection: this.collection,
-					},
-					context: {
-						database: getDatabase(),
-						schema: this.schema,
-						accountability: this.accountability,
-					},
-				}
+		itemsValues.forEach((itemValues) => {
+			if (opts.emitEvents === false
+				|| typeof itemValues === 'string'
+				|| typeof itemValues === 'number'
+			) {
+				return
+			}
 
+			const {
+				primaryKey,
+				actionHookPayload,
+				nestedActionEventsM2O,
+				nestedActionEventsA2O,
+				nestedActionEventsO2M,
+			} = itemValues
+
+			const actionEvent = {
+				event:
+					this.eventScope === `items`
+						? [`items.create`, `${this.collection}.items.create`]
+						: `${this.eventScope}.create`,
+				meta: {
+					actionHookPayload,
+					key: primaryKey,
+					collection: this.collection,
+				},
+				context: {
+					database: getDatabase(),
+					schema: this.schema,
+					accountability: this.accountability,
+				},
+			}
+
+			if (opts.bypassEmitAction) {
+				opts.bypassEmitAction(actionEvent)
+			}
+			else {
+				emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context)
+			}
+
+			const nestedActionEvents = [
+				...nestedActionEventsO2M || [],
+				...nestedActionEventsA2O,
+				...nestedActionEventsM2O,
+			]
+
+			for (const nestedActionEvent of nestedActionEvents) {
 				if (opts.bypassEmitAction) {
-					opts.bypassEmitAction(actionEvent)
+					opts.bypassEmitAction(nestedActionEvent)
 				}
 				else {
-					emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context)
-				}
-
-				const nestedActionEvents = [
-					...nestedActionEventsO2M || [],
-					...nestedActionEventsA2O,
-					...nestedActionEventsM2O,
-				]
-
-				for (const nestedActionEvent of nestedActionEvents) {
-					if (opts.bypassEmitAction) {
-						opts.bypassEmitAction(nestedActionEvent)
-					}
-					else {
-						emitter.emitAction(
-							nestedActionEvent.event,
-							nestedActionEvent.meta,
-							nestedActionEvent.context
-						)
-					}
+					emitter.emitAction(
+						nestedActionEvent.event,
+						nestedActionEvent.meta,
+						nestedActionEvent.context
+					)
 				}
 			}
 		})
@@ -858,7 +886,13 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			await this.cache.clear()
 		}
 
-		return itemsValues.map(({ primaryKey }) => primaryKey)
+		return itemsValues.map((itemValues) => {
+			if (typeof itemValues === 'string' || typeof itemValues === 'number') {
+				return itemValues
+			}
+
+			return itemValues.primaryKey
+		})
 	}
 
 	/**

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -480,6 +480,387 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		return primaryKeys;
 	}
 
+
+	async createManyAtOnce<T extends AnyItem>(
+		this: ItemsService,
+		data: Partial<T>[],
+		opts: MutationOptions = {}
+	): Promise<PrimaryKey[]> {
+		if (! opts.mutationTracker) {
+			opts.mutationTracker = this.createMutationTracker()
+		}
+
+		if (! opts.bypassLimits) {
+			opts.mutationTracker.trackMutations(1)
+		}
+
+		const { ActivityService } = await import('./activity.js');
+		const { RevisionsService } = await import('./revisions.js');
+
+		const primaryKeyField = this.schema.collections[this.collection]!.primary
+		const fields = Object.keys(this.schema.collections[this.collection]!.fields)
+
+		const aliases = Object.values(this.schema.collections[this.collection]!.fields)
+		.filter((field) => field.alias === true)
+		.map((field) => field.field)
+
+		// By wrapping the logic in a transaction, we make sure we automatically roll back all the
+		// changes in the DB if any of the parts contained within throws an error. This also means
+		// that any errors thrown in any nested relational changes will bubble up and cancel the whole
+		// update tree
+		type ItemValues = {
+			primaryKey: PrimaryKey,
+
+			actionHookPayload: any, // TODO better typing from processPayload()
+			payloadAfterHooks: Partial<typeof data[number]>,
+			payloadWithPresets: Partial<typeof data[number]>,
+			payloadWithoutAliases: Pick<Partial<AnyItem>, string>,
+
+			revisionsM2O: Awaited<ReturnType<PayloadService[`processM2O`]>>[`revisions`],
+			revisionsA2O: Awaited<ReturnType<PayloadService[`processA2O`]>>[`revisions`],
+			revisionsO2M?: Awaited<ReturnType<PayloadService[`processO2M`]>>[`revisions`],
+
+			nestedActionEventsM2O: Awaited<ReturnType<PayloadService[`processM2O`]>>[`nestedActionEvents`],
+			nestedActionEventsA2O: Awaited<ReturnType<PayloadService[`processA2O`]>>[`nestedActionEvents`],
+			nestedActionEventsO2M?: Awaited<ReturnType<PayloadService[`processO2M`]>>[`nestedActionEvents`],
+
+			userIntegrityCheckFlagsM2O: Awaited<ReturnType<PayloadService[`processM2O`]>>[`userIntegrityCheckFlags`],
+			userIntegrityCheckFlagsA2O: Awaited<ReturnType<PayloadService[`processM2O`]>>[`userIntegrityCheckFlags`],
+		}
+
+		// If a PK of type number was provided, although the PK is set the auto_increment,
+		// depending on the database, the sequence might need to be reset to protect future PK collisions.
+		let autoIncrementSequenceNeedsToBeReset = false;
+
+		const itemsValues: ItemValues[] = await this.knex.transaction(async (trx) => {
+			// We're creating new services instances so they can use the transaction as their Knex interface
+			const payloadService = new PayloadService(this.collection, {
+				accountability: this.accountability,
+				knex: trx,
+				schema: this.schema,
+			})
+
+			const itemsAnalyzingValues: ItemValues[] = []
+
+			for (const payloadToClone of data) {
+				const payload = cloneDeep(payloadToClone)
+
+				// Run all hooks that are attached to this event so the end user has the chance to augment the
+				// item that is about to be saved
+				const payloadAfterHooks =
+					opts.emitEvents !== false
+						? await emitter.emitFilter(
+							this.eventScope === `items`
+								? [`items.create`, `${this.collection}.items.create`]
+								: `${this.eventScope}.create`,
+							payload,
+							{
+								collection: this.collection,
+							},
+							{
+								database: trx,
+								schema: this.schema,
+								accountability: this.accountability,
+							}
+						)
+						: payload
+
+				if ( payloadAfterHooks === null // skip creation
+					|| typeof payloadAfterHooks === 'string' // replace new creation by an existing item having a uuid as its primary key
+					|| typeof payloadAfterHooks === 'number' // replace new creation by an existing item having a number as its primary key
+				) {
+					return payloadAfterHooks
+				}
+
+				const payloadWithPresets = this.accountability
+					? await processPayload(
+							{
+								accountability: this.accountability,
+								action: 'create',
+								collection: this.collection,
+								payload: payloadAfterHooks,
+								nested: this.nested,
+							},
+							{
+								knex: trx,
+								schema: this.schema,
+							},
+						)
+					: payloadAfterHooks;
+
+
+				if (opts.preMutationError) {
+					throw opts.preMutationError
+				}
+
+				// Ensure the action hook payload has the post filter hook + preset changes
+				const actionHookPayload = payloadWithPresets;
+
+				// We're creating new services instances so they can use the transaction as their Knex interface
+				const payloadService = new PayloadService(this.collection, {
+					accountability: this.accountability,
+					knex: trx,
+					schema: this.schema,
+					nested: this.nested,
+				});
+
+				const {
+					payload: payloadWithM2O,
+					revisions: revisionsM2O,
+					nestedActionEvents: nestedActionEventsM2O,
+					userIntegrityCheckFlags: userIntegrityCheckFlagsM2O,
+				} = await payloadService.processM2O(payloadWithPresets, opts);
+
+				const {
+					payload: payloadWithA2O,
+					revisions: revisionsA2O,
+					nestedActionEvents: nestedActionEventsA2O,
+					userIntegrityCheckFlags: userIntegrityCheckFlagsA2O,
+				} = await payloadService.processA2O(payloadWithM2O, opts);
+
+				const payloadWithoutAliases = pick(payloadWithA2O, without(fields, ...aliases))
+				const payloadWithTypeCasting = await payloadService.processValues(`create`, payloadWithoutAliases)
+
+				// In case of manual string / UUID primary keys, the PK already exists in the object we're saving.
+				const primaryKey = payloadWithTypeCasting[primaryKeyField]
+
+				if (primaryKey) {
+					validateKeys(this.schema, this.collection, primaryKeyField, primaryKey);
+				}
+
+
+				const pkField = this.schema.collections[this.collection]!.fields[primaryKeyField];
+
+				if (
+					primaryKey &&
+					pkField &&
+					!opts.bypassAutoIncrementSequenceReset &&
+					['integer', 'bigInteger'].includes(pkField.type) &&
+					pkField.defaultValue === 'AUTO_INCREMENT'
+				) {
+					autoIncrementSequenceNeedsToBeReset = true;
+				}
+
+				// batchInsertInput.push(payloadWithoutAliases)
+				itemsAnalyzingValues.push({
+					primaryKey,
+
+					actionHookPayload,
+					payloadAfterHooks,
+					payloadWithPresets,
+					payloadWithoutAliases,
+
+					revisionsM2O,
+					revisionsA2O,
+
+					nestedActionEventsM2O,
+					nestedActionEventsA2O,
+
+					userIntegrityCheckFlagsM2O,
+					userIntegrityCheckFlagsA2O,
+				})
+			}
+
+			try {
+				const results = await trx
+				.batchInsert(
+					this.collection,
+					itemsAnalyzingValues.map((v) => v.payloadWithoutAliases)
+				)
+				.returning(primaryKeyField)
+
+				results.forEach((result, index) => {
+					if (! itemsAnalyzingValues[index]) {
+						throw new Error(`No batchInsert itemInput found for index ${index}`)
+					}
+
+					const returnedKey = typeof result === `object` ? result[primaryKeyField] : result
+
+					if (this.schema.collections[this.collection]!.fields[primaryKeyField]!.type === `uuid`) {
+						itemsAnalyzingValues[index].primaryKey
+						= getHelpers(trx).schema.formatUUID(
+								(itemsAnalyzingValues[index].primaryKey ?? returnedKey) as string
+							)
+					}
+					else {
+						itemsAnalyzingValues[index].primaryKey
+						= itemsAnalyzingValues[index].primaryKey ?? returnedKey
+					}
+				})
+			}
+			catch (err: any) {
+				throw await translateDatabaseError(err, itemsValues)
+			}
+
+			// TODO
+			// Most database support returning, those who don't tend to return the PK anyways
+			// (MySQL/SQLite). In case the primary key isn't know yet, we'll do a best-attempt at
+			// fetching it based on the last inserted row
+			// if (! primaryKey) {
+			//   // Fetching it with max should be safe, as we're in the context of the current transaction
+			//   const result = await trx.max(primaryKeyField, { as: `id` }).from(this.collection)
+			//   .first()
+			//   primaryKey = result.id
+			//   // Set the primary key on the input item, in order for the "after" event hook to be able
+			//   // to read from it
+			//   payload[primaryKeyField] = primaryKey
+			// }
+
+			for (const itemsAnalyzingValue of itemsAnalyzingValues) {
+				const {
+					primaryKey,
+					payloadAfterHooks,
+					payloadWithPresets,
+					revisionsM2O,
+					revisionsA2O,
+					userIntegrityCheckFlagsM2O,
+					userIntegrityCheckFlagsA2O,
+				} = itemsAnalyzingValue
+
+				const {
+					revisions: revisionsO2M,
+					nestedActionEvents: nestedActionEventsO2M,
+					userIntegrityCheckFlags: userIntegrityCheckFlagsO2M,
+				} = await payloadService.processO2M(
+					payloadWithPresets,
+					primaryKey,
+					opts
+				)
+
+				const userIntegrityCheckFlags =
+					(opts.userIntegrityCheckFlags ?? UserIntegrityCheckFlag.None) |
+					userIntegrityCheckFlagsM2O |
+					userIntegrityCheckFlagsA2O |
+					userIntegrityCheckFlagsO2M;
+
+				if (userIntegrityCheckFlags) {
+					if (opts.onRequireUserIntegrityCheck) {
+						opts.onRequireUserIntegrityCheck(userIntegrityCheckFlags);
+					} else {
+						await validateUserCountIntegrity({ flags: userIntegrityCheckFlags, knex: trx });
+					}
+				}
+
+				itemsAnalyzingValue.nestedActionEventsO2M = nestedActionEventsO2M
+
+				// If this is an authenticated action, and accountability tracking is enabled, save activity row
+				if (this.accountability
+					&& this.schema.collections[this.collection]!.accountability !== null
+				) {
+					const activityService = new ActivityService({
+						knex: trx,
+						schema: this.schema,
+					})
+
+					const activity = await activityService.createOne({
+						action: Action.CREATE,
+						user: this.accountability!.user,
+						collection: this.collection,
+						ip: this.accountability!.ip,
+						user_agent: this.accountability!.userAgent,
+						origin: this.accountability!.origin,
+						item: primaryKey,
+					})
+
+					// If revisions are tracked, create revisions record
+					if (this.schema.collections[this.collection]!.accountability === `all`) {
+						const revisionsService = new RevisionsService({
+							knex: trx,
+							schema: this.schema,
+						})
+
+						const revisionDelta = await payloadService.prepareDelta(payloadAfterHooks)
+
+						const revision = await revisionsService.createOne({
+							activity,
+							collection: this.collection,
+							item: primaryKey,
+							data: revisionDelta,
+							delta: revisionDelta,
+						})
+
+						// Make sure to set the parent field of the child-revision rows
+						const childrenRevisions = [...revisionsM2O, ...revisionsA2O, ...revisionsO2M]
+
+						if (childrenRevisions.length > 0) {
+							await revisionsService.updateMany(childrenRevisions, { parent: revision })
+						}
+
+						if (opts.onRevisionCreate) {
+							opts.onRevisionCreate(revision)
+						}
+					}
+				}
+			}
+
+			if (autoIncrementSequenceNeedsToBeReset) {
+				await getHelpers(trx).sequence.resetAutoIncrementSequence(this.collection, primaryKeyField);
+			}
+
+			return itemsAnalyzingValues
+		})
+
+
+		itemsValues.forEach(({
+			primaryKey,
+			actionHookPayload,
+			nestedActionEventsM2O,
+			nestedActionEventsA2O,
+			nestedActionEventsO2M,
+		}) => {
+			if (opts.emitEvents !== false) {
+				const actionEvent = {
+					event:
+						this.eventScope === `items`
+							? [`items.create`, `${this.collection}.items.create`]
+							: `${this.eventScope}.create`,
+					meta: {
+						actionHookPayload,
+						key: primaryKey,
+						collection: this.collection,
+					},
+					context: {
+						database: getDatabase(),
+						schema: this.schema,
+						accountability: this.accountability,
+					},
+				}
+
+				if (opts.bypassEmitAction) {
+					opts.bypassEmitAction(actionEvent)
+				}
+				else {
+					emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context)
+				}
+
+				const nestedActionEvents = [
+					...nestedActionEventsO2M || [],
+					...nestedActionEventsA2O,
+					...nestedActionEventsM2O,
+				]
+
+				for (const nestedActionEvent of nestedActionEvents) {
+					if (opts.bypassEmitAction) {
+						opts.bypassEmitAction(nestedActionEvent)
+					}
+					else {
+						emitter.emitAction(
+							nestedActionEvent.event,
+							nestedActionEvent.meta,
+							nestedActionEvent.context
+						)
+					}
+				}
+			}
+		})
+
+		if (shouldClearCache(this.cache, opts, this.collection)) {
+			await this.cache.clear()
+		}
+
+		return itemsValues.map(({ primaryKey }) => primaryKey)
+	}
+
 	/**
 	 * Get items by query.
 	 */

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -170,6 +170,14 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 						)
 					: payload;
 
+			if (
+				payloadAfterHooks === null ||
+				typeof payloadAfterHooks === 'string' ||
+				typeof payloadAfterHooks === 'number'
+			) {
+				return payloadAfterHooks;
+			}
+
 			const payloadWithPresets = this.accountability
 				? await processPayload(
 						{

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -850,7 +850,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 						? [`items.create`, `${this.collection}.items.create`]
 						: `${this.eventScope}.create`,
 				meta: {
-					actionHookPayload,
+					payload: actionHookPayload,
 					key: primaryKey,
 					collection: this.collection,
 				},

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -1243,6 +1243,18 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					)
 				: payload;
 
+		// TODO add null to payloadAfterHooks possible types
+		const payloadKeys = Object.keys(payloadAfterHooks ?? {})
+
+		if ( payloadKeys.length === 0 // payloadAfterHooks == {} || null
+			|| (
+				payloadKeys.length === 1
+				&& payloadKeys[0] === primaryKeyField
+			) // payloadAfterHooks == {id: xxx}
+		) {
+			return []
+		}
+
 		// Sort keys to ensure that the order is maintained
 		keys.sort();
 

--- a/packages/types/src/items.ts
+++ b/packages/types/src/items.ts
@@ -55,7 +55,7 @@ export type MutationOptions = {
 	 * To bypass the emitting of action events if emitEvents is enabled
 	 * Can be used to queue up the nested events from item service's create, update and delete
 	 */
-	bypassEmitAction?: ((params: ActionEventParams) => void) | undefined;
+	bypassEmitAction?: ((params: ActionEventParams) => void) | ((params: ActionEventParams) => Promise<void>) | undefined;
 
 	/**
 	 * To bypass limits so that functions would work as intended


### PR DESCRIPTION
**Upstream-draft (v12):** #56 — the MSCL v12 implementation this BSL v11.10.1 feature is re-derived from.

Fork-permanent, stacked on `fork-feat/skip-noop`. Cherry-picked from `v11.9.2-hhh-dev` (`2fb505c`, `7a22a85`) — read-path only (run-ast.ts). The write-path `db.insert` event (`415ea65`) is deferred (entangled with batch-insert's deferred `2dd0d12`).

---
_Recreated from #89 after the branch rename to the version-namespaced scheme (`v11.10.1-feat/*` on `upstream-v11.10.1`)._