### PR TITLE
v11.10.1-feat: filterable DB errors (#34)

### DIFF
--- a/api/src/database/errors/translate.ts
+++ b/api/src/database/errors/translate.ts
@@ -40,9 +40,18 @@ export async function translateDatabaseError(error: SQLError, data: Partial<Item
 			break;
 	}
 
+	const mainThreadError = new Error(defaultError.message, {
+		cause: defaultError,
+	})
+
+	if (mainThreadError) {
+		// @ts-expect-error data doesn't exist on Error
+		mainThreadError.data = data
+	}
+
 	const hookError = await emitter.emitFilter(
 		'database.error',
-		defaultError,
+		mainThreadError,
 		{ client },
 		{
 			database: getDatabase(),
@@ -51,17 +60,7 @@ export async function translateDatabaseError(error: SQLError, data: Partial<Item
 		},
 	);
 
-	const mainThreadError = hookError ? new Error(hookError.message, {
-		cause: hookError,
-	}) : undefined
-
-
-	if (mainThreadError) {
-		// @ts-expect-error data doesn't exist on Error
-		mainThreadError.data = data
-	}
-
-	return mainThreadError;
+	return hookError;
 }
 
 

--- a/api/src/database/errors/translate.ts
+++ b/api/src/database/errors/translate.ts
@@ -51,5 +51,24 @@ export async function translateDatabaseError(error: SQLError, data: Partial<Item
 		},
 	);
 
-	return hookError;
+	const mainThreadError = hookError ? new Error(hookError.message, {
+		cause: hookError,
+	}) : undefined
+
+
+	if (mainThreadError) {
+		// @ts-expect-error data doesn't exist on Error
+		mainThreadError.data = data
+	}
+
+	return mainThreadError;
+}
+
+
+export async function throwDatabaseError(error: SQLError, data: Partial<Item>): Promise<any> {
+	const filteredError = await translateDatabaseError(error, data)
+
+	if (filteredError) {
+		throw filteredError
+	}
 }

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -25,7 +25,7 @@ import type { Knex } from 'knex';
 import { isEqual, isNil, merge } from 'lodash-es';
 import { clearSystemCache, getCache, getCacheValue, setCacheValue } from '../cache.js';
 import { ALIAS_TYPES, ALLOWED_DB_DEFAULT_FUNCTIONS } from '../constants.js';
-import { translateDatabaseError } from '../database/errors/translate.js';
+import { throwDatabaseError } from '../database/errors/translate.js';
 import type { Helpers } from '../database/helpers/index.js';
 import { getHelpers } from '../database/helpers/index.js';
 import getDatabase, { getSchemaInspector } from '../database/index.js';
@@ -537,7 +537,11 @@ export class FieldsService {
 							});
 						});
 					} catch (err: any) {
-						throw await translateDatabaseError(err, field);
+						await throwDatabaseError(err, {
+								collection,
+								field,
+								existingColumn
+						});
 					}
 				}
 			}

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -20,7 +20,7 @@ import type Keyv from 'keyv';
 import type { Knex } from 'knex';
 import { assign, clone, cloneDeep, omit, pick, without } from 'lodash-es';
 import { getCache } from '../cache.js';
-import { translateDatabaseError } from '../database/errors/translate.js';
+import { throwDatabaseError, translateDatabaseError } from '../database/errors/translate.js';
 import { getAstFromQuery } from '../database/get-ast-from-query/get-ast-from-query.js';
 import { getHelpers } from '../database/helpers/index.js';
 import getDatabase from '../database/index.js';
@@ -278,7 +278,9 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					delete dbError.extensions.primaryKey;
 				}
 
-				throw dbError;
+				if (dbError) {
+					throw dbError;
+				}
 			}
 
 			// Most database support returning, those who don't tend to return the PK anyways
@@ -712,7 +714,13 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 					}
 				});
 			} catch (err: any) {
-				throw await translateDatabaseError(err, data);
+				// console.log('Sql error', {
+				// 	err,
+				// 	data,
+				// 	sqliteFieldsRequiringValue
+				// })
+
+				await throwDatabaseError(err, data);
 			}
 
 			// TODO
@@ -1295,7 +1303,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 						await trx(this.collection).update(payloadWithTypeCasting).where(primaryKeyField, keys[0]);
 					}
 				} catch (err: any) {
-					throw await translateDatabaseError(err, data);
+					await throwDatabaseError(err, data);
 				}
 			}
 

--- a/tmp/compose-watch.log
+++ b/tmp/compose-watch.log
@@ -1,0 +1,1734 @@
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Sync fork main from upstream
+  * Discover open hhh-main copy PRs
+  * Compose hhh-main
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Sync fork main from upstream
+  * Discover open hhh-main copy PRs
+  * Compose hhh-main
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Sync fork main from upstream
+  * Discover open hhh-main copy PRs
+  * Compose hhh-main
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Sync fork main from upstream
+  * Discover open hhh-main copy PRs
+  * Compose hhh-main
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Sync fork main from upstream
+  * Discover open hhh-main copy PRs
+  * Compose hhh-main
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  * Sync fork main from upstream
+  * Discover open hhh-main copy PRs
+  * Compose hhh-main
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  * Compose hhh-main
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  * Compose hhh-main
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  * Compose hhh-main
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  * Compose hhh-main
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 6 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 6 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 6 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 6 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 6 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-main
+  * Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 6 minutes ago
+
+JOBS
+* compose (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  ✓ Test api
+  ✓ Publish hhh-main
+  - Report skipped PRs or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+✓ pr-controle compose-hhh-main · 27717817009
+Triggered via workflow_dispatch about 6 minutes ago
+
+JOBS
+✓ compose in 6m15s (ID 81995178298)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Sync fork main from upstream
+  ✓ Discover open hhh-main copy PRs
+  ✓ Compose hhh-main
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  ✓ Test api
+  ✓ Publish hhh-main
+  - Report skipped PRs or failed tests
+  ✓ Post Install + build
+  ✓ Post Run actions/checkout@v4
+  ✓ Complete job
+
+ANNOTATIONS
+! Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4, pnpm/action-setup@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+compose: .github#2
+

--- a/tmp/rebuild-apitest.log
+++ b/tmp/rebuild-apitest.log
@@ -1,0 +1,960 @@
+
+> @directus/api@36.0.2 test /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api
+> vitest run
+
+
+ RUN  v3.2.6 /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api
+
+ ✓ src/utils/encrypt.test.ts (12 tests) 3340ms
+   ✓ encrypt/decrypt (AES-256-GCM with scrypt KDF, v1 envelope) > round-trips plaintext with the same key  311ms
+   ✓ encrypt/decrypt (AES-256-GCM with scrypt KDF, v1 envelope) > uses a random IV so encrypting the same input twice yields different outputs  1006ms
+   ✓ encrypt/decrypt (AES-256-GCM with scrypt KDF, v1 envelope) > throws when decrypting with the wrong key  334ms
+   ✓ encrypt/decrypt (AES-256-GCM with scrypt KDF, v1 envelope) > throws when the tag is tampered with  338ms
+ ✓ src/deployment/drivers/vercel.test.ts (43 tests) 4652ms
+   ✓ VercelDriver > rate limiting > should retry on 429 and succeed on second attempt  1008ms
+   ✓ VercelDriver > rate limiting > should throw HitRateLimitError after 3 retries  3179ms
+ ❯ src/utils/schedule.test.ts (7 tests | 3 failed) 6448ms
+   ✓ validateCron > Returns true for valid cron expression 103ms
+   ✓ validateCron > Returns false for invalid cron expression 5ms
+   ✓ scheduleSynchronizedJob > long-running scenarios (25+ days) > Should execute daily job for 26 consecutive days  636ms
+   × scheduleSynchronizedJob > long-running scenarios (25+ days) > Should execute hourly job beyond setTimeout limit 5020ms
+     → Test timed out in 5000ms.
+If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".
+   × scheduleSynchronizedJob > long-running scenarios (25+ days) > Should execute daily job for 30 days without missing executions 512ms
+     → expected "spy" to be called 30 times, but got 25 times
+   ✓ scheduleSynchronizedJob > long-running scenarios (25+ days) > Should stop job execution after stop() is called 117ms
+   × scheduleSynchronizedJob > CronJob execution timing > cron job fires at scheduled time 34ms
+     → expected "spy" to be called 2 times, but got 3 times
+ ✓ src/flows.test.ts (2 tests) 8652ms
+   ✓ FlowManager > getFlow returns undefined when no flows are loaded  8515ms
+ ✓ src/services/mcp-oauth/index.test.ts (290 tests) 4357ms
+ ✓ src/controllers/mcp/oauth.test.ts (42 tests) 731ms
+ ✓ src/services/fields.test.ts (40 tests) 1049ms
+   ✓ Integration Tests > Services / Fields > columnInfo > should use cache when available  724ms
+ ✓ src/database/helpers/schema/dialects/mysql.test.ts (19 tests) 1081ms
+   ✓ SchemaHelperMySQL > parseCollectionName > should return collection name in lowercase if lower_case_table_names === 1  410ms
+   ✓ SchemaHelperMySQL > parseCollectionName > should return original collection name if lower_case_table_names !== 1  478ms
+18:21:22 [vite] (ssr) warning: invalid import "./${pathToRelativeUrl(url, dirname(fileURLToPath(root)))}${options.fresh ? `?t=${Date.now()}` : ""}". A file extension must be included in the static part of the import. For example: import(`./foo/${bar}.js`).
+  Plugin: vite:dynamic-import-vars
+  File: /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/utils/import-file-url.ts
+ ✓ src/operations/exec/index.test.ts (12 tests) 1096ms
+   ✓ Rejects when operation runs for longer than allowed   664ms
+ ✓ src/services/mail/rate-limiter.test.ts (6 tests) 901ms
+ ✓ src/mailer.test.ts (4 tests) 599ms
+   ✓ getMailer > should not throw when creating SES transport  592ms
+[18:21:41.133] WARN: Couldn't save file test-file-id-123.txt
+[18:21:41.144] WARN: fs error
+    err: {
+      "type": "Error",
+      "message": "fs error",
+      "stack":
+          Error: fs error
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/services/files.test.ts:319:64
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:863:59
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:752:26
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1897:20
+              at new Promise (<anonymous>)
+              at runWithTimeout (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1863:10)
+              at runTest (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1574:12)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+      "code": "EROFS"
+    }
+[18:21:41.185] WARN: Couldn't save file test-file-id-123.txt
+[18:21:41.187] WARN: fs error
+    err: {
+      "type": "Error",
+      "message": "fs error",
+      "stack":
+          Error: fs error
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/services/files.test.ts:319:64
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:863:59
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:752:26
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1897:20
+              at new Promise (<anonymous>)
+              at runWithTimeout (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1863:10)
+              at runTest (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1574:12)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+      "code": "EACCES"
+    }
+[18:21:41.204] WARN: Couldn't save file test-file-id-123.txt
+[18:21:41.159] ERROR: Background import to test_collection failed
+    err: {
+      "type": "Error",
+      "message": "",
+      "stack":
+          Error: 
+              at ImportService.service.importCSV (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/services/import-export.test.ts:946:11)
+              at ImportService.import (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/services/import-export.ts:290:19)
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/services/import-export.test.ts:957:4
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:752:20
+    }
+[18:21:41.205] WARN: fs error
+    err: {
+      "type": "Error",
+      "message": "fs error",
+      "stack":
+          Error: fs error
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/services/files.test.ts:319:64
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:863:59
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:752:26
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1897:20
+              at new Promise (<anonymous>)
+              at runWithTimeout (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1863:10)
+              at runTest (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1574:12)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+      "code": "EPERM"
+    }
+[18:21:41.214] WARN: Couldn't save file test-file-id-123.txt
+[18:21:41.215] WARN: Error
+    err: {
+      "type": "Error",
+      "message": "Error",
+      "stack":
+          Error: Error
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/services/files.test.ts:333:64
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:752:26
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1897:20
+              at new Promise (<anonymous>)
+              at runWithTimeout (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1863:10)
+              at runTest (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1574:12)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+    }
+[18:21:41.328] WARN: Couldn't save file test-file-id-123.txt
+[18:21:41.330] WARN: fs error
+    err: {
+      "type": "Error",
+      "message": "fs error",
+      "stack":
+          Error: fs error
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/services/files.test.ts:537:62
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:752:20
+      "code": "EROFS"
+    }
+[18:21:41.370] WARN: Couldn't save file test-file-id-123.txt
+[18:21:41.371] WARN: fs error
+    err: {
+      "type": "Error",
+      "message": "fs error",
+      "stack":
+          Error: fs error
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/services/files.test.ts:537:62
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:752:20
+      "code": "EACCES"
+    }
+[18:21:41.383] WARN: Couldn't save file test-file-id-123.txt
+[18:21:41.383] WARN: fs error
+    err: {
+      "type": "Error",
+      "message": "fs error",
+      "stack":
+          Error: fs error
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/services/files.test.ts:537:62
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:752:20
+      "code": "EPERM"
+    }
+ ✓ src/services/import-export.test.ts (37 tests) 739ms
+ ✓ src/services/users.test.ts (69 tests) 1732ms
+   ✓ Integration Tests > Services / Users > requestPasswordReset > should throw ForbiddenError for external provider users  505ms
+   ✓ Integration Tests > Services / Users > requestPasswordReset > should send reset email for default provider users  502ms
+   ✓ Integration Tests > Services / Users > requestPasswordReset > should throw a ForbiddenError with a reason for inactive users  501ms
+ ✓ src/services/files.test.ts (48 tests) 1767ms
+   ✓ Service / Files > updateMany > should delete original file when remote file exists and FILES_DELETE_ORIGINAL_ON_MOVE is true  538ms
+   ✓ Service / Files > updateMany > should not delete original file when remote file exists and FILES_DELETE_ORIGINAL_ON_MOVE is false  554ms
+[18:21:44.481] WARN: "SECRET" env variable is shorter than 32 bytes which is insecure. This is not appropriate for production usage.
+[18:21:44.542] WARN: Extensions directory (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/extensions) is not readable!
+{"level":30,"time":1781713304817,"pid":3915706,"hostname":"jean-ThinkPad-X1-Carbon-6th","req":{"id":1,"method":"GET","url":"/","query":{},"params":{},"headers":{"host":"127.0.0.1:39949","connection":"keep-alive","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}},"res":{"statusCode":302,"headers":{"content-security-policy":"script-src 'self' 'unsafe-eval';worker-src 'self' blob:;child-src 'self' blob:;img-src 'self' data: blob: https://raw.githubusercontent.com https://avatars.githubusercontent.com;media-src 'self';connect-src 'self' https://* wss://*;default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';object-src 'none';script-src-attr 'none';style-src 'self' https: 'unsafe-inline'","x-powered-by":"Directus","location":"./admin","vary":"Accept","content-type":"text/plain; charset=utf-8","content-length":"29"}},"responseTime":10,"msg":"request completed"}
+[18:21:44.866] WARN: "SECRET" env variable is shorter than 32 bytes which is insecure. This is not appropriate for production usage.
+[18:21:44.868] WARN: Extensions directory (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/extensions) is not readable!
+{"level":30,"time":1781713304949,"pid":3915706,"hostname":"jean-ThinkPad-X1-Carbon-6th","req":{"id":1,"method":"GET","url":"/","query":{},"params":{},"headers":{"host":"127.0.0.1:43423","connection":"keep-alive","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}},"res":{"statusCode":302,"headers":{"content-security-policy":"script-src 'self' 'unsafe-eval';worker-src 'self' blob:;child-src 'self' blob:;img-src 'self' data: blob: https://raw.githubusercontent.com https://avatars.githubusercontent.com;media-src 'self';connect-src 'self' https://* wss://*;default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';object-src 'none';script-src-attr 'none';style-src 'self' https: 'unsafe-inline'","x-powered-by":"Directus","location":"./admin","vary":"Accept","content-type":"text/plain; charset=utf-8","content-length":"29"}},"responseTime":9,"msg":"request completed"}
+[18:21:44.961] WARN: "SECRET" env variable is shorter than 32 bytes which is insecure. This is not appropriate for production usage.
+[18:21:44.963] WARN: Extensions directory (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/extensions) is not readable!
+{"level":30,"time":1781713305003,"pid":3915706,"hostname":"jean-ThinkPad-X1-Carbon-6th","req":{"id":1,"method":"GET","url":"/robots.txt","query":{},"params":{},"headers":{"host":"127.0.0.1:37335","connection":"keep-alive","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}},"res":{"statusCode":200,"headers":{"content-security-policy":"script-src 'self' 'unsafe-eval';worker-src 'self' blob:;child-src 'self' blob:;img-src 'self' data: blob: https://raw.githubusercontent.com https://avatars.githubusercontent.com;media-src 'self';connect-src 'self' https://* wss://*;default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';object-src 'none';script-src-attr 'none';style-src 'self' https: 'unsafe-inline'","x-powered-by":"Directus","content-type":"text/plain; charset=utf-8","content-length":"25","etag":"W/\"19-2NTlN/votVlrfMtAaltZ799LfR0\""}},"responseTime":5,"msg":"request completed"}
+[18:21:45.023] WARN: "SECRET" env variable is shorter than 32 bytes which is insecure. This is not appropriate for production usage.
+[18:21:45.025] WARN: Extensions directory (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/extensions) is not readable!
+{"level":30,"time":1781713305096,"pid":3915706,"hostname":"jean-ThinkPad-X1-Carbon-6th","req":{"id":1,"method":"GET","url":"/admin","query":{},"params":{},"headers":{"host":"127.0.0.1:33973","connection":"keep-alive","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}},"res":{"statusCode":200,"headers":{"content-security-policy":"script-src 'self' 'unsafe-eval';worker-src 'self' blob:;child-src 'self' blob:;img-src 'self' data: blob: https://raw.githubusercontent.com https://avatars.githubusercontent.com;media-src 'self';connect-src 'self' https://* wss://*;default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';object-src 'none';script-src-attr 'none';style-src 'self' https: 'unsafe-inline'","x-powered-by":"Directus","cache-control":"no-cache","vary":"Origin, Cache-Control","content-type":"text/html; charset=utf-8","content-length":"3339","etag":"W/\"d0b-l/a/rH2EWro3gG4DcDUaDXRRe4w\""}},"responseTime":2,"msg":"request completed"}
+[18:21:45.116] WARN: "SECRET" env variable is shorter than 32 bytes which is insecure. This is not appropriate for production usage.
+[18:21:45.128] WARN: Extensions directory (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/extensions) is not readable!
+{"level":30,"time":1781713305222,"pid":3915706,"hostname":"jean-ThinkPad-X1-Carbon-6th","req":{"id":1,"method":"GET","url":"/admin","query":{},"params":{},"headers":{"host":"127.0.0.1:34353","connection":"keep-alive","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}},"res":{"statusCode":200,"headers":{"content-security-policy":"script-src 'self' 'unsafe-eval';worker-src 'self' blob:;child-src 'self' blob:;img-src 'self' data: blob: https://raw.githubusercontent.com https://avatars.githubusercontent.com;media-src 'self';connect-src 'self' https://* wss://*;default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';object-src 'none';script-src-attr 'none';style-src 'self' https: 'unsafe-inline'","x-powered-by":"Directus","cache-control":"no-cache","vary":"Origin, Cache-Control","content-type":"text/html; charset=utf-8","content-length":"3339","etag":"W/\"d0b-l/a/rH2EWro3gG4DcDUaDXRRe4w\""}},"responseTime":4,"msg":"request completed"}
+[18:21:45.235] WARN: "SECRET" env variable is shorter than 32 bytes which is insecure. This is not appropriate for production usage.
+[18:21:45.236] WARN: Extensions directory (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/extensions) is not readable!
+ ✓ src/services/mcp-oauth/utils/cimd-egress.test.ts (25 tests) 632ms
+{"level":30,"time":1781713305334,"pid":3915706,"hostname":"jean-ThinkPad-X1-Carbon-6th","req":{"id":1,"method":"GET","url":"/admin","query":{},"params":{},"headers":{"host":"127.0.0.1:38857","connection":"keep-alive","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}},"res":{"statusCode":200,"headers":{"content-security-policy":"script-src 'self' 'unsafe-eval';worker-src 'self' blob:;child-src 'self' blob:;img-src 'self' data: blob: https://raw.githubusercontent.com https://avatars.githubusercontent.com;media-src 'self';connect-src 'self' https://* wss://*;default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';object-src 'none';script-src-attr 'none';style-src 'self' https: 'unsafe-inline'","x-powered-by":"Directus","cache-control":"no-cache","vary":"Origin, Cache-Control","content-type":"text/html; charset=utf-8","content-length":"3363","etag":"W/\"d23-7fgmlpT4JSBzRuh+gWarCMk9tVE\""}},"responseTime":1,"msg":"request completed"}
+[18:21:45.340] WARN: "SECRET" env variable is shorter than 32 bytes which is insecure. This is not appropriate for production usage.
+[18:21:45.341] WARN: Extensions directory (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/extensions) is not readable!
+{"level":30,"time":1781713305356,"pid":3915706,"hostname":"jean-ThinkPad-X1-Carbon-6th","req":{"id":1,"method":"GET","url":"/admin","query":{},"params":{},"headers":{"host":"127.0.0.1:38705","connection":"keep-alive","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}},"res":{"statusCode":200,"headers":{"content-security-policy":"script-src 'self' 'unsafe-eval';worker-src 'self' blob:;child-src 'self' blob:;img-src 'self' data: blob: https://raw.githubusercontent.com https://avatars.githubusercontent.com;media-src 'self';connect-src 'self' https://* wss://*;default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';object-src 'none';script-src-attr 'none';style-src 'self' https: 'unsafe-inline'","x-powered-by":"Directus","cache-control":"no-cache","vary":"Origin, Cache-Control","content-type":"text/html; charset=utf-8","content-length":"3363","etag":"W/\"d23-mGTdOrixkIOuDkhzWTjx5ajR3ys\""}},"responseTime":2,"msg":"request completed"}
+[18:21:45.362] WARN: "SECRET" env variable is shorter than 32 bytes which is insecure. This is not appropriate for production usage.
+[18:21:45.363] WARN: Extensions directory (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/extensions) is not readable!
+{"level":30,"time":1781713305392,"pid":3915706,"hostname":"jean-ThinkPad-X1-Carbon-6th","req":{"id":1,"method":"GET","url":"/server/ping","query":{},"params":{},"headers":{"host":"127.0.0.1:42505","connection":"keep-alive","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}},"res":{"statusCode":200,"headers":{"content-security-policy":"script-src 'self' 'unsafe-eval';worker-src 'self' blob:;child-src 'self' blob:;img-src 'self' data: blob: https://raw.githubusercontent.com https://avatars.githubusercontent.com;media-src 'self';connect-src 'self' https://* wss://*;default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';object-src 'none';script-src-attr 'none';style-src 'self' https: 'unsafe-inline'","x-powered-by":"Directus","content-type":"text/html; charset=utf-8","content-length":"4","etag":"W/\"4-DlFKBmK8tp3IY5U9HOJuPUDoGoc\""}},"responseTime":5,"msg":"request completed"}
+[18:21:45.405] WARN: "SECRET" env variable is shorter than 32 bytes which is insecure. This is not appropriate for production usage.
+[18:21:45.406] WARN: Extensions directory (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/extensions) is not readable!
+[18:21:45.575] ERROR: (0 , __vite_ssr_import_1__.getLicenseManager)(...).isLocked is not a function
+    err: {
+      "type": "TypeError",
+      "message": "(0 , __vite_ssr_import_1__.getLicenseManager)(...).isLocked is not a function",
+      "stack":
+          TypeError: (0 , __vite_ssr_import_1__.getLicenseManager)(...).isLocked is not a function
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/middleware/is-locked.ts:12:33
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/utils/async-handler.ts:4:18
+              at Layer.handle [as handle_request] (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/express@4.21.2/node_modules/express/lib/router/layer.js:95:5)
+              at trim_prefix (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/express@4.21.2/node_modules/express/lib/router/index.js:328:13)
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/express@4.21.2/node_modules/express/lib/router/index.js:286:9
+              at Function.process_params (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/express@4.21.2/node_modules/express/lib/router/index.js:346:12)
+              at next (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/express@4.21.2/node_modules/express/lib/router/index.js:280:10)
+              at Function.handle (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/express@4.21.2/node_modules/express/lib/router/index.js:175:3)
+              at router (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/express@4.21.2/node_modules/express/lib/router/index.js:47:12)
+              at Layer.handle [as handle_request] (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/express@4.21.2/node_modules/express/lib/router/layer.js:95:5)
+    }
+{"level":30,"time":1781713305616,"pid":3915706,"hostname":"jean-ThinkPad-X1-Carbon-6th","req":{"id":1,"method":"GET","url":"/items/test","query":{},"params":{},"headers":{"host":"127.0.0.1:35605","connection":"keep-alive","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}},"res":{"statusCode":500,"headers":{"content-security-policy":"script-src 'self' 'unsafe-eval';worker-src 'self' blob:;child-src 'self' blob:;img-src 'self' data: blob: https://raw.githubusercontent.com https://avatars.githubusercontent.com;media-src 'self';connect-src 'self' https://* wss://*;default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';object-src 'none';script-src-attr 'none';style-src 'self' https: 'unsafe-inline'","x-powered-by":"Directus","content-type":"application/json; charset=utf-8","content-length":"102","etag":"W/\"66-Nud5VyBm1ylGuQBca9jYWsctOKg\""}},"err":{"type":"Error","message":"failed with status code 500","stack":"Error: failed with status code 500\n    at onResFinished (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/pino-http@10.5.0/node_modules/pino-http/logger.js:115:39)\n    at ServerResponse.onResponseComplete (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/pino-http@10.5.0/node_modules/pino-http/logger.js:178:14)\n    at ServerResponse.emit (node:events:531:35)\n    at onFinish (node:_http_outgoing:1082:10)\n    at callback (node:internal/streams/writable:766:21)\n    at afterWrite (node:internal/streams/writable:710:5)\n    at afterWriteTick (node:internal/streams/writable:696:10)\n    at processTicksAndRejections (node:internal/process/task_queues:89:21)"},"responseTime":76,"msg":"request errored"}
+[18:21:45.635] WARN: "SECRET" env variable is shorter than 32 bytes which is insecure. This is not appropriate for production usage.
+[18:21:45.636] WARN: Extensions directory (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/extensions) is not readable!
+[18:21:45.655] ERROR: Invalid MCP_OAUTH_CLEANUP_SCHEDULE: "undefined". OAuth cleanup disabled.
+[18:21:45.663] ERROR: (0 , __vite_ssr_import_1__.getLicenseManager)(...).isLocked is not a function
+    err: {
+      "type": "TypeError",
+      "message": "(0 , __vite_ssr_import_1__.getLicenseManager)(...).isLocked is not a function",
+      "stack":
+          TypeError: (0 , __vite_ssr_import_1__.getLicenseManager)(...).isLocked is not a function
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/middleware/is-locked.ts:12:33
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/utils/async-handler.ts:4:18
+              at Layer.handle [as handle_request] (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/express@4.21.2/node_modules/express/lib/router/layer.js:95:5)
+              at trim_prefix (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/express@4.21.2/node_modules/express/lib/router/index.js:328:13)
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/express@4.21.2/node_modules/express/lib/router/index.js:286:9
+              at Function.process_params (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/express@4.21.2/node_modules/express/lib/router/index.js:346:12)
+              at next (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/express@4.21.2/node_modules/express/lib/router/index.js:280:10)
+              at Function.handle (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/express@4.21.2/node_modules/express/lib/router/index.js:175:3)
+              at router (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/express@4.21.2/node_modules/express/lib/router/index.js:47:12)
+              at Layer.handle [as handle_request] (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/express@4.21.2/node_modules/express/lib/router/layer.js:95:5)
+    }
+{"level":30,"time":1781713305667,"pid":3915706,"hostname":"jean-ThinkPad-X1-Carbon-6th","req":{"id":1,"method":"GET","url":"/items/test","query":{},"params":{},"headers":{"host":"127.0.0.1:43411","connection":"keep-alive","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}},"res":{"statusCode":500,"headers":{"content-security-policy":"script-src 'self' 'unsafe-eval';worker-src 'self' blob:;child-src 'self' blob:;img-src 'self' data: blob: https://raw.githubusercontent.com https://avatars.githubusercontent.com;media-src 'self';connect-src 'self' https://* wss://*;default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';object-src 'none';script-src-attr 'none';style-src 'self' https: 'unsafe-inline'","x-powered-by":"Directus","content-type":"application/json; charset=utf-8","content-length":"102","etag":"W/\"66-Nud5VyBm1ylGuQBca9jYWsctOKg\""}},"err":{"type":"Error","message":"failed with status code 500","stack":"Error: failed with status code 500\n    at onResFinished (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/pino-http@10.5.0/node_modules/pino-http/logger.js:115:39)\n    at ServerResponse.onResponseComplete (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/pino-http@10.5.0/node_modules/pino-http/logger.js:178:14)\n    at ServerResponse.emit (node:events:531:35)\n    at onFinish (node:_http_outgoing:1082:10)\n    at callback (node:internal/streams/writable:766:21)\n    at afterWrite (node:internal/streams/writable:710:5)\n    at afterWriteTick (node:internal/streams/writable:696:10)\n    at processTicksAndRejections (node:internal/process/task_queues:89:21)"},"responseTime":8,"msg":"request errored"}
+[18:21:45.674] WARN: "SECRET" env variable is shorter than 32 bytes which is insecure. This is not appropriate for production usage.
+[18:21:45.676] WARN: Extensions directory (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/extensions) is not readable!
+{"level":30,"time":1781713305692,"pid":3915706,"hostname":"jean-ThinkPad-X1-Carbon-6th","req":{"id":1,"method":"GET","url":"/custom-endpoint-to-test","query":{},"params":{},"headers":{"host":"127.0.0.1:44217","connection":"keep-alive","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}},"res":{"statusCode":404,"headers":{"content-security-policy":"script-src 'self' 'unsafe-eval';worker-src 'self' blob:;child-src 'self' blob:;img-src 'self' data: blob: https://raw.githubusercontent.com https://avatars.githubusercontent.com;media-src 'self';connect-src 'self' https://* wss://*;default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';object-src 'none';script-src-attr 'none';style-src 'self' https: 'unsafe-inline'","x-powered-by":"Directus","content-type":"application/json; charset=utf-8","content-length":"146","etag":"W/\"92-GaU/phs+ZPfL3MRC9KeKOkipuEU\""}},"responseTime":3,"msg":"request completed"}
+[18:21:45.702] WARN: "SECRET" env variable is shorter than 32 bytes which is insecure. This is not appropriate for production usage.
+[18:21:45.704] WARN: Extensions directory (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/extensions) is not readable!
+{"level":30,"time":1781713305717,"pid":3915706,"hostname":"jean-ThinkPad-X1-Carbon-6th","req":{"id":1,"method":"GET","url":"/custom-endpoint-to-test","query":{},"params":{},"headers":{"host":"127.0.0.1:40365","connection":"keep-alive","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}},"res":{"statusCode":200,"headers":{"content-security-policy":"script-src 'self' 'unsafe-eval';worker-src 'self' blob:;child-src 'self' blob:;img-src 'self' data: blob: https://raw.githubusercontent.com https://avatars.githubusercontent.com;media-src 'self';connect-src 'self' https://* wss://*;default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';object-src 'none';script-src-attr 'none';style-src 'self' https: 'unsafe-inline'","x-powered-by":"Directus","content-type":"application/json; charset=utf-8","content-length":"15","etag":"W/\"f-IoRYCVqVAgcPwRPZlQQiam/5Cpo\""}},"responseTime":2,"msg":"request completed"}
+[18:21:45.722] WARN: "SECRET" env variable is shorter than 32 bytes which is insecure. This is not appropriate for production usage.
+[18:21:45.723] WARN: Extensions directory (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/extensions) is not readable!
+{"level":30,"time":1781713305760,"pid":3915706,"hostname":"jean-ThinkPad-X1-Carbon-6th","req":{"id":1,"method":"GET","url":"/this-route-does-not-exist","query":{},"params":{},"headers":{"host":"127.0.0.1:35451","connection":"keep-alive","accept":"*/*","accept-language":"*","sec-fetch-mode":"cors","user-agent":"node","accept-encoding":"gzip, deflate"}},"res":{"statusCode":404,"headers":{"content-security-policy":"script-src 'self' 'unsafe-eval';worker-src 'self' blob:;child-src 'self' blob:;img-src 'self' data: blob: https://raw.githubusercontent.com https://avatars.githubusercontent.com;media-src 'self';connect-src 'self' https://* wss://*;default-src 'self';base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';object-src 'none';script-src-attr 'none';style-src 'self' https: 'unsafe-inline'","x-powered-by":"Directus","content-type":"application/json; charset=utf-8","content-length":"150","etag":"W/\"96-8Hn6piYDlIZELG5/eAUTxX2kgws\""}},"responseTime":3,"msg":"request completed"}
+ ✓ src/app.test.ts (13 tests) 1352ms
+   ✓ createApp > Content Security Policy > Should set content-security-policy header by default  408ms
+[18:21:46.905] WARN: An error was thrown while executing action "test.items.create"
+[18:21:46.954] WARN: boom
+    err: {
+      "type": "Error",
+      "message": "boom",
+      "stack":
+          Error: boom
+              at EventEmitter.handler (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/services/items.test.ts:731:42)
+              at EventEmitter.emitAsync (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/eventemitter2@6.4.9/node_modules/eventemitter2/lib/eventemitter2.js:1160:36)
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/emitter.ts:78:24
+              at Array.map (<anonymous>)
+              at Emitter.emitAction (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/emitter.ts:77:11)
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/services/items.ts:54:15
+              at Array.map (<anonymous>)
+              at emitActionEvents (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/services/items.ts:51:16)
+              at ItemsService.createMany (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/services/items.ts:586:10)
+              at ItemsService.createOne (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/services/items.ts:155:24)
+    }
+ ✓ src/services/items.test.ts (49 tests) 1165ms
+18:21:48 [vite] (ssr) warning: File URL host must be "localhost" or empty on linux
+  Plugin: vite:dynamic-import-vars
+  File: /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/database/migrations/run.ts
+18:21:48 [vite] (ssr) warning: File URL host must be "localhost" or empty on linux
+  Plugin: vite:dynamic-import-vars
+  File: /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/database/migrations/run.ts
+18:21:48 [vite] (ssr) warning: File URL host must be "localhost" or empty on linux
+  Plugin: vite:dynamic-import-vars
+  File: /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/database/migrations/run.ts
+ ✓ src/operations/mail/rate-limiter.test.ts (5 tests) 552ms
+[18:21:50.857] ERROR: [Collab] Failed to initialize collaborative editing settings
+    err: {
+      "type": "Error",
+      "message": "",
+      "stack":
+          Error: 
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/websocket/collab/collab.test.ts:1026:56
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:752:26
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1897:20
+              at new Promise (<anonymous>)
+              at runWithTimeout (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1863:10)
+              at runTest (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1574:12)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+    }
+[18:21:50.857] ERROR: [Collab] Failed to initialize collaborative editing settings
+    err: {
+      "type": "Error",
+      "message": "",
+      "stack":
+          Error: 
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/websocket/collab/collab.test.ts:1026:56
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:752:26
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1897:20
+              at new Promise (<anonymous>)
+              at runWithTimeout (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1863:10)
+              at runTest (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1574:12)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+    }
+[18:21:50.956] ERROR: [Collab] Failed to initialize collaborative editing settings
+    err: {
+      "type": "Error",
+      "message": "",
+      "stack":
+          Error: 
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/websocket/collab/collab.test.ts:1026:56
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:752:26
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1897:20
+              at new Promise (<anonymous>)
+              at runWithTimeout (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1863:10)
+              at runTest (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1574:12)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+    }
+[18:21:50.956] ERROR: [Collab] Failed to initialize collaborative editing settings
+    err: {
+      "type": "Error",
+      "message": "",
+      "stack":
+          Error: 
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/websocket/collab/collab.test.ts:1026:56
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:752:26
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1897:20
+              at new Promise (<anonymous>)
+              at runWithTimeout (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1863:10)
+              at runTest (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1574:12)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+    }
+[18:21:50.976] ERROR: [Collab] Failed to initialize collaborative editing settings
+    err: {
+      "type": "Error",
+      "message": "",
+      "stack":
+          Error: 
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/websocket/collab/collab.test.ts:1026:56
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:752:26
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1897:20
+              at new Promise (<anonymous>)
+              at runWithTimeout (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1863:10)
+              at runTest (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1574:12)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+    }
+[18:21:51.035] ERROR: [Collab] Failed to initialize collaborative editing settings
+    err: {
+      "type": "Error",
+      "message": "",
+      "stack":
+          Error: 
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/websocket/collab/collab.test.ts:1026:56
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:752:26
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1897:20
+              at new Promise (<anonymous>)
+              at runWithTimeout (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1863:10)
+              at runTest (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1574:12)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+    }
+ ✓ src/websocket/collab/collab.test.ts (53 tests) 1021ms
+[18:21:54.998] INFO: Applying Remove Collection Foreign Keys...
+[18:21:55.086] INFO: Applying Remove System Relations...
+[18:21:55.157] INFO: Applying Remove Collection Foreign Keys...
+[18:21:55.170] INFO: Applying Remove Collection Foreign Keys...
+ ✓ src/database/migrations/run.test.ts (12 tests) 1764ms
+   ✓ run > when migration keys collide > throws an error listing the colliding version and its files  400ms
+   ✓ run > when migration keys collide > formats each collision as a tab-dashed line listing comma-separated files  397ms
+   ✓ run > when migration keys collide > lists every colliding version when several versions collide  367ms
+ ✓ src/services/authentication.test.ts (20 tests) 422ms
+ ✓ src/services/assets.test.ts (19 tests) 193ms
+[18:22:05.219] WARN: Failed to emit nested translation actions after generate-translations commit
+    err: {
+      "type": "Error",
+      "message": "schema refresh failed",
+      "stack":
+          Error: schema refresh failed
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/utils/generate-translations.test.ts:866:27
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:752:26
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1897:20
+              at new Promise (<anonymous>)
+              at runWithTimeout (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1863:10)
+              at runTest (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1574:12)
+              at processTicksAndRejections (node:internal/process/task_queues:105:5)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+    }
+[18:22:05.275] WARN: Failed to emit nested translation actions after generate-translations commit
+    err: {
+      "type": "Error",
+      "message": "schema refresh failed",
+      "stack":
+          Error: schema refresh failed
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/utils/generate-translations.test.ts:1097:46
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:752:26
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1897:20
+              at new Promise (<anonymous>)
+              at runWithTimeout (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1863:10)
+              at runTest (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1574:12)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+              at runFiles (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1787:3)
+    }
+ ✓ src/utils/generate-translations.test.ts (26 tests) 199ms
+ ✓ src/ai/mcp/server.test.ts (54 tests) 493ms
+ ✓ src/websocket/collab/room.test.ts (68 tests) 672ms
+ ✓ src/ai/telemetry/index.test.ts (13 tests) 338ms
+ ✓ src/auth/drivers/ldap.test.ts (62 tests) 325ms
+[18:22:16.024] WARN: [webhook:netlify] Missing webhook token
+[18:22:16.039] WARN: [webhook:netlify] Token mismatch
+ ✓ src/deployment/drivers/netlify.test.ts (47 tests) 218ms
+ ✓ src/services/payload.test.ts (53 tests) 107ms
+ ✓ src/auth/drivers/openid.test.ts (51 tests) 164ms
+ ✓ src/operations/mail/index.test.ts (7 tests) 156ms
+ ✓ src/utils/apply-diff.test.ts (20 tests) 421ms
+ ✓ src/utils/validate-query.test.ts (92 tests) 319ms
+ ✓ src/services/collections.test.ts (36 tests) 237ms
+ ✓ src/auth/drivers/oauth2.test.ts (58 tests) 330ms
+ ✓ src/ai/chat/controllers/chat.post.test.ts (21 tests) 111ms
+ ✓ src/services/deployment.test.ts (23 tests) 390ms
+ ✓ src/services/versions.test.ts (20 tests) 366ms
+ ✓ src/middleware/request-counter.test.ts (9 tests) 188ms
+ ✓ src/middleware/error-handler.test.ts (16 tests) 190ms
+ ✓ src/controllers/mcp/oauth-consent-page.test.ts (6 tests) 232ms
+ ✓ src/utils/get-snapshot-diff.test.ts (37 tests) 126ms
+ ✓ src/cli/index.test.ts (16 tests) 135ms
+ ✓ src/ai/files/controllers/upload.test.ts (21 tests) 221ms
+ ✓ src/ai/chat/lib/create-ui-stream.test.ts (16 tests) 343ms
+[18:22:38.517] ERROR: [Collab] verifyPermissions failed for user "Mock User", collection "articles", and item "1"
+    err: {
+      "type": "Error",
+      "message": "DB Error",
+      "stack":
+          Error: DB Error
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/websocket/collab/verify-permissions.test.ts:479:53
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:752:26
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1897:20
+              at new Promise (<anonymous>)
+              at runWithTimeout (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1863:10)
+              at runTest (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1574:12)
+              at processTicksAndRejections (node:internal/process/task_queues:105:5)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+    }
+[18:22:38.631] ERROR: [Collab] verifyPermissions failed for user "Mock User", collection "articles", and item "1"
+    err: {
+      "type": "Error",
+      "message": "",
+      "stack":
+          Error: 
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/websocket/collab/verify-permissions.test.ts:588:10
+              at mockCall (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+spy@3.2.6/node_modules/@vitest/spy/dist/index.js:96:15)
+              at getService (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/tinyspy@4.0.4/node_modules/tinyspy/dist/index.js:47:80)
+              at Module.verifyPermissions (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/websocket/collab/verify-permissions.ts:45:24)
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/websocket/collab/verify-permissions.test.ts:591:24
+              at processTicksAndRejections (node:internal/process/task_queues:105:5)
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:752:20
+    }
+ ✓ src/websocket/collab/verify-permissions.test.ts (22 tests) 422ms
+[18:22:44.958] ERROR: Failed to flush buffered counter for requests:get
+[18:22:44.981] ERROR: Failed to flush buffered counter for requests:get
+[18:22:45.009] ERROR: Failed to flush buffered counter for requests:get
+ ✓ src/telemetry/counter/use-buffered-counter.test.ts (48 tests) 275ms
+ ✓ src/extensions/lib/sync/sync.test.ts (18 tests) 243ms
+ ✓ src/schedules/metrics.test.ts (4 tests) 91ms
+ ✓ src/schedules/retention.test.ts (4 tests) 163ms
+ ✓ src/websocket/collab/permissions-integration.test.ts (18 tests) 74ms
+[18:22:53.892] ERROR: An error message
+    err: {
+      "type": "GraphQLError",
+      "message": "An error message",
+      "stack":
+          GraphQLError: An error message
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/services/graphql/utils/process-error.test.ts:8:22
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:734:40
+              at runWithSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1849:8)
+              at Object.collect (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:734:10)
+              at Object.collect (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:738:54)
+              at processTicksAndRejections (node:internal/process/task_queues:105:5)
+              at collectTests (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1179:25)
+              at startTests (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1817:17)
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/vitest@3.2.6_@types+node@22.13.14_@vitest+ui@3.2.6_happy-dom@20.8.9_jiti@2.6.1_jsdom@20_adb1f9f62293ec4388afdb2696b45de7/node_modules/vitest/dist/chunks/runBaseTests.9Ij9_de-.js:117:26
+              at withEnv (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/vitest@3.2.6_@types+node@22.13.14_@vitest+ui@3.2.6_happy-dom@20.8.9_jiti@2.6.1_jsdom@20_adb1f9f62293ec4388afdb2696b45de7/node_modules/vitest/dist/chunks/runBaseTests.9Ij9_de-.js:84:3)
+      "path": [
+        "test_collection"
+      ],
+      "extensions": {}
+    }
+[18:22:53.950] ERROR: An error message
+    err: {
+      "type": "GraphQLError",
+      "message": "An error message",
+      "stack":
+          GraphQLError: An error message
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/services/graphql/utils/process-error.test.ts:8:22
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:734:40
+              at runWithSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1849:8)
+              at Object.collect (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:734:10)
+              at Object.collect (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:738:54)
+              at processTicksAndRejections (node:internal/process/task_queues:105:5)
+              at collectTests (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1179:25)
+              at startTests (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1817:17)
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/vitest@3.2.6_@types+node@22.13.14_@vitest+ui@3.2.6_happy-dom@20.8.9_jiti@2.6.1_jsdom@20_adb1f9f62293ec4388afdb2696b45de7/node_modules/vitest/dist/chunks/runBaseTests.9Ij9_de-.js:117:26
+              at withEnv (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/vitest@3.2.6_@types+node@22.13.14_@vitest+ui@3.2.6_happy-dom@20.8.9_jiti@2.6.1_jsdom@20_adb1f9f62293ec4388afdb2696b45de7/node_modules/vitest/dist/chunks/runBaseTests.9Ij9_de-.js:84:3)
+      "path": [
+        "test_collection"
+      ],
+      "extensions": {}
+    }
+[18:22:53.954] ERROR: An error message
+    err: {
+      "type": "GraphQLError",
+      "message": "An error message",
+      "stack":
+          GraphQLError: An error message
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/services/graphql/utils/process-error.test.ts:8:22
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:734:40
+              at runWithSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1849:8)
+              at Object.collect (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:734:10)
+              at Object.collect (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:738:54)
+              at processTicksAndRejections (node:internal/process/task_queues:105:5)
+              at collectTests (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1179:25)
+              at startTests (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1817:17)
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/vitest@3.2.6_@types+node@22.13.14_@vitest+ui@3.2.6_happy-dom@20.8.9_jiti@2.6.1_jsdom@20_adb1f9f62293ec4388afdb2696b45de7/node_modules/vitest/dist/chunks/runBaseTests.9Ij9_de-.js:117:26
+              at withEnv (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/vitest@3.2.6_@types+node@22.13.14_@vitest+ui@3.2.6_happy-dom@20.8.9_jiti@2.6.1_jsdom@20_adb1f9f62293ec4388afdb2696b45de7/node_modules/vitest/dist/chunks/runBaseTests.9Ij9_de-.js:84:3)
+      "path": [
+        "test_collection"
+      ],
+      "extensions": {}
+    }
+[18:22:53.962] ERROR: An error message
+    err: {
+      "type": "GraphQLError",
+      "message": "An error message",
+      "stack":
+          DirectusError: Something went wrong...
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/services/graphql/utils/process-error.test.ts:45:19
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:752:26
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1897:20
+              at new Promise (<anonymous>)
+              at runWithTimeout (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1863:10)
+              at runTest (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1574:12)
+              at processTicksAndRejections (node:internal/process/task_queues:105:5)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+              at runSuite (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1729:8)
+      "path": [
+        "test_collection"
+      ],
+      "extensions": {}
+    }
+ ✓ src/services/graphql/utils/process-error.test.ts (4 tests) 265ms
+ ✓ src/ai/tools/items/index.test.ts (30 tests) 135ms
+ ✓ src/utils/apply-snapshot.test.ts (5 tests) 123ms
+ ✓ src/redis/lib/create-redis.test.ts (2 tests) 129ms
+ ✓ src/ai/chat/controllers/object.post.test.ts (20 tests) 105ms
+ ✓ src/ai/providers/options.test.ts (10 tests) 19ms
+ ✓ src/utils/get-snapshot.test.ts (17 tests) 108ms
+ ✓ src/utils/deep-freeze.test.ts (14 tests) 12ms
+[18:22:57.842] ERROR: Anthropic file support: could not parse request body
+[18:22:57.874] ERROR: Anthropic file support: could not parse request body
+ ✓ src/ai/providers/anthropic-file-support.test.ts (10 tests) 109ms
+ ✓ src/websocket/collab/payload-permissions-sanitize.test.ts (37 tests) 73ms
+ ✓ src/database/helpers/fn/json/parse-function.test.ts (115 tests) 160ms
+ ✓ src/schedules/oauth-cleanup.test.ts (4 tests) 130ms
+ ✓ src/cli/commands/schema/apply.test.ts (24 tests) 81ms
+[18:23:03.512] WARN: GraphQL skipping collection "123table" because it is not a valid name matching /^[_A-Za-z][_0-9A-Za-z]*$/ or starts with __
+[18:23:03.524] WARN: GraphQL skipping collection "__underscore" because it is not a valid name matching /^[_A-Za-z][_0-9A-Za-z]*$/ or starts with __
+[18:23:03.528] WARN: GraphQL skipping collection "a-dash" because it is not a valid name matching /^[_A-Za-z][_0-9A-Za-z]*$/ or starts with __
+[18:23:03.529] WARN: GraphQL skipping collection "Schrödinger" because it is not a valid name matching /^[_A-Za-z][_0-9A-Za-z]*$/ or starts with __
+[18:23:03.531] WARN: GraphQL skipping collection "" because it is not a valid name matching /^[_A-Za-z][_0-9A-Za-z]*$/ or starts with __
+[18:23:03.537] WARN: GraphQL skipping collection "Subscription" because it is a reserved keyword
+[18:23:03.538] WARN: GraphQL skipping collection "Mutation" because it is a reserved keyword
+[18:23:03.539] WARN: GraphQL skipping collection "String" because it is a reserved keyword
+[18:23:03.545] WARN: GraphQL skipping collection "__invalid_collection" because it is not a valid name matching /^[_A-Za-z][_0-9A-Za-z]*$/ or starts with __
+[18:23:03.547] WARN: GraphQL skipping relation "normal_collection.test" because it links to a non-existent or invalid collection.
+[18:23:03.548] WARN: GraphQL skipping relation "__invalid_collection.test" because it links to a non-existent or invalid collection.
+[18:23:03.548] WARN: GraphQL skipping relation "normal_collection.test" because it links to a non-existent or invalid collection.
+ ✓ src/services/graphql/utils/sanitize-gql-schema.test.ts (4 tests) 109ms
+ ✓ src/services/deployment-projects.test.ts (5 tests) 74ms
+ ✓ src/services/mcp-oauth/utils/redirect.test.ts (43 tests) 72ms
+ ✓ src/controllers/tus.test.ts (11 tests) 58ms
+ ✓ src/ai/telemetry/braintrust.test.ts (2 tests) 89ms
+ ✓ src/websocket/handlers/logs.test.ts (5 tests) 113ms
+ ✓ src/services/specifications.test.ts (2 tests) 80ms
+ ✓ src/database/run-ast/lib/apply-query/search.test.ts (17 tests) 64ms
+ ✓ src/utils/split-fields.test.ts (48 tests) 78ms
+ ✓ src/database/run-ast/lib/apply-query/sort.test.ts (15 tests) 93ms
+ ✓ src/websocket/handlers/subscribe.test.ts (5 tests) 93ms
+ ✓ src/redis/lib/use-redis.test.ts (2 tests) 62ms
+ ✓ src/ai/providers/registry.test.ts (16 tests) 61ms
+[18:23:13.131] WARN: File part missing providerMetadata.directus.fileId, filtering out
+[18:23:13.147] WARN: File part missing providerMetadata.directus.fileId, filtering out
+[18:23:13.150] WARN: File part missing providerMetadata.directus.fileId, filtering out
+ ✓ src/ai/chat/lib/transform-file-parts.test.ts (7 tests) 109ms
+ ✓ src/database/run-ast/lib/apply-query/filter/index.test.ts (32 tests) 141ms
+ ✓ src/services/mcp-oauth/cimd.test.ts (70 tests) 148ms
+ ✓ src/websocket/collab/payload-permissions-validate.test.ts (14 tests) 75ms
+[18:23:16.685] ERROR: test
+    err: {
+      "type": "Error",
+      "message": "test",
+      "stack":
+          Error: test
+              at Object.<anonymous> (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/services/files/utils/get-metadata.test.ts:19:9)
+              at Object.mockCall (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+spy@3.2.6/node_modules/@vitest/spy/dist/index.js:96:15)
+              at Object.spy [as metadata] (file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/tinyspy@4.0.4/node_modules/tinyspy/dist/index.js:47:80)
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/services/files/utils/get-metadata.ts:26:16
+              at new Promise (<anonymous>)
+              at Module.getMetadata (/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/services/files/utils/get-metadata.ts:23:9)
+              at /home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/src/services/files/utils/get-metadata.test.ts:26:23
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:155:11
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:752:26
+              at file:///home/jean/dev/Hippocast/dev/deps/directus-cms-2/node_modules/.pnpm/@vitest+runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js:1897:20
+    }
+ ✓ src/services/files/utils/get-metadata.test.ts (2 tests) 35ms
+ ✓ src/services/graphql/schema/parse-query.test.ts (24 tests) 40ms
+ ✓ src/websocket/collab/payload-permissions.test.ts (6 tests) 81ms
+ ✓ src/utils/get-cache-key.test.ts (28 tests) 88ms
+ ✓ src/database/helpers/capabilities/capabilities.test.ts (18 tests) 43ms
+ ✓ src/utils/validate-diff.test.ts (22 tests) 54ms
+ ✓ src/ai/files/adapters/google.test.ts (12 tests) 116ms
+ ✓ src/services/graphql/utils/dedupe-resolvers.test.ts (13 tests) 36ms
+ ✓ src/utils/md.test.ts (3 tests) 74ms
+ ✓ src/websocket/handlers/items.test.ts (11 tests) 64ms
+ ✓ src/utils/get-ip-from-req.test.ts (9 tests) 65ms
+ ✓ src/telemetry/utils/get-field-count.test.ts (3 tests) 65ms
+ ✓ src/schedules/utils/duration-to-cron.test.ts (13 tests) 97ms
+ ✓ src/ai/tools/fields/index.test.ts (34 tests) 83ms
+ ✓ src/services/roles.test.ts (6 tests) 37ms
+ ✓ src/permissions/modules/validate-access/lib/validate-item-access.test.ts (20 tests) 55ms
+ ✓ src/operations/item-read/index.test.ts (20 tests) 49ms
+ ✓ src/utils/get-accountability-for-token.test.ts (13 tests) 62ms
+ ✓ src/services/relations.test.ts (4 tests) 15ms
+ ✓ src/permissions/modules/fetch-allowed-collections/fetch-allowed-collections.test.ts (2 tests) 12ms
+ ✓ src/ai/files/adapters/openai.test.ts (10 tests) 40ms
+ ✓ src/database/helpers/schema/dialects/default.test.ts (8 tests) 46ms
+ ✓ src/websocket/collab/permissions-cache.test.ts (28 tests) 40ms
+ ✓ src/utils/is-url-allowed.test.ts (5 tests) 93ms
+ ✓ src/websocket/collab/messenger.test.ts (27 tests) 77ms
+ ✓ src/operations/throw-error/index.test.ts (6 tests) 13ms
+ ✓ src/database/run-ast/lib/apply-query/filter/operator.test.ts (15 tests) 122ms
+ ✓ src/auth/utils/resolve-login-redirect.test.ts (72 tests) 58ms
+ ✓ src/request/is-denied-ip.test.ts (10 tests) 77ms
+ ✓ src/operations/item-update/index.test.ts (20 tests) 42ms
+ ✓ src/request/agent-with-ip-validation.test.ts (7 tests) 45ms
+ ✓ src/services/meta.test.ts (22 tests) 92ms
+ ✓ src/utils/url.test.ts (30 tests) 43ms
+ ✓ src/license/utils/compute-license-status.test.ts (11 tests) 48ms
+ ✓ src/database/run-ast/lib/apply-query/pagination.test.ts (8 tests) 26ms
+ ✓ src/permissions/modules/process-ast/lib/inject-cases.test.ts (9 tests) 31ms
+ ✓ src/services/comments.test.ts (7 tests) 34ms
+ ✓ src/ai/chat/utils/chat-request-tool-to-ai-sdk-tool.test.ts (9 tests) 74ms
+ ✓ src/ai/chat/utils/format-context.test.ts (17 tests) 22ms
+ ✓ src/middleware/validate-batch.test.ts (8 tests) 37ms
+ ✓ src/ai/tools/folders/index.test.ts (15 tests) 47ms
+ ✓ src/schedules/project.test.ts (4 tests) 83ms
+ ✓ src/utils/sanitize-query.test.ts (59 tests) 62ms
+ ✓ src/utils/get-cache-headers.test.ts (13 tests) 16ms
+ ✓ src/telemetry/utils/get-filesize-sum.test.ts (3 tests) 39ms
+ ✓ src/database/run-ast/utils/get-column.test.ts (5 tests) 35ms
+ ✓ src/ai/tools/files/index.test.ts (8 tests) 27ms
+ ✓ src/operations/json-web-token/index.test.ts (12 tests) 59ms
+ ✓ src/license/utils/get-core-grace-expires-at.test.ts (5 tests) 34ms
+ ✓ src/ai/tools/collections/index.test.ts (11 tests) 47ms
+ ✓ src/operations/condition/index.test.ts (4 tests) 30ms
+ ✓ src/permissions/modules/process-ast/process-ast.test.ts (6 tests) 31ms
+ ✓ src/utils/store.test.ts (14 tests) 53ms
+ ✓ src/services/folders.test.ts (13 tests) 38ms
+ ✓ src/utils/validate-user-count-integrity.test.ts (16 tests) 34ms
+ ✓ src/utils/get-address.test.ts (4 tests) 24ms
+ ✓ src/telemetry/lib/send-report.test.ts (4 tests) 73ms
+ ✓ src/utils/get-accountability-for-role.test.ts (4 tests) 60ms
+ ✓ src/ai/tools/operations/index.test.ts (9 tests) 77ms
+ ✓ src/permissions/modules/process-payload/process-payload.test.ts (13 tests) 117ms
+ ✓ src/utils/get-allowed-log-levels.test.ts (4 tests) 12ms
+ ✓ src/utils/redact-object.test.ts (14 tests) 47ms
+ ✓ src/telemetry/utils/check-user-limits.test.ts (2 tests) 13ms
+ ✓ src/extensions/lib/installation/manager.test.ts (4 tests) 27ms
+ ✓ src/utils/is-admin.test.ts (6 tests) 13ms
+ ✓ src/ai/tools/relations/index.test.ts (10 tests) 30ms
+ ✓ src/services/graphql/schema/read.test.ts (4 tests) 44ms
+ ✓ src/telemetry/counter/use-counters.test.ts (6 tests) 46ms
+ ✓ src/storage/get-storage-driver.test.ts (2 tests) 167ms
+ ✓ src/ai/tools/schema/index.test.ts (20 tests) 151ms
+ ✓ src/utils/deep-map-response.test.ts (11 tests) 101ms
+ ✓ src/license/entitlements/lib/seats.test.ts (15 tests) 70ms
+ ✓ src/middleware/authenticate.test.ts (7 tests) 75ms
+ ✓ src/services/server.test.ts (2 tests) 31ms
+ ✓ src/ai/telemetry/langfuse.test.ts (9 tests) 68ms
+ ✓ src/services/tus/server.test.ts (2 tests) 72ms
+ ✓ src/database/run-ast/utils/merge-with-parent-items.test.ts (18 tests) 69ms
+ ✓ src/operations/sleep/index.test.ts (2 tests) 41ms
+ ✓ src/telemetry/lib/track.test.ts (4 tests) 20ms
+ ✓ src/services/assets/name-deduper.test.ts (24 tests) 74ms
+ ✓ src/schedules/tus.test.ts (2 tests) 51ms
+ ✓ src/database/get-ast-from-query/utils/get-relation.test.ts (4 tests) 46ms
+ ✓ src/websocket/utils/message.test.ts (7 tests) 73ms
+ ✓ src/database/run-ast/lib/apply-query/add-join.test.ts (7 tests) 106ms
+ ✓ src/ai/tools/utils.test.ts (15 tests) 26ms
+ ✓ src/ai/tools/assets/index.test.ts (12 tests) 94ms
+ ✓ src/license/entitlements/lib/custom-permission-rules-enabled.test.ts (22 tests) 51ms
+ ✓ src/ai/files/adapters/anthropic.test.ts (8 tests) 56ms
+ ✓ src/websocket/handlers/heartbeat.test.ts (3 tests) 43ms
+ ✓ src/websocket/utils/wait-for-message.test.ts (6 tests) 41ms
+ ✓ src/services/schema.test.ts (9 tests) 55ms
+ ✓ src/services/fields/build-collection-and-field-relations.test.ts (4 tests) 22ms
+ ✓ src/middleware/extract-token.test.ts (12 tests) 19ms
+ ✓ src/request/index.test.ts (2 tests) 27ms
+ ✓ src/database/helpers/schema/dialects/cockroachdb.test.ts (8 tests) 19ms
+ ✓ src/permissions/modules/process-ast/lib/extract-fields-from-children.test.ts (12 tests) 64ms
+ ✓ src/operations/item-create/index.test.ts (10 tests) 34ms
+ ✓ src/permissions/lib/fetch-policies.test.ts (6 tests) 32ms
+ ✓ src/operations/item-delete/index.test.ts (20 tests) 36ms
+ ✓ src/permissions/modules/process-ast/utils/flatten-filter.test.ts (13 tests | 1 skipped) 18ms
+ ✓ src/database/get-ast-from-query/lib/convert-wildcards.test.ts (20 tests) 37ms
+ ✓ src/services/mcp-oauth/utils/loopback.test.ts (10 tests) 13ms
+ ✓ src/services/graphql/utils/aggregate-query.test.ts (17 tests) 29ms
+ ✓ src/utils/is-unauthenticated.test.ts (7 tests) 10ms
+ ✓ src/ai/files/lib/fetch-provider.test.ts (4 tests) 42ms
+ ✓ src/database/get-ast-from-query/lib/parse-fields.test.ts (11 tests) 30ms
+ ✓ src/services/mcp-oauth/utils/registration-debug.test.ts (1 test) 13ms
+ ✓ src/database/run-ast/lib/apply-query/filter/validate-operator.test.ts (3 tests) 32ms
+ ✓ src/utils/stall.test.ts (6 tests) 21ms
+ ✓ src/utils/validate-keys.test.ts (10 tests) 30ms
+ ✓ src/websocket/errors.test.ts (7 tests) 47ms
+ ✓ src/database/run-ast/lib/apply-query/aggregate.test.ts (8 tests) 28ms
+ ✓ src/redis/utils/redis-config-available.test.ts (5 tests) 14ms
+ ✓ src/ai/chat/utils/parse-json-schema-7.test.ts (12 tests) 54ms
+ ✓ src/logger/redact-query.test.ts (2 tests) 37ms
+ ✓ src/database/helpers/schema/dialects/sqlite.test.ts (7 tests) 28ms
+ ✓ src/database/run-ast/utils/generate-alias.test.ts (18 tests) 26ms
+ ✓ src/ai/chat/middleware/load-settings.test.ts (8 tests) 198ms
+ ✓ src/utils/jwt.test.ts (10 tests) 31ms
+ ✓ src/services/utils.test.ts (2 tests) 35ms
+ ✓ src/storage/index.test.ts (6 tests) 17ms
+ ✓ src/utils/get-config-from-env.test.ts (6 tests) 30ms
+ ✓ src/telemetry/utils/get-item-count.test.ts (7 tests) 29ms
+ ✓ src/permissions/utils/with-cache.test.ts (7 tests) 27ms
+ ✓ src/controllers/files.test.ts (5 tests) 34ms
+ ✓ src/utils/versioning/merge-version-data.test.ts (3 tests) 16ms
+ ✓ src/database/helpers/fn/dialects/sqlite.test.ts (3 tests) 48ms
+ ✓ src/logger/logs-stream.test.ts (5 tests) 60ms
+ ✓ src/permissions/modules/validate-access/lib/validate-collection-access.test.ts (2 tests) 27ms
+ ✓ src/telemetry/lib/get-report.test.ts (9 tests) 42ms
+ ✓ src/database/get-ast-from-query/utils/get-deep-query.test.ts (4 tests) 11ms
+ ✓ src/permissions/lib/fetch-permissions.test.ts (5 tests) 75ms
+ ✓ src/websocket/utils/get-expires-at-for-token.test.ts (3 tests) 19ms
+ ✓ src/database/helpers/schema/dialects/mssql.test.ts (13 tests) 25ms
+ ✓ src/permissions/modules/process-ast/lib/field-map-from-ast.test.ts (1 test) 15ms
+ ✓ src/license/entitlements/lib/sso-enabled.test.ts (9 tests) 54ms
+ ✓ src/permissions/modules/fetch-inconsistent-field-map/fetch-inconsistent-field-map.test.ts (2 tests) 19ms
+ ✓ src/ai/files/lib/upload-to-provider.test.ts (7 tests) 61ms
+ ✓ src/cli/commands/cache/clear.test.ts (6 tests) 28ms
+ ✓ src/ai/chat/utils/fix-error-tool-calls.test.ts (15 tests) 31ms
+ ✓ src/utils/destroy-piped-stream.test.ts (1 test) 58ms
+ ✓ src/services/graphql/resolvers/query.test.ts (9 tests) 29ms
+ ✓ src/utils/extract-function-name.test.ts (8 tests) 21ms
+ ✓ src/services/files/lib/get-sharp-instance.test.ts (1 test) 15ms
+ ✓ src/utils/get-string-byte-size.test.ts (12 tests) 16ms
+ ✓ src/database/helpers/schema/dialects/oracle.test.ts (12 tests) 30ms
+ ✓ src/ai/tools/flows/index.test.ts (10 tests) 39ms
+ ✓ src/utils/transformations.test.ts (16 tests) 21ms
+ ✓ src/utils/validate-snapshot.test.ts (8 tests) 29ms
+ ✓ src/permissions/utils/get-permissions-for-share.test.ts (6 tests) 29ms
+ ✓ src/auth/utils/generate-callback-url.test.ts (9 tests) 15ms
+ ✓ src/utils/sanitize-schema.test.ts (11 tests) 22ms
+ ✓ src/storage/register-drivers.test.ts (5 tests) 59ms
+ ✓ src/middleware/mcp-oauth-guard.test.ts (17 tests) 28ms
+ ✓ src/services/permissions.test.ts (8 tests) 23ms
+ ✓ src/database/helpers/schema/types.test.ts (7 tests) 19ms
+ ✓ src/database/run-ast/lib/apply-query/get-operation.test.ts (10 tests) 19ms
+ ✓ src/permissions/modules/process-ast/utils/format-a2o-key.test.ts (1 test) 7ms
+ ✓ src/permissions/modules/process-ast/utils/extract-paths-from-query.test.ts (16 tests) 28ms
+ ✓ src/permissions/modules/process-ast/utils/validate-path/validate-path-existence.test.ts (4 tests) 15ms
+ ✓ src/services/mail/index.test.ts (6 tests) 60ms
+ ✓ src/extensions/lib/sync/utils.test.ts (13 tests) 61ms
+ ✓ src/websocket/authenticate.test.ts (10 tests) 24ms
+ ✓ src/permissions/utils/filter-policies-by-ip.test.ts (2 tests) 23ms
+ ✓ src/ai/chat/utils/prompt-caching.test.ts (13 tests) 25ms
+ ✓ src/telemetry/utils/should-check-user-limits.test.ts (4 tests) 10ms
+ ✓ src/utils/get-field-relational-depth.test.ts (9 tests) 14ms
+ ✓ src/utils/fetch-user-count/fetch-access-roles.test.ts (8 tests) 37ms
+ ✓ src/database/helpers/fn/dialects/postgres.test.ts (6 tests) 22ms
+ ✓ src/telemetry/utils/format-api-request-counts.test.ts (8 tests) 14ms
+ ✓ src/utils/is-directus-jwt.test.ts (4 tests) 22ms
+ ✓ src/database/helpers/schema/dialects/postgres.test.ts (10 tests) 21ms
+ ✓ src/database/helpers/fn/types.test.ts (3 tests) 34ms
+ ✓ src/operations/request/index.test.ts (5 tests) 20ms
+ ✓ src/services/graphql/schema/get-types.test.ts (8 tests) 22ms
+ ✓ src/utils/parse-oauth-scope.test.ts (10 tests) 29ms
+ ✓ src/database/helpers/fn/dialects/mysql.test.ts (5 tests) 48ms
+ ✓ src/database/get-ast-from-query/utils/get-allowed-sort.test.ts (8 tests) 23ms
+ ✓ src/operations/notification/index.test.ts (8 tests) 23ms
+ ✓ src/database/run-ast/lib/apply-query/join-filter-with-cases.test.ts (4 tests) 23ms
+ ✓ src/ai/tools/trigger-flow/index.test.ts (8 tests) 31ms
+ ✓ src/telemetry/utils/get-settings.test.ts (4 tests) 47ms
+ ✓ src/schedules/license.test.ts (5 tests) 26ms
+ ✓ src/permissions/modules/process-ast/lib/extract-fields-from-query.test.ts (5 tests) 18ms
+ ✓ src/utils/should-skip-cache.test.ts (12 tests) 22ms
+ ✓ src/services/fields/get-collection-relation-list.test.ts (5 tests) 19ms
+ ✓ src/utils/get-column-path.test.ts (8 tests) 14ms
+ ✓ src/database/helpers/fn/json/postgres-json-path.test.ts (22 tests) 20ms
+ ✓ src/permissions/utils/merge-fields.test.ts (26 tests) 33ms
+ ✓ src/controllers/mcp/index.test.ts (3 tests) 27ms
+ ✓ src/extensions/lib/sync/tracker.test.ts (6 tests) 40ms
+ ✓ src/storage/register-locations.test.ts (2 tests) 42ms
+ ✓ src/services/graphql/utils/replace-fragments.test.ts (7 tests) 29ms
+ ✓ src/utils/validate-env.test.ts (2 tests) 11ms
+ ✓ src/database/run-ast/lib/apply-query/normalize-filter.test.ts (17 tests) 22ms
+ ✓ src/license/entitlements/lib/collections.test.ts (6 tests) 24ms
+ ✓ src/services/extensions.test.ts (1 test) 16ms
+ ✓ src/utils/calculate-field-depth.test.ts (7 tests) 16ms
+ ✓ src/extensions/lib/sync/status.test.ts (6 tests) 19ms
+ ✓ src/deployment.test.ts (4 tests) 27ms
+ ✓ src/permissions/modules/fetch-accountability-collection-access/fetch-accountability-collection-access.test.ts (5 tests) 16ms
+ ✓ src/utils/freeze-schema.test.ts (7 tests) 15ms
+ ✓ src/services/graphql/types/json-filter.test.ts (12 tests) 17ms
+ ✓ src/ai/chat/utils/add-additional-properties-to-json-schema.test.ts (9 tests) 14ms
+ ✓ src/permissions/utils/fetch-dynamic-variable-data.test.ts (3 tests) 21ms
+ ✓ src/utils/verify-session-jwt.test.ts (4 tests) 19ms
+ ✓ src/utils/filter-items.test.ts (4 tests) 18ms
+ ✓ src/services/websocket.test.ts (4 tests) 20ms
+ ✓ src/services/graphql/utils/filter-replace-m2a.test.ts (15 tests) 50ms
+ ✓ src/lock/lib/use-lock.test.ts (5 tests) 16ms
+ ✓ src/permissions/modules/process-ast/utils/collections-in-field-map.test.ts (1 test) 8ms
+ ✓ src/operations/transform/index.test.ts (2 tests) 25ms
+ ✓ src/utils/translations-shared.test.ts (3 tests) 42ms
+ ✓ src/metrics/lib/use-metrics.test.ts (3 tests) 293ms
+ ✓ src/utils/get-collection-from-alias.test.ts (2 tests) 139ms
+ ✓ src/database/helpers/fn/dialects/oracle.test.ts (5 tests) 154ms
+ ✓ src/license/utils/is-in-core-grace-period.test.ts (3 tests) 272ms
+ ✓ src/schedules/telemetry.test.ts (6 tests) 126ms
+ ✓ src/database/run-ast/utils/apply-function-to-column-name.test.ts (7 tests) 71ms
+ ✓ src/extensions/lib/get-extensions-settings.test.ts (3 tests) 326ms
+ ✓ src/utils/get-milliseconds.test.ts (16 tests) 59ms
+ ✓ src/utils/get-auth-providers.test.ts (4 tests) 91ms
+ ✓ src/permissions/modules/fetch-allowed-field-map/fetch-allowed-field-map.test.ts (2 tests) 42ms
+ ✓ src/permissions/modules/process-ast/utils/dedupe-access.test.ts (3 tests) 57ms
+ ✓ src/services/fields/get-collection-meta-updates.test.ts (12 tests) 175ms
+ ✓ src/database/helpers/fn/dialects/mssql.test.ts (3 tests) 57ms
+ ✓ src/operations/trigger/index.test.ts (5 tests) 77ms
+ ✓ src/database/run-ast/lib/apply-query/filter/get-filter-type.test.ts (4 tests) 98ms
+ ✓ src/bus/lib/use-bus.test.ts (5 tests) 119ms
+ ✓ src/emitter.test.ts (5 tests) 106ms
+ ✓ src/database/helpers/fn/json/mysql-json-path.test.ts (20 tests) 64ms
+ ✓ src/permissions/modules/process-payload/lib/is-field-nullable.test.ts (4 tests) 33ms
+ ✓ src/telemetry/utils/get-random-wait-time.test.ts (1 test) 42ms
+ ✓ src/permissions/utils/merge-permissions.test.ts (3 tests) 51ms
+ ✓ src/utils/versioning/split-recursive.test.ts (4 tests) 67ms
+ ✓ src/permissions/modules/fetch-accountability-policy-globals/fetch-accountability-policy-globals.test.ts (2 tests) 49ms
+ ✓ src/utils/user-name.test.ts (13 tests) 46ms
+ ✓ src/license/utils/is-sso-bypass-allowed.test.ts (4 tests) 88ms
+ ✓ src/websocket/collab/filter-to-fields.test.ts (6 tests) 63ms
+ ✓ src/ai/tools/system/index.test.ts (7 tests) 110ms
+ ✓ src/utils/split-field-path.test.ts (7 tests) 70ms
+ ✓ src/database/get-ast-from-query/utils/get-related-collection.test.ts (5 tests) 60ms
+ ✓ src/utils/get-service.test.ts (2 tests) 93ms
+ ✓ src/operations/log/index.test.ts (2 tests) 69ms
+ ✓ src/utils/get-secret.test.ts (2 tests) 159ms
+ ✓ src/utils/is-field-allowed.test.ts (10 tests) 45ms
+ ✓ src/utils/permissions-cacheable.test.ts (15 tests) 86ms
+ ✓ src/utils/get-versioned-hash.test.ts (3 tests) 87ms
+ ✓ src/permissions/lib/with-app-minimal-permissions.test.ts (2 tests) 120ms
+ ✓ src/controllers/utils/handle-registry-error.test.ts (4 tests) 43ms
+ ✓ src/services/mcp-oauth/utils/domain.test.ts (7 tests) 193ms
+ ✓ src/utils/parse-filter-key.test.ts (5 tests) 46ms
+ ✓ src/ai/providers/anthropic-tool-search.test.ts (5 tests) 136ms
+ ✓ src/database/helpers/schema/utils/prep-query-params.test.ts (4 tests) 42ms
+ ✓ src/permissions/modules/process-ast/utils/get-info-for-path.test.ts (4 tests) 39ms
+ ✓ src/telemetry/utils/get-user-item-count.test.ts (3 tests) 89ms
+ ✓ src/permissions/modules/process-ast/utils/validate-path/validate-path-permissions.test.ts (4 tests) 60ms
+ ✓ src/license/entitlements/lib/custom-llms-enabled.test.ts (8 tests) 49ms
+ ✓ src/utils/is-valid-uuid.test.ts (6 tests) 41ms
+ ✓ src/utils/should-clear-cache.test.ts (8 tests) 87ms
+ ✓ src/permissions/utils/extract-required-dynamic-variable-context.test.ts (2 tests) 38ms
+ ✓ src/utils/get-graphql-query-and-variables.test.ts (2 tests) 64ms
+ ✓ src/permissions/modules/process-ast/utils/has-item-permissions.test.ts (3 tests) 75ms
+ ✓ src/permissions/modules/process-ast/utils/context-has-dynamic-variables.test.ts (2 tests) 26ms
+ ✓ src/permissions/modules/fetch-allowed-fields/fetch-allowed-fields.test.ts (2 tests) 112ms
+ ✓ src/utils/async-handler.test.ts (1 test) 54ms
+ ✓ src/permissions/modules/process-ast/utils/stringify-query-path.test.ts (1 test) 36ms
+ ✓ src/database/run-ast/lib/apply-query/get-filter-path.test.ts (4 tests) 62ms
+ ✓ src/permissions/modules/process-ast/utils/find-related-collection.test.ts (3 tests) 34ms
+ ✓ src/permissions/modules/validate-access/validate-access.test.ts (5 tests) 57ms
+ ✓ src/telemetry/utils/get-extension-count.test.ts (1 test) 35ms
+ ✓ src/services/shares.test.ts (1 test) 14ms
+ ✓ src/services/notifications.test.ts (1 test) 21ms
+ ✓ src/services/policies.test.ts (1 test) 25ms
+
+⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯
+
+ FAIL  src/utils/schedule.test.ts > scheduleSynchronizedJob > long-running scenarios (25+ days) > Should execute hourly job beyond setTimeout limit
+Error: Test timed out in 5000ms.
+If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".
+ ❯ src/utils/schedule.test.ts:58:3
+     56|   });
+     57| 
+     58|   test('Should execute hourly job beyond setTimeout limit', async () =…
+       |   ^
+     59|    const callback = vi.fn().mockResolvedValue(undefined);
+     60|    const startTime = new Date('2025-01-01T00:00:00.000Z');
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/3]⎯
+
+ FAIL  src/utils/schedule.test.ts > scheduleSynchronizedJob > long-running scenarios (25+ days) > Should execute daily job for 30 days without missing executions
+AssertionError: expected "spy" to be called 30 times, but got 25 times
+ ❯ src/utils/schedule.test.ts:99:21
+     97|    }
+     98| 
+     99|    expect(callback).toHaveBeenCalledTimes(30);
+       |                     ^
+    100|    await job.stop();
+    101|   });
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/3]⎯
+
+ FAIL  src/utils/schedule.test.ts > scheduleSynchronizedJob > CronJob execution timing > cron job fires at scheduled time
+AssertionError: expected "spy" to be called 2 times, but got 3 times
+ ❯ src/utils/schedule.test.ts:157:25
+    155|    await vi.advanceTimersByTimeAsync(60 * 1000);
+    156| 
+    157|    expect(mockCallback).toHaveBeenCalledTimes(2);
+       |                         ^
+    158| 
+    159|    vi.useRealTimers();
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/3]⎯
+
+
+ Test Files  1 failed | 354 passed (355)
+      Tests  3 failed | 4579 passed | 1 todo (4583)
+   Start at  18:20:58
+   Duration  457.17s (transform 46.76s, setup 0ms, collect 2588.89s, tests 68.49s, environment 326ms, prepare 166.15s)
+
+/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api:
+ ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @directus/api@36.0.2 test: `vitest run`
+Exit status 1

--- a/tmp/rebuild-build.log
+++ b/tmp/rebuild-build.log
@@ -1,0 +1,2710 @@
+
+> directus-monorepo@ build /home/jean/dev/Hippocast/dev/deps/directus-cms-2
+> pnpm --recursive run build
+
+Scope: 40 of 41 workspace projects
+packages/ai build$ tsdown src/index.ts --dts
+packages/constants build$ tsdown src/index.ts --dts
+packages/ai build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/constants build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/ai build: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/ai build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/ai build: [34mℹ[39m Build start
+packages/constants build: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/constants build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/constants build: [34mℹ[39m Build start
+packages/ai build: [34mℹ[39m Cleaning 2 files
+packages/constants build: [34mℹ[39m Cleaning 2 files
+packages/ai build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m    [2m7.22 kB[22m [2m│ gzip: 1.04 kB[22m
+packages/ai build: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m3.00 kB[22m [2m│ gzip: 1.02 kB[22m
+packages/ai build: [34mℹ[39m 2 files, total: 10.22 kB
+packages/ai build: [32m✔[39m Build complete in [32m417ms[39m
+packages/constants build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m    [2m6.25 kB[22m [2m│ gzip: 2.08 kB[22m
+packages/constants build: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m6.34 kB[22m [2m│ gzip: 1.91 kB[22m
+packages/constants build: [34mℹ[39m 2 files, total: 12.59 kB
+packages/constants build: [32m✔[39m Build complete in [32m427ms[39m
+packages/ai build: Done
+packages/format-title build$ pnpm run '/^bundle|typecheck$/'
+packages/constants build: Done
+packages/release-notes-generator build$ tsdown --tsconfig tsconfig.prod.json
+packages/release-notes-generator build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/release-notes-generator build: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/release-notes-generator build: [34mℹ[39m tsconfig: [34mtsconfig.prod.json[39m
+packages/release-notes-generator build: [34mℹ[39m Build start
+packages/release-notes-generator build: [34mℹ[39m Cleaning 1 files
+packages/release-notes-generator build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m  [2m13.50 kB[22m [2m│ gzip: 3.87 kB[22m
+packages/release-notes-generator build: [34mℹ[39m 1 files, total: 13.50 kB
+packages/release-notes-generator build: [32m✔[39m Build complete in [32m57ms[39m
+packages/release-notes-generator build: Done
+packages/schema build$ tsdown src/index.ts --dts
+packages/schema build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/schema build: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/schema build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/schema build: [34mℹ[39m Build start
+packages/schema build: [34mℹ[39m Cleaning 2 files
+packages/schema build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m    [2m66.43 kB[22m [2m│ gzip: 13.48 kB[22m
+packages/schema build: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m 2.85 kB[22m [2m│ gzip:  0.81 kB[22m
+packages/schema build: [34mℹ[39m 2 files, total: 69.28 kB
+packages/schema build: [32m✔[39m Build complete in [32m365ms[39m
+packages/schema build: Done
+packages/specs build$ swagger-cli bundle src/openapi.yaml -o dist/openapi.json
+packages/format-title build: . bundle$ tsdown src/index.ts --dts
+packages/format-title build: . typecheck$ tsc --noEmit
+packages/format-title build: . bundle: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/format-title build: . bundle: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/format-title build: . bundle: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/format-title build: . bundle: [34mℹ[39m Build start
+packages/format-title build: . bundle: [34mℹ[39m Cleaning 2 files
+packages/specs build: Created dist/openapi.json from src/openapi.yaml
+packages/specs build: Done
+packages/stores build$ tsdown src/index.ts --dts
+packages/format-title build: . bundle: [34mℹ[39m [2mdist/[22m[1mindex.js[22m    [2m3.94 kB[22m [2m│ gzip: 1.46 kB[22m
+packages/format-title build: . bundle: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m0.16 kB[22m [2m│ gzip: 0.14 kB[22m
+packages/format-title build: . bundle: [34mℹ[39m 2 files, total: 4.10 kB
+packages/format-title build: . bundle: [32m✔[39m Build complete in [32m349ms[39m
+packages/format-title build: . bundle: Done
+packages/stores build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/stores build: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/stores build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/stores build: [34mℹ[39m Build start
+packages/stores build: [34mℹ[39m Cleaning 2 files
+packages/format-title build: . typecheck: Done
+packages/format-title build: Done
+packages/system-data build$ NODE_ENV=production tsdown
+packages/stores build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m    [2m0.42 kB[22m [2m│ gzip: 0.27 kB[22m
+packages/stores build: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m1.27 kB[22m [2m│ gzip: 0.33 kB[22m
+packages/stores build: [34mℹ[39m 2 files, total: 1.70 kB
+packages/stores build: [32m✔[39m Build complete in [32m2616ms[39m
+packages/stores build: Done
+packages/update-check build$ pnpm run '/^bundle|typecheck$/'
+packages/system-data build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/system-data build: [34mℹ[39m Using tsdown config: [4m/home/jean/dev/Hippocast/dev/deps/directus-cms-2/packages/system-data/tsdown.config.ts[24m
+packages/system-data build: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/system-data build: [34mℹ[39m target: [34mes2020[39m
+packages/system-data build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/system-data build: [34mℹ[39m Build start
+packages/system-data build: [34mℹ[39m Cleaning 4 files
+packages/system-data build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m  [2m70.42 kB[22m [2m│ gzip: 10.88 kB[22m
+packages/system-data build: [34mℹ[39m [33m[CJS][39m 1 files, total: 70.42 kB
+packages/update-check build: . bundle$ tsdown src/index.ts --dts
+packages/update-check build: . typecheck$ tsc --noEmit
+packages/system-data build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m    [2m70.15 kB[22m [2m│ gzip: 10.72 kB[22m
+packages/system-data build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m 5.60 kB[22m [2m│ gzip:  1.38 kB[22m
+packages/system-data build: [34mℹ[39m [34m[ESM][39m 2 files, total: 75.75 kB
+packages/system-data build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m  [2m5.60 kB[22m [2m│ gzip: 1.38 kB[22m
+packages/system-data build: [34mℹ[39m [33m[CJS][39m 1 files, total: 5.60 kB
+packages/system-data build: [32m✔[39m Build complete in [32m800ms[39m
+packages/system-data build: Done
+packages/update-check build: . bundle: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/update-check build: . bundle: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/update-check build: . bundle: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/update-check build: . bundle: [34mℹ[39m Build start
+packages/update-check build: . bundle: [34mℹ[39m Cleaning 2 files
+packages/update-check build: . bundle: [34mℹ[39m [2mdist/[22m[1mindex.js[22m    [2m2.94 kB[22m [2m│ gzip: 1.19 kB[22m
+packages/update-check build: . bundle: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m0.13 kB[22m [2m│ gzip: 0.13 kB[22m
+packages/update-check build: . bundle: [34mℹ[39m 2 files, total: 3.07 kB
+packages/update-check build: . bundle: [32m✔[39m Build complete in [32m272ms[39m
+packages/update-check build: . bundle: Done
+packages/update-check build: . typecheck: Done
+packages/update-check build: Done
+packages/types build$ tsdown --dts
+sdk build$ NODE_ENV=production tsdown
+packages/types build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+sdk build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/types build: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/types build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/types build: [34mℹ[39m Build start
+packages/types build: [34mℹ[39m Cleaning 2 files
+sdk build: [34mℹ[39m Using tsdown config: [4m/home/jean/dev/Hippocast/dev/deps/directus-cms-2/sdk/tsdown.config.ts[24m
+sdk build: [34mℹ[39m entry: [34msrc/index.ts[39m
+sdk build: [34mℹ[39m target: [34mes2022[39m
+sdk build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+sdk build: [34mℹ[39m Build start
+sdk build: [34mℹ[39m Cleaning 1003 files
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m                                    [2m17.87 kB[22m [2m│ gzip: 3.08 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrealtime/composable.cjs.map                  [2m21.95 kB[22m [2m│ gzip: 6.07 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mauth/composable.cjs.map                      [2m 9.25 kB[22m [2m│ gzip: 2.60 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/deployment.cjs.map        [2m 8.82 kB[22m [2m│ gzip: 1.78 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mutils/query-to-params.cjs.map                [2m 5.76 kB[22m [2m│ gzip: 1.72 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrealtime/composable.cjs                      [2m 5.70 kB[22m [2m│ gzip: 2.17 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/index.cjs                               [2m 5.66 kB[22m [2m│ gzip: 0.90 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/items.cjs.map           [2m 5.16 kB[22m [2m│ gzip: 1.27 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/assets.cjs.map            [2m 4.69 kB[22m [2m│ gzip: 1.15 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/extensions.cjs.map        [2m 4.36 kB[22m [2m│ gzip: 1.18 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/index.cjs                      [2m 4.24 kB[22m [2m│ gzip: 0.79 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/utils/users.cjs.map            [2m 4.10 kB[22m [2m│ gzip: 1.23 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/composable.cjs.map                      [2m 3.95 kB[22m [2m│ gzip: 1.43 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/users.cjs.map           [2m 3.69 kB[22m [2m│ gzip: 0.94 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/permissions.cjs.map       [2m 3.55 kB[22m [2m│ gzip: 1.17 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/comments.cjs.map        [2m 3.47 kB[22m [2m│ gzip: 1.05 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/utils/versions.cjs.map         [2m 3.21 kB[22m [2m│ gzip: 1.05 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/files.cjs.map           [2m 3.21 kB[22m [2m│ gzip: 0.99 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/notifications.cjs.map   [2m 3.06 kB[22m [2m│ gzip: 0.86 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/translations.cjs.map    [2m 3.05 kB[22m [2m│ gzip: 0.87 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/permissions.cjs.map     [2m 3.03 kB[22m [2m│ gzip: 0.87 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/versions.cjs.map        [2m 3.02 kB[22m [2m│ gzip: 0.85 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/items.cjs.map             [2m 3.02 kB[22m [2m│ gzip: 0.92 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/items.cjs.map           [2m 2.97 kB[22m [2m│ gzip: 0.86 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/dashboards.cjs.map      [2m 2.96 kB[22m [2m│ gzip: 0.86 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/operations.cjs.map      [2m 2.96 kB[22m [2m│ gzip: 0.86 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/policies.cjs.map        [2m 2.90 kB[22m [2m│ gzip: 0.87 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/folders.cjs.map         [2m 2.89 kB[22m [2m│ gzip: 0.86 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/presets.cjs.map         [2m 2.88 kB[22m [2m│ gzip: 0.86 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/items.cjs.map           [2m 2.84 kB[22m [2m│ gzip: 0.95 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/panels.cjs.map          [2m 2.83 kB[22m [2m│ gzip: 0.85 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/shares.cjs.map          [2m 2.83 kB[22m [2m│ gzip: 0.85 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/flows.cjs.map           [2m 2.80 kB[22m [2m│ gzip: 0.84 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/roles.cjs.map           [2m 2.80 kB[22m [2m│ gzip: 0.84 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mgraphql/composable.cjs.map                   [2m 2.67 kB[22m [2m│ gzip: 1.14 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/fields.cjs.map          [2m 2.51 kB[22m [2m│ gzip: 0.82 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/deployment.cjs.map      [2m 2.50 kB[22m [2m│ gzip: 0.89 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/roles.cjs.map             [2m 2.34 kB[22m [2m│ gzip: 0.83 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/users.cjs.map             [2m 2.34 kB[22m [2m│ gzip: 0.83 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/utils/shares.cjs.map           [2m 2.33 kB[22m [2m│ gzip: 0.99 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/utils/deployment.cjs.map       [2m 2.33 kB[22m [2m│ gzip: 0.90 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/policies.cjs.map          [2m 2.26 kB[22m [2m│ gzip: 0.89 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrealtime/utils/message-callback.cjs.map      [2m 2.26 kB[22m [2m│ gzip: 0.92 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mauth/composable.cjs                          [2m 2.25 kB[22m [2m│ gzip: 0.86 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mutils/request.cjs.map                        [2m 2.20 kB[22m [2m│ gzip: 0.95 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/collections.cjs.map     [2m 2.18 kB[22m [2m│ gzip: 0.80 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/relations.cjs.map         [2m 2.16 kB[22m [2m│ gzip: 0.76 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/fields.cjs.map            [2m 2.10 kB[22m [2m│ gzip: 0.72 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/files.cjs.map           [2m 2.00 kB[22m [2m│ gzip: 0.78 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/notifications.cjs.map   [2m 1.99 kB[22m [2m│ gzip: 0.64 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/translations.cjs.map      [2m 1.98 kB[22m [2m│ gzip: 0.79 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/notifications.cjs.map     [2m 1.97 kB[22m [2m│ gzip: 0.78 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/versions.cjs.map          [2m 1.97 kB[22m [2m│ gzip: 0.78 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/versions.cjs.map        [2m 1.97 kB[22m [2m│ gzip: 0.64 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/translations.cjs.map    [2m 1.96 kB[22m [2m│ gzip: 0.64 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/permissions.cjs.map     [2m 1.96 kB[22m [2m│ gzip: 0.65 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/operations.cjs.map        [2m 1.94 kB[22m [2m│ gzip: 0.77 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/revisions.cjs.map         [2m 1.92 kB[22m [2m│ gzip: 0.78 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/activity.cjs.map          [2m 1.92 kB[22m [2m│ gzip: 0.77 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/dashboards.cjs.map        [2m 1.91 kB[22m [2m│ gzip: 0.77 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/operations.cjs.map      [2m 1.91 kB[22m [2m│ gzip: 0.63 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/dashboards.cjs.map      [2m 1.91 kB[22m [2m│ gzip: 0.64 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mutils/format-fields.cjs.map                  [2m 1.90 kB[22m [2m│ gzip: 0.77 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/comments.cjs.map          [2m 1.90 kB[22m [2m│ gzip: 0.78 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/comments.cjs.map        [2m 1.89 kB[22m [2m│ gzip: 0.76 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/folders.cjs.map           [2m 1.88 kB[22m [2m│ gzip: 0.78 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/presets.cjs.map           [2m 1.88 kB[22m [2m│ gzip: 0.78 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/singleton.cjs.map       [2m 1.88 kB[22m [2m│ gzip: 0.81 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/folders.cjs.map         [2m 1.88 kB[22m [2m│ gzip: 0.64 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/comments.cjs.map        [2m 1.87 kB[22m [2m│ gzip: 0.63 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/shares.cjs.map            [2m 1.86 kB[22m [2m│ gzip: 0.78 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/policies.cjs.map        [2m 1.85 kB[22m [2m│ gzip: 0.65 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/files.cjs.map             [2m 1.84 kB[22m [2m│ gzip: 0.78 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/presets.cjs.map         [2m 1.84 kB[22m [2m│ gzip: 0.63 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/panels.cjs.map            [2m 1.84 kB[22m [2m│ gzip: 0.77 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/shares.cjs.map          [2m 1.82 kB[22m [2m│ gzip: 0.63 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/flows.cjs.map             [2m 1.82 kB[22m [2m│ gzip: 0.77 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/panels.cjs.map          [2m 1.82 kB[22m [2m│ gzip: 0.63 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mutils/extract-data.cjs.map                   [2m 1.80 kB[22m [2m│ gzip: 0.80 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/roles.cjs.map           [2m 1.80 kB[22m [2m│ gzip: 0.63 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/users.cjs.map           [2m 1.80 kB[22m [2m│ gzip: 0.64 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/aggregate.cjs.map         [2m 1.79 kB[22m [2m│ gzip: 0.79 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/flows.cjs.map           [2m 1.79 kB[22m [2m│ gzip: 0.63 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/singleton.cjs.map         [2m 1.71 kB[22m [2m│ gzip: 0.76 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/extensions.cjs.map      [2m 1.70 kB[22m [2m│ gzip: 0.72 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mutils/get-request-url.cjs.map                [2m 1.68 kB[22m [2m│ gzip: 0.82 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/server/info.cjs.map            [2m 1.65 kB[22m [2m│ gzip: 0.65 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/relations.cjs.map       [2m 1.60 kB[22m [2m│ gzip: 0.70 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/auth/login.cjs.map             [2m 1.60 kB[22m [2m│ gzip: 0.68 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mutils/query-to-params.cjs                    [2m 1.50 kB[22m [2m│ gzip: 0.62 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/deployment.cjs            [2m 1.44 kB[22m [2m│ gzip: 0.34 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/collections.cjs.map       [2m 1.41 kB[22m [2m│ gzip: 0.61 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mclient.cjs.map                               [2m 1.39 kB[22m [2m│ gzip: 0.67 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/collections.cjs.map     [2m 1.36 kB[22m [2m│ gzip: 0.66 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/translations.cjs.map    [2m 1.33 kB[22m [2m│ gzip: 0.56 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/fields.cjs.map          [2m 1.33 kB[22m [2m│ gzip: 0.64 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/permissions.cjs.map     [2m 1.33 kB[22m [2m│ gzip: 0.56 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/notifications.cjs.map   [2m 1.32 kB[22m [2m│ gzip: 0.55 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/extensions.cjs.map      [2m 1.32 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/dashboards.cjs.map      [2m 1.29 kB[22m [2m│ gzip: 0.55 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/versions.cjs.map        [2m 1.29 kB[22m [2m│ gzip: 0.54 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/operations.cjs.map      [2m 1.28 kB[22m [2m│ gzip: 0.54 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/policies.cjs.map        [2m 1.27 kB[22m [2m│ gzip: 0.56 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/presets.cjs.map         [2m 1.27 kB[22m [2m│ gzip: 0.56 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/users.cjs.map           [2m 1.27 kB[22m [2m│ gzip: 0.56 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/shares.cjs.map          [2m 1.25 kB[22m [2m│ gzip: 0.56 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/folders.cjs.map         [2m 1.25 kB[22m [2m│ gzip: 0.54 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/roles.cjs.map           [2m 1.24 kB[22m [2m│ gzip: 0.55 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/panels.cjs.map          [2m 1.24 kB[22m [2m│ gzip: 0.54 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/deployment.cjs.map      [2m 1.23 kB[22m [2m│ gzip: 0.58 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/flows.cjs.map           [2m 1.22 kB[22m [2m│ gzip: 0.54 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/files.cjs.map           [2m 1.22 kB[22m [2m│ gzip: 0.54 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/schema/diff.cjs.map            [2m 1.20 kB[22m [2m│ gzip: 0.65 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/auth/refresh.cjs.map           [2m 1.14 kB[22m [2m│ gzip: 0.58 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/settings.cjs.map        [2m 1.12 kB[22m [2m│ gzip: 0.55 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/assets.cjs                [2m 1.10 kB[22m [2m│ gzip: 0.38 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/items.cjs               [2m 1.09 kB[22m [2m│ gzip: 0.40 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/auth/logout.cjs.map            [2m 1.07 kB[22m [2m│ gzip: 0.57 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/extensions.cjs.map      [2m 1.04 kB[22m [2m│ gzip: 0.55 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/utils/hash.cjs.map             [2m 1.04 kB[22m [2m│ gzip: 0.49 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/relations.cjs.map       [2m 1.03 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/fields.cjs.map          [2m 1.03 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/helpers/with-search.cjs.map             [2m 1.01 kB[22m [2m│ gzip: 0.54 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/helpers/with-options.cjs.map            [2m 1.01 kB[22m [2m│ gzip: 0.51 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/relations.cjs.map       [2m 1.00 kB[22m [2m│ gzip: 0.51 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/utils/export.cjs.map           [2m 1.00 kB[22m [2m│ gzip: 0.56 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/settings.cjs.map          [2m 0.99 kB[22m [2m│ gzip: 0.49 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/utils/flows.cjs.map            [2m 0.96 kB[22m [2m│ gzip: 0.54 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mauth/static.cjs.map                          [2m 0.94 kB[22m [2m│ gzip: 0.47 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/auth/password-request.cjs.map  [2m 0.92 kB[22m [2m│ gzip: 0.55 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/schema/apply.cjs.map           [2m 0.92 kB[22m [2m│ gzip: 0.56 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/composable.cjs                          [2m 0.90 kB[22m [2m│ gzip: 0.47 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/utils/users.cjs                [2m 0.90 kB[22m [2m│ gzip: 0.35 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/auth/password-reset.cjs.map    [2m 0.90 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mutils/error.cjs.map                          [2m 0.86 kB[22m [2m│ gzip: 0.47 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/utils/sort.cjs.map             [2m 0.82 kB[22m [2m│ gzip: 0.49 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/schema/snapshot.cjs.map        [2m 0.79 kB[22m [2m│ gzip: 0.47 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/index.cjs                 [2m 0.79 kB[22m [2m│ gzip: 0.25 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/items.cjs               [2m 0.78 kB[22m [2m│ gzip: 0.35 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mutils/is-directus-error.cjs.map              [2m 0.78 kB[22m [2m│ gzip: 0.44 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/deployment.cjs.map      [2m 0.76 kB[22m [2m│ gzip: 0.46 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/utils/is-system-collection.cjs          [2m 0.76 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/server/health.cjs.map          [2m 0.73 kB[22m [2m│ gzip: 0.42 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/auth/providers.cjs.map         [2m 0.70 kB[22m [2m│ gzip: 0.42 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mauth/utils/memory-storage.cjs.map            [2m 0.70 kB[22m [2m│ gzip: 0.37 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mutils/is-response.cjs.map                    [2m 0.69 kB[22m [2m│ gzip: 0.39 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/helpers/with-token.cjs.map              [2m 0.68 kB[22m [2m│ gzip: 0.41 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/utils/import.cjs.map           [2m 0.67 kB[22m [2m│ gzip: 0.45 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/comments.cjs            [2m 0.66 kB[22m [2m│ gzip: 0.33 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/utils/throw-core-collection.cjs.map     [2m 0.64 kB[22m [2m│ gzip: 0.40 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/utils/random.cjs.map           [2m 0.64 kB[22m [2m│ gzip: 0.41 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/files.cjs               [2m 0.63 kB[22m [2m│ gzip: 0.33 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mgraphql/composable.cjs                       [2m 0.62 kB[22m [2m│ gzip: 0.41 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/collections.cjs.map     [2m 0.61 kB[22m [2m│ gzip: 0.36 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/items.cjs               [2m 0.61 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/users.cjs               [2m 0.61 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/items.cjs                 [2m 0.60 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/server/openapi.cjs.map         [2m 0.60 kB[22m [2m│ gzip: 0.40 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/server/graphql.cjs.map         [2m 0.59 kB[22m [2m│ gzip: 0.40 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mutils/request.cjs                            [2m 0.59 kB[22m [2m│ gzip: 0.34 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrealtime/commands/auth.cjs.map               [2m 0.58 kB[22m [2m│ gzip: 0.32 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/utils/cache.cjs.map            [2m 0.58 kB[22m [2m│ gzip: 0.40 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mutils/extract-data.cjs                       [2m 0.57 kB[22m [2m│ gzip: 0.34 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/translations.cjs        [2m 0.56 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/notifications.cjs       [2m 0.56 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/extensions.cjs            [2m 0.56 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/permissions.cjs           [2m 0.56 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/utils/versions.cjs             [2m 0.56 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/permissions.cjs         [2m 0.56 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/versions.cjs            [2m 0.55 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/dashboards.cjs          [2m 0.54 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/operations.cjs          [2m 0.54 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/policies.cjs            [2m 0.53 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/presets.cjs             [2m 0.53 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/folders.cjs             [2m 0.52 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/panels.cjs              [2m 0.51 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/shares.cjs              [2m 0.51 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/utils/deployment.cjs           [2m 0.51 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrealtime/utils/message-callback.cjs          [2m 0.51 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/flows.cjs               [2m 0.51 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/roles.cjs               [2m 0.51 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mutils/get-request-url.cjs                    [2m 0.49 kB[22m [2m│ gzip: 0.34 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/utils/is-system-collection.cjs.map      [2m 0.49 kB[22m [2m│ gzip: 0.34 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/utils/throw-if-empty.cjs.map            [2m 0.48 kB[22m [2m│ gzip: 0.33 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/comments.cjs            [2m 0.47 kB[22m [2m│ gzip: 0.29 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/utils/get-auth-endpoint.cjs.map         [2m 0.47 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/fields.cjs              [2m 0.45 kB[22m [2m│ gzip: 0.26 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/aggregate.cjs             [2m 0.44 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/fields.cjs                [2m 0.44 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrealtime/utils/generate-uid.cjs.map          [2m 0.44 kB[22m [2m│ gzip: 0.32 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/extensions.cjs          [2m 0.43 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/deployment.cjs          [2m 0.43 kB[22m [2m│ gzip: 0.25 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/server/ping.cjs.map            [2m 0.42 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/helpers/custom-endpoint.cjs.map         [2m 0.42 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mutils/format-fields.cjs                      [2m 0.41 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/relations.cjs             [2m 0.41 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrealtime/utils/sleep.cjs.map                 [2m 0.39 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/singleton.cjs           [2m 0.39 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/utils/shares.cjs               [2m 0.39 kB[22m [2m│ gzip: 0.25 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/policies.cjs              [2m 0.38 kB[22m [2m│ gzip: 0.24 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/collections.cjs         [2m 0.38 kB[22m [2m│ gzip: 0.25 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/translations.cjs        [2m 0.37 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/roles.cjs                 [2m 0.36 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/notifications.cjs       [2m 0.36 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/permissions.cjs         [2m 0.36 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/users.cjs                 [2m 0.36 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/extensions.cjs          [2m 0.36 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/singleton.cjs             [2m 0.36 kB[22m [2m│ gzip: 0.25 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/versions.cjs            [2m 0.35 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/dashboards.cjs          [2m 0.35 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/operations.cjs          [2m 0.35 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/policies.cjs            [2m 0.34 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/presets.cjs             [2m 0.34 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/shares.cjs              [2m 0.34 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/folders.cjs             [2m 0.33 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/roles.cjs               [2m 0.33 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/users.cjs               [2m 0.33 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/extensions.cjs          [2m 0.33 kB[22m [2m│ gzip: 0.24 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/panels.cjs              [2m 0.33 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/notifications.cjs         [2m 0.33 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/files.cjs               [2m 0.32 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/flows.cjs               [2m 0.32 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/translations.cjs          [2m 0.32 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/versions.cjs              [2m 0.32 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/dashboards.cjs            [2m 0.31 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/operations.cjs            [2m 0.31 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/helpers/with-search.cjs                 [2m 0.31 kB[22m [2m│ gzip: 0.25 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/revisions.cjs             [2m 0.31 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/activity.cjs              [2m 0.30 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/files.cjs               [2m 0.30 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/relations.cjs           [2m 0.30 kB[22m [2m│ gzip: 0.24 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/comments.cjs              [2m 0.30 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/folders.cjs               [2m 0.30 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/presets.cjs               [2m 0.30 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mclient.cjs                                   [2m 0.29 kB[22m [2m│ gzip: 0.21 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/panels.cjs                [2m 0.29 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/shares.cjs                [2m 0.29 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/collections.cjs           [2m 0.29 kB[22m [2m│ gzip: 0.20 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/files.cjs                 [2m 0.29 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/flows.cjs                 [2m 0.29 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/notifications.cjs       [2m 0.29 kB[22m [2m│ gzip: 0.17 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/translations.cjs        [2m 0.28 kB[22m [2m│ gzip: 0.17 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/auth/login.cjs                 [2m 0.28 kB[22m [2m│ gzip: 0.24 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/permissions.cjs         [2m 0.28 kB[22m [2m│ gzip: 0.17 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/versions.cjs            [2m 0.28 kB[22m [2m│ gzip: 0.17 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/dashboards.cjs          [2m 0.27 kB[22m [2m│ gzip: 0.17 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/operations.cjs          [2m 0.27 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/utils/hash.cjs                 [2m 0.27 kB[22m [2m│ gzip: 0.18 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/relations.cjs           [2m 0.26 kB[22m [2m│ gzip: 0.21 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/comments.cjs            [2m 0.26 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/policies.cjs            [2m 0.26 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/folders.cjs             [2m 0.26 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/presets.cjs             [2m 0.26 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/fields.cjs              [2m 0.26 kB[22m [2m│ gzip: 0.20 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/panels.cjs              [2m 0.25 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/shares.cjs              [2m 0.25 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/flows.cjs               [2m 0.25 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/roles.cjs               [2m 0.25 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/users.cjs               [2m 0.25 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrealtime/commands/pong.cjs.map               [2m 0.24 kB[22m [2m│ gzip: 0.20 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mutils/is-directus-error.cjs                  [2m 0.24 kB[22m [2m│ gzip: 0.18 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/auth/refresh.cjs               [2m 0.24 kB[22m [2m│ gzip: 0.20 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/auth/logout.cjs                [2m 0.24 kB[22m [2m│ gzip: 0.20 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mutils/error.cjs                              [2m 0.23 kB[22m [2m│ gzip: 0.18 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/deployment.cjs          [2m 0.22 kB[22m [2m│ gzip: 0.19 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mutils/is-response.cjs                        [2m 0.22 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/utils/flows.cjs                [2m 0.21 kB[22m [2m│ gzip: 0.18 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/auth/password-request.cjs      [2m 0.19 kB[22m [2m│ gzip: 0.17 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/utils/throw-core-collection.cjs         [2m 0.19 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/auth/password-reset.cjs        [2m 0.17 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/utils/import.cjs               [2m 0.17 kB[22m [2m│ gzip: 0.17 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/helpers/with-options.cjs                [2m 0.17 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/server/graphql.cjs             [2m 0.17 kB[22m [2m│ gzip: 0.15 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/utils/export.cjs               [2m 0.17 kB[22m [2m│ gzip: 0.17 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/helpers/with-token.cjs                  [2m 0.17 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/schema/apply.cjs               [2m 0.16 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/collections.cjs         [2m 0.16 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/deployment.cjs          [2m 0.16 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/schema/diff.cjs                [2m 0.16 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/update/settings.cjs            [2m 0.15 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/utils/sort.cjs                 [2m 0.15 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/fields.cjs              [2m 0.15 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/utils/random.cjs               [2m 0.15 kB[22m [2m│ gzip: 0.15 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mauth/static.cjs                              [2m 0.15 kB[22m [2m│ gzip: 0.14 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/create/relations.cjs           [2m 0.14 kB[22m [2m│ gzip: 0.14 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/utils/cache.cjs                [2m 0.14 kB[22m [2m│ gzip: 0.14 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mauth/utils/memory-storage.cjs                [2m 0.14 kB[22m [2m│ gzip: 0.13 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/auth/providers.cjs             [2m 0.14 kB[22m [2m│ gzip: 0.14 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/utils/get-auth-endpoint.cjs             [2m 0.13 kB[22m [2m│ gzip: 0.13 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/delete/collections.cjs         [2m 0.13 kB[22m [2m│ gzip: 0.13 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/read/settings.cjs              [2m 0.12 kB[22m [2m│ gzip: 0.13 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/server/openapi.cjs             [2m 0.12 kB[22m [2m│ gzip: 0.13 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/schema/snapshot.cjs            [2m 0.12 kB[22m [2m│ gzip: 0.12 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/utils/throw-if-empty.cjs                [2m 0.12 kB[22m [2m│ gzip: 0.13 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/server/health.cjs              [2m 0.11 kB[22m [2m│ gzip: 0.12 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrealtime/utils/generate-uid.cjs              [2m 0.11 kB[22m [2m│ gzip: 0.12 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/server/info.cjs                [2m 0.11 kB[22m [2m│ gzip: 0.12 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/commands/server/ping.cjs                [2m 0.11 kB[22m [2m│ gzip: 0.12 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrealtime/commands/auth.cjs                   [2m 0.10 kB[22m [2m│ gzip: 0.12 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mauth/index.cjs                               [2m 0.10 kB[22m [2m│ gzip: 0.09 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrest/helpers/custom-endpoint.cjs             [2m 0.10 kB[22m [2m│ gzip: 0.11 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrealtime/utils/sleep.cjs                     [2m 0.09 kB[22m [2m│ gzip: 0.11 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mrealtime/commands/pong.cjs                   [2m 0.09 kB[22m [2m│ gzip: 0.11 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m 303 files, total: 388.70 kB
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m                                [2m27.75 kB[22m [2m│ gzip: 4.69 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/deployment.d.cts[39m        [2m 5.98 kB[22m [2m│ gzip: 1.36 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mtypes/functions.d.cts[39m                      [2m 5.65 kB[22m [2m│ gzip: 1.78 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mtypes/output.d.cts[39m                         [2m 4.47 kB[22m [2m│ gzip: 1.34 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mtypes/aggregate.d.cts[39m                      [2m 3.87 kB[22m [2m│ gzip: 1.05 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/extensions.d.cts[39m        [2m 3.67 kB[22m [2m│ gzip: 0.94 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mtypes/filters.d.cts[39m                        [2m 3.67 kB[22m [2m│ gzip: 0.98 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrealtime/types.d.cts[39m                       [2m 3.66 kB[22m [2m│ gzip: 1.12 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mtypes/fields.d.cts[39m                         [2m 3.63 kB[22m [2m│ gzip: 1.11 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mtypes/query.d.cts[39m                          [2m 3.45 kB[22m [2m│ gzip: 1.11 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mtypes/schema.d.cts[39m                         [2m 3.30 kB[22m [2m│ gzip: 0.92 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/update/items.d.cts[39m           [2m 2.80 kB[22m [2m│ gzip: 0.66 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/settings.d.cts[39m                      [2m 2.64 kB[22m [2m│ gzip: 0.83 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mtypes/utils.d.cts[39m                          [2m 2.63 kB[22m [2m│ gzip: 0.97 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/permissions.d.cts[39m       [2m 2.59 kB[22m [2m│ gzip: 0.81 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/update/users.d.cts[39m           [2m 2.43 kB[22m [2m│ gzip: 0.59 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/utils/users.d.cts[39m            [2m 2.42 kB[22m [2m│ gzip: 0.82 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mauth/types.d.cts[39m                           [2m 2.24 kB[22m [2m│ gzip: 0.76 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/utils/versions.d.cts[39m         [2m 2.13 kB[22m [2m│ gzip: 0.74 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/core.d.cts[39m                          [2m 2.08 kB[22m [2m│ gzip: 0.51 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/field.d.cts[39m                         [2m 2.07 kB[22m [2m│ gzip: 0.69 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/update/notifications.d.cts[39m   [2m 2.06 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/update/versions.d.cts[39m        [2m 2.05 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/update/translations.d.cts[39m    [2m 2.03 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/update/permissions.d.cts[39m     [2m 2.01 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/update/comments.d.cts[39m        [2m 1.98 kB[22m [2m│ gzip: 0.54 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/update/dashboards.d.cts[39m      [2m 1.96 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/update/operations.d.cts[39m      [2m 1.96 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/assets.d.cts[39m            [2m 1.91 kB[22m [2m│ gzip: 0.60 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/create/items.d.cts[39m           [2m 1.91 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/update/folders.d.cts[39m         [2m 1.89 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/items.d.cts[39m             [2m 1.89 kB[22m [2m│ gzip: 0.58 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/update/policies.d.cts[39m        [2m 1.88 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/update/presets.d.cts[39m         [2m 1.86 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/update/files.d.cts[39m           [2m 1.85 kB[22m [2m│ gzip: 0.56 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/update/panels.d.cts[39m          [2m 1.83 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/update/shares.d.cts[39m          [2m 1.83 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/update/deployment.d.cts[39m      [2m 1.80 kB[22m [2m│ gzip: 0.62 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/update/flows.d.cts[39m           [2m 1.80 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/update/roles.d.cts[39m           [2m 1.80 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/roles.d.cts[39m             [2m 1.64 kB[22m [2m│ gzip: 0.57 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/policies.d.cts[39m          [2m 1.63 kB[22m [2m│ gzip: 0.63 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/users.d.cts[39m             [2m 1.62 kB[22m [2m│ gzip: 0.56 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/deployment.d.cts[39m                    [2m 1.61 kB[22m [2m│ gzip: 0.51 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/update/fields.d.cts[39m          [2m 1.60 kB[22m [2m│ gzip: 0.51 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/utils/shares.d.cts[39m           [2m 1.58 kB[22m [2m│ gzip: 0.68 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/update/collections.d.cts[39m     [2m 1.55 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/create/notifications.d.cts[39m   [2m 1.55 kB[22m [2m│ gzip: 0.46 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/create/versions.d.cts[39m        [2m 1.55 kB[22m [2m│ gzip: 0.47 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/create/translations.d.cts[39m    [2m 1.52 kB[22m [2m│ gzip: 0.46 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/create/permissions.d.cts[39m     [2m 1.52 kB[22m [2m│ gzip: 0.47 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/relations.d.cts[39m         [2m 1.50 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/create/operations.d.cts[39m      [2m 1.47 kB[22m [2m│ gzip: 0.45 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/create/dashboards.d.cts[39m      [2m 1.47 kB[22m [2m│ gzip: 0.46 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/versions.d.cts[39m          [2m 1.46 kB[22m [2m│ gzip: 0.54 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/translations.d.cts[39m      [2m 1.45 kB[22m [2m│ gzip: 0.54 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/notifications.d.cts[39m     [2m 1.44 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/create/folders.d.cts[39m         [2m 1.43 kB[22m [2m│ gzip: 0.46 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/create/files.d.cts[39m           [2m 1.43 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/create/comments.d.cts[39m        [2m 1.43 kB[22m [2m│ gzip: 0.46 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/create/policies.d.cts[39m        [2m 1.41 kB[22m [2m│ gzip: 0.47 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/operations.d.cts[39m        [2m 1.41 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/create/presets.d.cts[39m         [2m 1.40 kB[22m [2m│ gzip: 0.45 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/revisions.d.cts[39m         [2m 1.39 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/activity.d.cts[39m          [2m 1.38 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/dashboards.d.cts[39m        [2m 1.38 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/create/shares.d.cts[39m          [2m 1.38 kB[22m [2m│ gzip: 0.46 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/utils/deployment.d.cts[39m       [2m 1.38 kB[22m [2m│ gzip: 0.54 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/create/panels.d.cts[39m          [2m 1.37 kB[22m [2m│ gzip: 0.45 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/comments.d.cts[39m          [2m 1.36 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/collection.d.cts[39m                    [2m 1.36 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/create/roles.d.cts[39m           [2m 1.35 kB[22m [2m│ gzip: 0.46 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/create/users.d.cts[39m           [2m 1.35 kB[22m [2m│ gzip: 0.46 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/folders.d.cts[39m           [2m 1.34 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/presets.d.cts[39m           [2m 1.34 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/create/flows.d.cts[39m           [2m 1.34 kB[22m [2m│ gzip: 0.46 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/shares.d.cts[39m            [2m 1.32 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/fields.d.cts[39m            [2m 1.31 kB[22m [2m│ gzip: 0.47 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/update/singleton.d.cts[39m       [2m 1.31 kB[22m [2m│ gzip: 0.51 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/user.d.cts[39m                          [2m 1.31 kB[22m [2m│ gzip: 0.48 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/files.d.cts[39m             [2m 1.31 kB[22m [2m│ gzip: 0.54 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/server/info.d.cts[39m            [2m 1.30 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/panels.d.cts[39m            [2m 1.30 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/flows.d.cts[39m             [2m 1.28 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/singleton.d.cts[39m         [2m 1.21 kB[22m [2m│ gzip: 0.49 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/delete/items.d.cts[39m           [2m 1.18 kB[22m [2m│ gzip: 0.42 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/create/collections.d.cts[39m     [2m 1.16 kB[22m [2m│ gzip: 0.49 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/update/relations.d.cts[39m       [2m 1.09 kB[22m [2m│ gzip: 0.43 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/create/fields.d.cts[39m          [2m 1.08 kB[22m [2m│ gzip: 0.46 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/create/deployment.d.cts[39m      [2m 1.03 kB[22m [2m│ gzip: 0.42 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/file.d.cts[39m                          [2m 1.03 kB[22m [2m│ gzip: 0.41 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mtypes/globals.d.cts[39m                        [2m 1.01 kB[22m [2m│ gzip: 0.49 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/collections.d.cts[39m       [2m 0.97 kB[22m [2m│ gzip: 0.41 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/relation.d.cts[39m                      [2m 0.94 kB[22m [2m│ gzip: 0.36 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/update/extensions.d.cts[39m      [2m 0.94 kB[22m [2m│ gzip: 0.42 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/update/settings.d.cts[39m        [2m 0.92 kB[22m [2m│ gzip: 0.39 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mtypes/deep.d.cts[39m                           [2m 0.91 kB[22m [2m│ gzip: 0.42 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/schema/diff.d.cts[39m            [2m 0.88 kB[22m [2m│ gzip: 0.47 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/create/relations.d.cts[39m       [2m 0.83 kB[22m [2m│ gzip: 0.38 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/aggregate.d.cts[39m         [2m 0.82 kB[22m [2m│ gzip: 0.39 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/read/settings.d.cts[39m          [2m 0.82 kB[22m [2m│ gzip: 0.37 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/delete/comments.d.cts[39m        [2m 0.81 kB[22m [2m│ gzip: 0.35 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/delete/extensions.d.cts[39m      [2m 0.78 kB[22m [2m│ gzip: 0.34 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/operation.d.cts[39m                     [2m 0.77 kB[22m [2m│ gzip: 0.34 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/preset.d.cts[39m                        [2m 0.77 kB[22m [2m│ gzip: 0.33 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/panel.d.cts[39m                         [2m 0.75 kB[22m [2m│ gzip: 0.35 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/extension.d.cts[39m                     [2m 0.75 kB[22m [2m│ gzip: 0.37 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mtypes/client.d.cts[39m                         [2m 0.75 kB[22m [2m│ gzip: 0.38 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/delete/notifications.d.cts[39m   [2m 0.73 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/delete/translations.d.cts[39m    [2m 0.72 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/version.d.cts[39m                       [2m 0.72 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/delete/permissions.d.cts[39m     [2m 0.72 kB[22m [2m│ gzip: 0.32 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/delete/versions.d.cts[39m        [2m 0.72 kB[22m [2m│ gzip: 0.32 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/auth/login.d.cts[39m             [2m 0.71 kB[22m [2m│ gzip: 0.33 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/flow.d.cts[39m                          [2m 0.71 kB[22m [2m│ gzip: 0.33 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/share.d.cts[39m                         [2m 0.71 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/delete/dashboards.d.cts[39m      [2m 0.70 kB[22m [2m│ gzip: 0.32 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/delete/operations.d.cts[39m      [2m 0.70 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mtypes/assets.d.cts[39m                         [2m 0.69 kB[22m [2m│ gzip: 0.40 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/policy.d.cts[39m                        [2m 0.68 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/utils/export.d.cts[39m           [2m 0.68 kB[22m [2m│ gzip: 0.39 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mtypes/request.d.cts[39m                        [2m 0.66 kB[22m [2m│ gzip: 0.34 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/delete/policies.d.cts[39m        [2m 0.66 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/delete/folders.d.cts[39m         [2m 0.66 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/delete/presets.d.cts[39m         [2m 0.66 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/delete/users.d.cts[39m           [2m 0.66 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mgraphql/types.d.cts[39m                        [2m 0.65 kB[22m [2m│ gzip: 0.33 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/delete/panels.d.cts[39m          [2m 0.65 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/delete/shares.d.cts[39m          [2m 0.65 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/revision.d.cts[39m                      [2m 0.65 kB[22m [2m│ gzip: 0.29 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/auth/password-reset.d.cts[39m    [2m 0.64 kB[22m [2m│ gzip: 0.37 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/activity.d.cts[39m                      [2m 0.64 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/delete/flows.d.cts[39m           [2m 0.64 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/delete/roles.d.cts[39m           [2m 0.64 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/delete/files.d.cts[39m           [2m 0.64 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/comment.d.cts[39m                       [2m 0.64 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/schema/snapshot.d.cts[39m        [2m 0.63 kB[22m [2m│ gzip: 0.36 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mauth/composable.d.cts[39m                      [2m 0.62 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/schema/apply.d.cts[39m           [2m 0.62 kB[22m [2m│ gzip: 0.39 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/auth/password-request.d.cts[39m  [2m 0.61 kB[22m [2m│ gzip: 0.36 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/utils/hash.d.cts[39m             [2m 0.60 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/role.d.cts[39m                          [2m 0.60 kB[22m [2m│ gzip: 0.29 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/notification.d.cts[39m                  [2m 0.59 kB[22m [2m│ gzip: 0.29 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/server/health.d.cts[39m          [2m 0.59 kB[22m [2m│ gzip: 0.33 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/permission.d.cts[39m                    [2m 0.58 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/delete/relations.d.cts[39m       [2m 0.57 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/delete/fields.d.cts[39m          [2m 0.57 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/types.d.cts[39m                           [2m 0.55 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/access.d.cts[39m                        [2m 0.54 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/utils/sort.d.cts[39m             [2m 0.54 kB[22m [2m│ gzip: 0.32 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/create/extensions.d.cts[39m      [2m 0.52 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrealtime/composable.d.cts[39m                  [2m 0.52 kB[22m [2m│ gzip: 0.29 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/auth/providers.d.cts[39m         [2m 0.52 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/auth/refresh.d.cts[39m           [2m 0.52 kB[22m [2m│ gzip: 0.29 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mclient.d.cts[39m                               [2m 0.51 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/helpers/with-options.d.cts[39m            [2m 0.51 kB[22m [2m│ gzip: 0.29 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/dashboard.d.cts[39m                     [2m 0.50 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mauth/static.d.cts[39m                          [2m 0.49 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrealtime/utils/message-callback.d.cts[39m      [2m 0.48 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mutils/query-to-params.d.cts[39m                [2m 0.46 kB[22m [2m│ gzip: 0.29 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mgraphql/composable.d.cts[39m                   [2m 0.46 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/auth/logout.d.cts[39m            [2m 0.45 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/server/openapi.d.cts[39m         [2m 0.44 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/delete/collections.d.cts[39m     [2m 0.44 kB[22m [2m│ gzip: 0.25 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/composable.d.cts[39m                      [2m 0.44 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/delete/deployment.d.cts[39m      [2m 0.43 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrealtime/commands/auth.d.cts[39m               [2m 0.42 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/utils/flows.d.cts[39m            [2m 0.41 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/utils/random.d.cts[39m           [2m 0.39 kB[22m [2m│ gzip: 0.25 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/utils/import.d.cts[39m           [2m 0.37 kB[22m [2m│ gzip: 0.26 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mtypes/error.d.cts[39m                          [2m 0.37 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/utils/throw-core-collection.d.cts[39m     [2m 0.37 kB[22m [2m│ gzip: 0.24 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/utils/cache.d.cts[39m            [2m 0.36 kB[22m [2m│ gzip: 0.26 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/server/graphql.d.cts[39m         [2m 0.36 kB[22m [2m│ gzip: 0.26 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/translation.d.cts[39m                   [2m 0.35 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mutils/is-directus-error.d.cts[39m              [2m 0.34 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/helpers/custom-endpoint.d.cts[39m         [2m 0.34 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mschema/folder.d.cts[39m                        [2m 0.34 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mauth/utils/memory-storage.d.cts[39m            [2m 0.32 kB[22m [2m│ gzip: 0.21 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/utils/throw-if-empty.d.cts[39m            [2m 0.32 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/utils/get-auth-endpoint.d.cts[39m         [2m 0.32 kB[22m [2m│ gzip: 0.21 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/helpers/with-token.d.cts[39m              [2m 0.29 kB[22m [2m│ gzip: 0.20 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/helpers/with-search.d.cts[39m             [2m 0.28 kB[22m [2m│ gzip: 0.19 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrest/commands/server/ping.d.cts[39m            [2m 0.28 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrealtime/utils/generate-uid.d.cts[39m          [2m 0.27 kB[22m [2m│ gzip: 0.20 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrealtime/utils/sleep.d.cts[39m                 [2m 0.25 kB[22m [2m│ gzip: 0.20 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mutils/format-fields.d.cts[39m                  [2m 0.20 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mrealtime/commands/pong.d.cts[39m               [2m 0.14 kB[22m [2m│ gzip: 0.13 kB[22m
+sdk build: [34mℹ[39m [33m[CJS][39m 188 files, total: 256.37 kB
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m                                    [2m17.93 kB[22m [2m│ gzip: 3.86 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrealtime/composable.js.map                  [2m21.82 kB[22m [2m│ gzip: 6.01 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/index.js                               [2m10.84 kB[22m [2m│ gzip: 2.30 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/index.js                      [2m 9.29 kB[22m [2m│ gzip: 2.11 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mauth/composable.js.map                      [2m 9.14 kB[22m [2m│ gzip: 2.56 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/deployment.js.map        [2m 8.77 kB[22m [2m│ gzip: 1.78 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils/query-to-params.js.map                [2m 5.74 kB[22m [2m│ gzip: 1.71 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrealtime/composable.js                      [2m 5.67 kB[22m [2m│ gzip: 2.18 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/items.js.map           [2m 5.11 kB[22m [2m│ gzip: 1.27 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/assets.js.map            [2m 4.67 kB[22m [2m│ gzip: 1.15 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/extensions.js.map        [2m 4.35 kB[22m [2m│ gzip: 1.18 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/utils/users.js.map            [2m 4.10 kB[22m [2m│ gzip: 1.22 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/composable.js.map                      [2m 3.91 kB[22m [2m│ gzip: 1.41 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/users.js.map           [2m 3.69 kB[22m [2m│ gzip: 0.94 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/permissions.js.map       [2m 3.55 kB[22m [2m│ gzip: 1.17 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/comments.js.map        [2m 3.46 kB[22m [2m│ gzip: 1.04 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/files.js.map           [2m 3.20 kB[22m [2m│ gzip: 0.99 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/utils/versions.js.map         [2m 3.20 kB[22m [2m│ gzip: 1.05 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/notifications.js.map   [2m 3.06 kB[22m [2m│ gzip: 0.86 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/translations.js.map    [2m 3.04 kB[22m [2m│ gzip: 0.87 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/permissions.js.map     [2m 3.02 kB[22m [2m│ gzip: 0.88 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/versions.js.map        [2m 3.01 kB[22m [2m│ gzip: 0.85 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/items.js.map             [2m 2.99 kB[22m [2m│ gzip: 0.92 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/dashboards.js.map      [2m 2.96 kB[22m [2m│ gzip: 0.86 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/operations.js.map      [2m 2.96 kB[22m [2m│ gzip: 0.86 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/items.js.map           [2m 2.95 kB[22m [2m│ gzip: 0.86 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/policies.js.map        [2m 2.89 kB[22m [2m│ gzip: 0.87 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/folders.js.map         [2m 2.89 kB[22m [2m│ gzip: 0.86 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/presets.js.map         [2m 2.88 kB[22m [2m│ gzip: 0.86 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/panels.js.map          [2m 2.83 kB[22m [2m│ gzip: 0.85 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/shares.js.map          [2m 2.83 kB[22m [2m│ gzip: 0.85 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/items.js.map           [2m 2.81 kB[22m [2m│ gzip: 0.95 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/flows.js.map           [2m 2.80 kB[22m [2m│ gzip: 0.85 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/roles.js.map           [2m 2.80 kB[22m [2m│ gzip: 0.84 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mgraphql/composable.js.map                   [2m 2.63 kB[22m [2m│ gzip: 1.12 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/deployment.js.map      [2m 2.50 kB[22m [2m│ gzip: 0.89 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/fields.js.map          [2m 2.50 kB[22m [2m│ gzip: 0.82 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/roles.js.map             [2m 2.34 kB[22m [2m│ gzip: 0.83 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/users.js.map             [2m 2.33 kB[22m [2m│ gzip: 0.83 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/utils/shares.js.map           [2m 2.33 kB[22m [2m│ gzip: 0.99 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/utils/deployment.js.map       [2m 2.31 kB[22m [2m│ gzip: 0.90 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/policies.js.map          [2m 2.26 kB[22m [2m│ gzip: 0.89 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrealtime/utils/message-callback.js.map      [2m 2.25 kB[22m [2m│ gzip: 0.92 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mauth/composable.js                          [2m 2.23 kB[22m [2m│ gzip: 0.87 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/index.js                 [2m 2.19 kB[22m [2m│ gzip: 0.66 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/collections.js.map     [2m 2.18 kB[22m [2m│ gzip: 0.80 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils/request.js.map                        [2m 2.16 kB[22m [2m│ gzip: 0.93 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/relations.js.map         [2m 2.16 kB[22m [2m│ gzip: 0.76 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/fields.js.map            [2m 2.09 kB[22m [2m│ gzip: 0.72 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/files.js.map           [2m 2.00 kB[22m [2m│ gzip: 0.78 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/notifications.js.map   [2m 1.99 kB[22m [2m│ gzip: 0.64 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/translations.js.map      [2m 1.98 kB[22m [2m│ gzip: 0.79 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/notifications.js.map     [2m 1.97 kB[22m [2m│ gzip: 0.78 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/versions.js.map          [2m 1.97 kB[22m [2m│ gzip: 0.78 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/versions.js.map        [2m 1.97 kB[22m [2m│ gzip: 0.64 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/translations.js.map    [2m 1.96 kB[22m [2m│ gzip: 0.64 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/permissions.js.map     [2m 1.96 kB[22m [2m│ gzip: 0.65 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/operations.js.map        [2m 1.94 kB[22m [2m│ gzip: 0.78 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/revisions.js.map         [2m 1.92 kB[22m [2m│ gzip: 0.78 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/activity.js.map          [2m 1.91 kB[22m [2m│ gzip: 0.78 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/dashboards.js.map        [2m 1.91 kB[22m [2m│ gzip: 0.77 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/operations.js.map      [2m 1.91 kB[22m [2m│ gzip: 0.63 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/dashboards.js.map      [2m 1.91 kB[22m [2m│ gzip: 0.64 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils/format-fields.js.map                  [2m 1.90 kB[22m [2m│ gzip: 0.77 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/comments.js.map          [2m 1.90 kB[22m [2m│ gzip: 0.78 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/folders.js.map           [2m 1.88 kB[22m [2m│ gzip: 0.78 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/presets.js.map           [2m 1.88 kB[22m [2m│ gzip: 0.78 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/comments.js.map        [2m 1.88 kB[22m [2m│ gzip: 0.76 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/folders.js.map         [2m 1.88 kB[22m [2m│ gzip: 0.64 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/singleton.js.map       [2m 1.87 kB[22m [2m│ gzip: 0.81 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/comments.js.map        [2m 1.86 kB[22m [2m│ gzip: 0.63 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/shares.js.map            [2m 1.85 kB[22m [2m│ gzip: 0.78 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/policies.js.map        [2m 1.85 kB[22m [2m│ gzip: 0.65 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/files.js.map             [2m 1.84 kB[22m [2m│ gzip: 0.78 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/presets.js.map         [2m 1.84 kB[22m [2m│ gzip: 0.63 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/panels.js.map            [2m 1.84 kB[22m [2m│ gzip: 0.77 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/shares.js.map          [2m 1.82 kB[22m [2m│ gzip: 0.63 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/flows.js.map             [2m 1.82 kB[22m [2m│ gzip: 0.77 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/panels.js.map          [2m 1.82 kB[22m [2m│ gzip: 0.63 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/roles.js.map           [2m 1.79 kB[22m [2m│ gzip: 0.63 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/users.js.map           [2m 1.79 kB[22m [2m│ gzip: 0.64 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/flows.js.map           [2m 1.79 kB[22m [2m│ gzip: 0.63 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils/extract-data.js.map                   [2m 1.78 kB[22m [2m│ gzip: 0.79 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/aggregate.js.map         [2m 1.76 kB[22m [2m│ gzip: 0.79 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/singleton.js.map         [2m 1.70 kB[22m [2m│ gzip: 0.75 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/extensions.js.map      [2m 1.70 kB[22m [2m│ gzip: 0.72 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils/get-request-url.js.map                [2m 1.66 kB[22m [2m│ gzip: 0.81 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/server/info.js.map            [2m 1.65 kB[22m [2m│ gzip: 0.65 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/relations.js.map       [2m 1.60 kB[22m [2m│ gzip: 0.70 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/auth/login.js.map             [2m 1.57 kB[22m [2m│ gzip: 0.67 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils/query-to-params.js                    [2m 1.50 kB[22m [2m│ gzip: 0.63 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/collections.js.map       [2m 1.41 kB[22m [2m│ gzip: 0.61 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mclient.js.map                               [2m 1.39 kB[22m [2m│ gzip: 0.67 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/collections.js.map     [2m 1.36 kB[22m [2m│ gzip: 0.66 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/fields.js.map          [2m 1.33 kB[22m [2m│ gzip: 0.63 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/translations.js.map    [2m 1.32 kB[22m [2m│ gzip: 0.56 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/permissions.js.map     [2m 1.32 kB[22m [2m│ gzip: 0.56 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/notifications.js.map   [2m 1.32 kB[22m [2m│ gzip: 0.55 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/extensions.js.map      [2m 1.31 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/dashboards.js.map      [2m 1.28 kB[22m [2m│ gzip: 0.55 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/versions.js.map        [2m 1.28 kB[22m [2m│ gzip: 0.54 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/deployment.js            [2m 1.28 kB[22m [2m│ gzip: 0.34 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/operations.js.map      [2m 1.28 kB[22m [2m│ gzip: 0.54 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/policies.js.map        [2m 1.26 kB[22m [2m│ gzip: 0.56 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/presets.js.map         [2m 1.26 kB[22m [2m│ gzip: 0.56 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/users.js.map           [2m 1.26 kB[22m [2m│ gzip: 0.56 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/shares.js.map          [2m 1.25 kB[22m [2m│ gzip: 0.55 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/folders.js.map         [2m 1.24 kB[22m [2m│ gzip: 0.54 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/roles.js.map           [2m 1.24 kB[22m [2m│ gzip: 0.55 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/deployment.js.map      [2m 1.23 kB[22m [2m│ gzip: 0.58 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/panels.js.map          [2m 1.23 kB[22m [2m│ gzip: 0.54 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/flows.js.map           [2m 1.22 kB[22m [2m│ gzip: 0.54 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/files.js.map           [2m 1.22 kB[22m [2m│ gzip: 0.54 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/schema/diff.js.map            [2m 1.20 kB[22m [2m│ gzip: 0.65 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/auth/refresh.js.map           [2m 1.14 kB[22m [2m│ gzip: 0.58 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/settings.js.map        [2m 1.12 kB[22m [2m│ gzip: 0.55 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/auth/logout.js.map            [2m 1.07 kB[22m [2m│ gzip: 0.57 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/utils/hash.js.map             [2m 1.04 kB[22m [2m│ gzip: 0.49 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/extensions.js.map      [2m 1.04 kB[22m [2m│ gzip: 0.55 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/assets.js                [2m 1.03 kB[22m [2m│ gzip: 0.38 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/relations.js.map       [2m 1.03 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/fields.js.map          [2m 1.02 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/helpers/with-options.js.map            [2m 1.01 kB[22m [2m│ gzip: 0.51 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/relations.js.map       [2m 1.00 kB[22m [2m│ gzip: 0.51 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/utils/export.js.map           [2m 1.00 kB[22m [2m│ gzip: 0.56 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/settings.js.map          [2m 0.99 kB[22m [2m│ gzip: 0.49 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/helpers/with-search.js.map             [2m 0.99 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/items.js               [2m 0.98 kB[22m [2m│ gzip: 0.41 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/utils/flows.js.map            [2m 0.96 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mauth/static.js.map                          [2m 0.94 kB[22m [2m│ gzip: 0.47 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/auth/password-request.js.map  [2m 0.92 kB[22m [2m│ gzip: 0.55 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/schema/apply.js.map           [2m 0.92 kB[22m [2m│ gzip: 0.56 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/composable.js                          [2m 0.91 kB[22m [2m│ gzip: 0.48 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/auth/password-reset.js.map    [2m 0.89 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/utils/users.js                [2m 0.87 kB[22m [2m│ gzip: 0.35 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils/error.js.map                          [2m 0.86 kB[22m [2m│ gzip: 0.47 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/utils/sort.js.map             [2m 0.81 kB[22m [2m│ gzip: 0.49 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/schema/snapshot.js.map        [2m 0.79 kB[22m [2m│ gzip: 0.47 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils/is-directus-error.js.map              [2m 0.78 kB[22m [2m│ gzip: 0.44 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/utils/is-system-collection.js          [2m 0.76 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/deployment.js.map      [2m 0.76 kB[22m [2m│ gzip: 0.46 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/server/health.js.map          [2m 0.73 kB[22m [2m│ gzip: 0.42 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/items.js               [2m 0.71 kB[22m [2m│ gzip: 0.36 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/auth/providers.js.map         [2m 0.70 kB[22m [2m│ gzip: 0.42 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mauth/utils/memory-storage.js.map            [2m 0.69 kB[22m [2m│ gzip: 0.37 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils/is-response.js.map                    [2m 0.69 kB[22m [2m│ gzip: 0.39 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/helpers/with-token.js.map              [2m 0.68 kB[22m [2m│ gzip: 0.41 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/utils/import.js.map           [2m 0.67 kB[22m [2m│ gzip: 0.45 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/utils/random.js.map           [2m 0.64 kB[22m [2m│ gzip: 0.41 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mgraphql/composable.js                       [2m 0.63 kB[22m [2m│ gzip: 0.42 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/comments.js            [2m 0.63 kB[22m [2m│ gzip: 0.34 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/utils/throw-core-collection.js.map     [2m 0.62 kB[22m [2m│ gzip: 0.39 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/files.js               [2m 0.61 kB[22m [2m│ gzip: 0.33 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/collections.js.map     [2m 0.61 kB[22m [2m│ gzip: 0.36 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/server/openapi.js.map         [2m 0.60 kB[22m [2m│ gzip: 0.40 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils/request.js                            [2m 0.60 kB[22m [2m│ gzip: 0.35 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/server/graphql.js.map         [2m 0.59 kB[22m [2m│ gzip: 0.40 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/users.js               [2m 0.59 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/items.js               [2m 0.58 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrealtime/commands/auth.js.map               [2m 0.58 kB[22m [2m│ gzip: 0.32 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/utils/cache.js.map            [2m 0.58 kB[22m [2m│ gzip: 0.40 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils/extract-data.js                       [2m 0.57 kB[22m [2m│ gzip: 0.34 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/items.js                 [2m 0.56 kB[22m [2m│ gzip: 0.29 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/translations.js        [2m 0.55 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/notifications.js       [2m 0.54 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/extensions.js            [2m 0.54 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/permissions.js         [2m 0.54 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/permissions.js           [2m 0.54 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/versions.js            [2m 0.53 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/utils/versions.js             [2m 0.53 kB[22m [2m│ gzip: 0.29 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/dashboards.js          [2m 0.52 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/operations.js          [2m 0.52 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/policies.js            [2m 0.52 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/presets.js             [2m 0.51 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrealtime/utils/message-callback.js          [2m 0.51 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/folders.js             [2m 0.50 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/panels.js              [2m 0.49 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/shares.js              [2m 0.49 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/flows.js               [2m 0.49 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/roles.js               [2m 0.49 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils/get-request-url.js                    [2m 0.49 kB[22m [2m│ gzip: 0.35 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/utils/is-system-collection.js.map      [2m 0.48 kB[22m [2m│ gzip: 0.33 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/utils/throw-if-empty.js.map            [2m 0.48 kB[22m [2m│ gzip: 0.33 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/utils/deployment.js           [2m 0.47 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/utils/get-auth-endpoint.js.map         [2m 0.47 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/comments.js            [2m 0.45 kB[22m [2m│ gzip: 0.29 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/aggregate.js             [2m 0.44 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrealtime/utils/generate-uid.js.map          [2m 0.44 kB[22m [2m│ gzip: 0.32 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/fields.js              [2m 0.42 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/server/ping.js.map            [2m 0.42 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/helpers/custom-endpoint.js.map         [2m 0.42 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/extensions.js          [2m 0.42 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils/format-fields.js                      [2m 0.42 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/deployment.js          [2m 0.41 kB[22m [2m│ gzip: 0.25 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/fields.js                [2m 0.41 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/singleton.js           [2m 0.40 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/relations.js             [2m 0.40 kB[22m [2m│ gzip: 0.24 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrealtime/utils/sleep.js.map                 [2m 0.39 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/collections.js         [2m 0.38 kB[22m [2m│ gzip: 0.25 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/policies.js              [2m 0.38 kB[22m [2m│ gzip: 0.25 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/utils/shares.js               [2m 0.38 kB[22m [2m│ gzip: 0.25 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/singleton.js             [2m 0.37 kB[22m [2m│ gzip: 0.25 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/roles.js                 [2m 0.36 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/users.js                 [2m 0.36 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/translations.js        [2m 0.35 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/notifications.js       [2m 0.35 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/permissions.js         [2m 0.35 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/extensions.js          [2m 0.34 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/versions.js            [2m 0.34 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/dashboards.js          [2m 0.34 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/operations.js          [2m 0.34 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/policies.js            [2m 0.33 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/presets.js             [2m 0.33 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/notifications.js         [2m 0.33 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/shares.js              [2m 0.32 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/extensions.js          [2m 0.32 kB[22m [2m│ gzip: 0.24 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/translations.js          [2m 0.32 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/folders.js             [2m 0.32 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/roles.js               [2m 0.32 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/users.js               [2m 0.32 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/versions.js              [2m 0.32 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/panels.js              [2m 0.32 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/dashboards.js            [2m 0.31 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/operations.js            [2m 0.31 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/files.js               [2m 0.31 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/flows.js               [2m 0.31 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/revisions.js             [2m 0.31 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/helpers/with-search.js                 [2m 0.31 kB[22m [2m│ gzip: 0.25 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/activity.js              [2m 0.31 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/comments.js              [2m 0.30 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/files.js               [2m 0.30 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/folders.js               [2m 0.30 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/presets.js               [2m 0.30 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/relations.js           [2m 0.30 kB[22m [2m│ gzip: 0.24 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mclient.js                                   [2m 0.29 kB[22m [2m│ gzip: 0.21 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/panels.js                [2m 0.29 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/shares.js                [2m 0.29 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/collections.js           [2m 0.29 kB[22m [2m│ gzip: 0.20 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/files.js                 [2m 0.29 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/flows.js                 [2m 0.29 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/notifications.js       [2m 0.28 kB[22m [2m│ gzip: 0.17 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/translations.js        [2m 0.28 kB[22m [2m│ gzip: 0.17 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/auth/login.js                 [2m 0.28 kB[22m [2m│ gzip: 0.23 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/permissions.js         [2m 0.27 kB[22m [2m│ gzip: 0.17 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/versions.js            [2m 0.27 kB[22m [2m│ gzip: 0.17 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/dashboards.js          [2m 0.27 kB[22m [2m│ gzip: 0.17 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/operations.js          [2m 0.27 kB[22m [2m│ gzip: 0.17 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/utils/hash.js                 [2m 0.26 kB[22m [2m│ gzip: 0.18 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/comments.js            [2m 0.26 kB[22m [2m│ gzip: 0.17 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/policies.js            [2m 0.26 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/relations.js           [2m 0.26 kB[22m [2m│ gzip: 0.21 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/folders.js             [2m 0.25 kB[22m [2m│ gzip: 0.17 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/presets.js             [2m 0.25 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/panels.js              [2m 0.25 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/shares.js              [2m 0.25 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/fields.js              [2m 0.25 kB[22m [2m│ gzip: 0.20 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils/is-directus-error.js                  [2m 0.24 kB[22m [2m│ gzip: 0.18 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/auth/refresh.js               [2m 0.24 kB[22m [2m│ gzip: 0.20 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrealtime/commands/pong.js.map               [2m 0.24 kB[22m [2m│ gzip: 0.20 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/flows.js               [2m 0.24 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/roles.js               [2m 0.24 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/users.js               [2m 0.24 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/auth/logout.js                [2m 0.24 kB[22m [2m│ gzip: 0.20 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils/error.js                              [2m 0.24 kB[22m [2m│ gzip: 0.18 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/deployment.js          [2m 0.22 kB[22m [2m│ gzip: 0.19 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mutils/is-response.js                        [2m 0.22 kB[22m [2m│ gzip: 0.17 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/utils/flows.js                [2m 0.21 kB[22m [2m│ gzip: 0.18 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/utils/throw-core-collection.js         [2m 0.20 kB[22m [2m│ gzip: 0.17 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/auth/password-request.js      [2m 0.19 kB[22m [2m│ gzip: 0.17 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/auth/password-reset.js        [2m 0.18 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/utils/import.js               [2m 0.18 kB[22m [2m│ gzip: 0.17 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/helpers/with-options.js                [2m 0.18 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/server/graphql.js             [2m 0.18 kB[22m [2m│ gzip: 0.15 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/utils/export.js               [2m 0.17 kB[22m [2m│ gzip: 0.17 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/helpers/with-token.js                  [2m 0.17 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/schema/apply.js               [2m 0.17 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/collections.js         [2m 0.16 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/deployment.js          [2m 0.16 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/schema/diff.js                [2m 0.16 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mauth/index.js                               [2m 0.16 kB[22m [2m│ gzip: 0.12 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/update/settings.js            [2m 0.16 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/utils/sort.js                 [2m 0.16 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/fields.js              [2m 0.15 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/utils/random.js               [2m 0.15 kB[22m [2m│ gzip: 0.15 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mauth/static.js                              [2m 0.15 kB[22m [2m│ gzip: 0.14 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/create/relations.js           [2m 0.14 kB[22m [2m│ gzip: 0.14 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/utils/cache.js                [2m 0.14 kB[22m [2m│ gzip: 0.14 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mauth/utils/memory-storage.js                [2m 0.14 kB[22m [2m│ gzip: 0.13 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/auth/providers.js             [2m 0.14 kB[22m [2m│ gzip: 0.14 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/utils/get-auth-endpoint.js             [2m 0.13 kB[22m [2m│ gzip: 0.13 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/delete/collections.js         [2m 0.13 kB[22m [2m│ gzip: 0.13 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/read/settings.js              [2m 0.13 kB[22m [2m│ gzip: 0.13 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/server/openapi.js             [2m 0.12 kB[22m [2m│ gzip: 0.13 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/schema/snapshot.js            [2m 0.12 kB[22m [2m│ gzip: 0.12 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/utils/throw-if-empty.js                [2m 0.12 kB[22m [2m│ gzip: 0.13 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/server/health.js              [2m 0.12 kB[22m [2m│ gzip: 0.12 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrealtime/utils/generate-uid.js              [2m 0.11 kB[22m [2m│ gzip: 0.13 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/server/info.js                [2m 0.11 kB[22m [2m│ gzip: 0.12 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/commands/server/ping.js                [2m 0.11 kB[22m [2m│ gzip: 0.12 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrealtime/commands/auth.js                   [2m 0.11 kB[22m [2m│ gzip: 0.12 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrest/helpers/custom-endpoint.js             [2m 0.10 kB[22m [2m│ gzip: 0.11 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrealtime/utils/sleep.js                     [2m 0.10 kB[22m [2m│ gzip: 0.11 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mrealtime/commands/pong.js                   [2m 0.09 kB[22m [2m│ gzip: 0.11 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m                                  [2m27.56 kB[22m [2m│ gzip: 4.69 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/deployment.d.ts[39m          [2m 5.98 kB[22m [2m│ gzip: 1.36 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mtypes/functions.d.ts[39m                        [2m 5.65 kB[22m [2m│ gzip: 1.78 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mtypes/output.d.ts[39m                           [2m 4.46 kB[22m [2m│ gzip: 1.34 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mtypes/aggregate.d.ts[39m                        [2m 3.86 kB[22m [2m│ gzip: 1.04 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/extensions.d.ts[39m          [2m 3.67 kB[22m [2m│ gzip: 0.94 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mtypes/filters.d.ts[39m                          [2m 3.66 kB[22m [2m│ gzip: 0.98 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrealtime/types.d.ts[39m                         [2m 3.65 kB[22m [2m│ gzip: 1.12 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mtypes/fields.d.ts[39m                           [2m 3.62 kB[22m [2m│ gzip: 1.11 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mtypes/query.d.ts[39m                            [2m 3.44 kB[22m [2m│ gzip: 1.11 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mtypes/schema.d.ts[39m                           [2m 3.30 kB[22m [2m│ gzip: 0.92 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/update/items.d.ts[39m             [2m 2.80 kB[22m [2m│ gzip: 0.66 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/settings.d.ts[39m                        [2m 2.63 kB[22m [2m│ gzip: 0.83 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mtypes/utils.d.ts[39m                            [2m 2.63 kB[22m [2m│ gzip: 0.97 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/permissions.d.ts[39m         [2m 2.58 kB[22m [2m│ gzip: 0.81 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/update/users.d.ts[39m             [2m 2.43 kB[22m [2m│ gzip: 0.59 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/utils/users.d.ts[39m              [2m 2.42 kB[22m [2m│ gzip: 0.82 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mauth/types.d.ts[39m                             [2m 2.24 kB[22m [2m│ gzip: 0.76 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/utils/versions.d.ts[39m           [2m 2.13 kB[22m [2m│ gzip: 0.74 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/field.d.ts[39m                           [2m 2.07 kB[22m [2m│ gzip: 0.68 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/core.d.ts[39m                            [2m 2.06 kB[22m [2m│ gzip: 0.51 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/update/notifications.d.ts[39m     [2m 2.06 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/update/versions.d.ts[39m          [2m 2.04 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/update/translations.d.ts[39m      [2m 2.02 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/update/permissions.d.ts[39m       [2m 2.01 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/update/comments.d.ts[39m          [2m 1.97 kB[22m [2m│ gzip: 0.54 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/update/dashboards.d.ts[39m        [2m 1.96 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/update/operations.d.ts[39m        [2m 1.96 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/assets.d.ts[39m              [2m 1.90 kB[22m [2m│ gzip: 0.59 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/create/items.d.ts[39m             [2m 1.90 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/update/folders.d.ts[39m           [2m 1.88 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/items.d.ts[39m               [2m 1.88 kB[22m [2m│ gzip: 0.58 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/update/policies.d.ts[39m          [2m 1.87 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/update/presets.d.ts[39m           [2m 1.86 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/update/files.d.ts[39m             [2m 1.85 kB[22m [2m│ gzip: 0.55 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/update/panels.d.ts[39m            [2m 1.82 kB[22m [2m│ gzip: 0.51 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/update/shares.d.ts[39m            [2m 1.82 kB[22m [2m│ gzip: 0.51 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/update/deployment.d.ts[39m        [2m 1.79 kB[22m [2m│ gzip: 0.62 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/update/flows.d.ts[39m             [2m 1.79 kB[22m [2m│ gzip: 0.51 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/update/roles.d.ts[39m             [2m 1.79 kB[22m [2m│ gzip: 0.51 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/roles.d.ts[39m               [2m 1.64 kB[22m [2m│ gzip: 0.57 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/policies.d.ts[39m            [2m 1.63 kB[22m [2m│ gzip: 0.63 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/users.d.ts[39m               [2m 1.61 kB[22m [2m│ gzip: 0.56 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/deployment.d.ts[39m                      [2m 1.61 kB[22m [2m│ gzip: 0.51 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/update/fields.d.ts[39m            [2m 1.60 kB[22m [2m│ gzip: 0.50 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/utils/shares.d.ts[39m             [2m 1.58 kB[22m [2m│ gzip: 0.68 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/update/collections.d.ts[39m       [2m 1.54 kB[22m [2m│ gzip: 0.51 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/create/notifications.d.ts[39m     [2m 1.54 kB[22m [2m│ gzip: 0.46 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/create/versions.d.ts[39m          [2m 1.54 kB[22m [2m│ gzip: 0.46 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/create/translations.d.ts[39m      [2m 1.52 kB[22m [2m│ gzip: 0.45 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/create/permissions.d.ts[39m       [2m 1.51 kB[22m [2m│ gzip: 0.47 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/relations.d.ts[39m           [2m 1.50 kB[22m [2m│ gzip: 0.51 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/create/operations.d.ts[39m        [2m 1.47 kB[22m [2m│ gzip: 0.45 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/create/dashboards.d.ts[39m        [2m 1.47 kB[22m [2m│ gzip: 0.46 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/versions.d.ts[39m            [2m 1.45 kB[22m [2m│ gzip: 0.54 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/translations.d.ts[39m        [2m 1.44 kB[22m [2m│ gzip: 0.54 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/notifications.d.ts[39m       [2m 1.44 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/create/folders.d.ts[39m           [2m 1.43 kB[22m [2m│ gzip: 0.46 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/create/files.d.ts[39m             [2m 1.42 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/create/comments.d.ts[39m          [2m 1.42 kB[22m [2m│ gzip: 0.45 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/create/policies.d.ts[39m          [2m 1.40 kB[22m [2m│ gzip: 0.46 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/operations.d.ts[39m          [2m 1.40 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/create/presets.d.ts[39m           [2m 1.39 kB[22m [2m│ gzip: 0.45 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/revisions.d.ts[39m           [2m 1.38 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/activity.d.ts[39m            [2m 1.38 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/dashboards.d.ts[39m          [2m 1.38 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/utils/deployment.d.ts[39m         [2m 1.38 kB[22m [2m│ gzip: 0.54 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/create/shares.d.ts[39m            [2m 1.37 kB[22m [2m│ gzip: 0.45 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/create/panels.d.ts[39m            [2m 1.37 kB[22m [2m│ gzip: 0.45 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/comments.d.ts[39m            [2m 1.36 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/collection.d.ts[39m                      [2m 1.35 kB[22m [2m│ gzip: 0.51 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/create/roles.d.ts[39m             [2m 1.35 kB[22m [2m│ gzip: 0.45 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/create/users.d.ts[39m             [2m 1.35 kB[22m [2m│ gzip: 0.46 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/folders.d.ts[39m             [2m 1.34 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/presets.d.ts[39m             [2m 1.34 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/create/flows.d.ts[39m             [2m 1.34 kB[22m [2m│ gzip: 0.45 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/shares.d.ts[39m              [2m 1.31 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/fields.d.ts[39m              [2m 1.31 kB[22m [2m│ gzip: 0.47 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/update/singleton.d.ts[39m         [2m 1.30 kB[22m [2m│ gzip: 0.51 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/user.d.ts[39m                            [2m 1.30 kB[22m [2m│ gzip: 0.48 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/files.d.ts[39m               [2m 1.30 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/server/info.d.ts[39m              [2m 1.30 kB[22m [2m│ gzip: 0.53 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/panels.d.ts[39m              [2m 1.30 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/flows.d.ts[39m               [2m 1.28 kB[22m [2m│ gzip: 0.52 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/singleton.d.ts[39m           [2m 1.21 kB[22m [2m│ gzip: 0.49 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/delete/items.d.ts[39m             [2m 1.18 kB[22m [2m│ gzip: 0.42 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/create/collections.d.ts[39m       [2m 1.15 kB[22m [2m│ gzip: 0.49 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/update/relations.d.ts[39m         [2m 1.09 kB[22m [2m│ gzip: 0.43 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/create/fields.d.ts[39m            [2m 1.07 kB[22m [2m│ gzip: 0.46 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/file.d.ts[39m                            [2m 1.03 kB[22m [2m│ gzip: 0.40 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/create/deployment.d.ts[39m        [2m 1.02 kB[22m [2m│ gzip: 0.42 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mtypes/globals.d.ts[39m                          [2m 1.01 kB[22m [2m│ gzip: 0.49 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/collections.d.ts[39m         [2m 0.97 kB[22m [2m│ gzip: 0.41 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/relation.d.ts[39m                        [2m 0.94 kB[22m [2m│ gzip: 0.35 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/update/extensions.d.ts[39m        [2m 0.94 kB[22m [2m│ gzip: 0.42 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/update/settings.d.ts[39m          [2m 0.92 kB[22m [2m│ gzip: 0.38 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mtypes/deep.d.ts[39m                             [2m 0.91 kB[22m [2m│ gzip: 0.41 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/schema/diff.d.ts[39m              [2m 0.87 kB[22m [2m│ gzip: 0.47 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/create/relations.d.ts[39m         [2m 0.82 kB[22m [2m│ gzip: 0.38 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/aggregate.d.ts[39m           [2m 0.82 kB[22m [2m│ gzip: 0.38 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/read/settings.d.ts[39m            [2m 0.81 kB[22m [2m│ gzip: 0.36 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/delete/comments.d.ts[39m          [2m 0.80 kB[22m [2m│ gzip: 0.35 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/delete/extensions.d.ts[39m        [2m 0.77 kB[22m [2m│ gzip: 0.33 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/operation.d.ts[39m                       [2m 0.76 kB[22m [2m│ gzip: 0.33 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/preset.d.ts[39m                          [2m 0.76 kB[22m [2m│ gzip: 0.33 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/extension.d.ts[39m                       [2m 0.75 kB[22m [2m│ gzip: 0.36 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/panel.d.ts[39m                           [2m 0.75 kB[22m [2m│ gzip: 0.35 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mtypes/client.d.ts[39m                           [2m 0.75 kB[22m [2m│ gzip: 0.38 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/delete/notifications.d.ts[39m     [2m 0.73 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/delete/translations.d.ts[39m      [2m 0.72 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/version.d.ts[39m                         [2m 0.72 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/delete/permissions.d.ts[39m       [2m 0.71 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/delete/versions.d.ts[39m          [2m 0.71 kB[22m [2m│ gzip: 0.32 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/auth/login.d.ts[39m               [2m 0.71 kB[22m [2m│ gzip: 0.33 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/flow.d.ts[39m                            [2m 0.71 kB[22m [2m│ gzip: 0.32 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/share.d.ts[39m                           [2m 0.71 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/delete/dashboards.d.ts[39m        [2m 0.70 kB[22m [2m│ gzip: 0.32 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/delete/operations.d.ts[39m        [2m 0.69 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mtypes/assets.d.ts[39m                           [2m 0.68 kB[22m [2m│ gzip: 0.39 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/policy.d.ts[39m                          [2m 0.68 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/utils/export.d.ts[39m             [2m 0.68 kB[22m [2m│ gzip: 0.38 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mtypes/request.d.ts[39m                          [2m 0.66 kB[22m [2m│ gzip: 0.34 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/delete/policies.d.ts[39m          [2m 0.66 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/delete/folders.d.ts[39m           [2m 0.66 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/delete/presets.d.ts[39m           [2m 0.66 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/delete/users.d.ts[39m             [2m 0.65 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mgraphql/types.d.ts[39m                          [2m 0.65 kB[22m [2m│ gzip: 0.33 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/delete/panels.d.ts[39m            [2m 0.65 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/delete/shares.d.ts[39m            [2m 0.65 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/revision.d.ts[39m                        [2m 0.64 kB[22m [2m│ gzip: 0.29 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/auth/password-reset.d.ts[39m      [2m 0.64 kB[22m [2m│ gzip: 0.37 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/activity.d.ts[39m                        [2m 0.63 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/delete/flows.d.ts[39m             [2m 0.63 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/delete/roles.d.ts[39m             [2m 0.63 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/delete/files.d.ts[39m             [2m 0.63 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/comment.d.ts[39m                         [2m 0.63 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/schema/snapshot.d.ts[39m          [2m 0.63 kB[22m [2m│ gzip: 0.36 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mauth/composable.d.ts[39m                        [2m 0.62 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/schema/apply.d.ts[39m             [2m 0.62 kB[22m [2m│ gzip: 0.38 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/auth/password-request.d.ts[39m    [2m 0.61 kB[22m [2m│ gzip: 0.36 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/utils/hash.d.ts[39m               [2m 0.60 kB[22m [2m│ gzip: 0.31 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/role.d.ts[39m                            [2m 0.59 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/notification.d.ts[39m                    [2m 0.59 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/server/health.d.ts[39m            [2m 0.58 kB[22m [2m│ gzip: 0.33 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/permission.d.ts[39m                      [2m 0.58 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/delete/relations.d.ts[39m         [2m 0.57 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/delete/fields.d.ts[39m            [2m 0.57 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/types.d.ts[39m                             [2m 0.55 kB[22m [2m│ gzip: 0.29 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/access.d.ts[39m                          [2m 0.54 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/utils/sort.d.ts[39m               [2m 0.54 kB[22m [2m│ gzip: 0.32 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/create/extensions.d.ts[39m        [2m 0.52 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/auth/providers.d.ts[39m           [2m 0.51 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrealtime/composable.d.ts[39m                    [2m 0.51 kB[22m [2m│ gzip: 0.29 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/auth/refresh.d.ts[39m             [2m 0.51 kB[22m [2m│ gzip: 0.29 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mclient.d.ts[39m                                 [2m 0.51 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/helpers/with-options.d.ts[39m              [2m 0.51 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/dashboard.d.ts[39m                       [2m 0.50 kB[22m [2m│ gzip: 0.26 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mauth/static.d.ts[39m                            [2m 0.49 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrealtime/utils/message-callback.d.ts[39m        [2m 0.47 kB[22m [2m│ gzip: 0.30 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mutils/query-to-params.d.ts[39m                  [2m 0.46 kB[22m [2m│ gzip: 0.29 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mgraphql/composable.d.ts[39m                     [2m 0.46 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/auth/logout.d.ts[39m              [2m 0.45 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/server/openapi.d.ts[39m           [2m 0.44 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/delete/collections.d.ts[39m       [2m 0.44 kB[22m [2m│ gzip: 0.25 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/composable.d.ts[39m                        [2m 0.44 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/delete/deployment.d.ts[39m        [2m 0.43 kB[22m [2m│ gzip: 0.27 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrealtime/commands/auth.d.ts[39m                 [2m 0.42 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/utils/flows.d.ts[39m              [2m 0.41 kB[22m [2m│ gzip: 0.28 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/utils/random.d.ts[39m             [2m 0.38 kB[22m [2m│ gzip: 0.25 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/utils/import.d.ts[39m             [2m 0.37 kB[22m [2m│ gzip: 0.26 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mtypes/error.d.ts[39m                            [2m 0.37 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/utils/throw-core-collection.d.ts[39m       [2m 0.37 kB[22m [2m│ gzip: 0.24 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/utils/cache.d.ts[39m              [2m 0.36 kB[22m [2m│ gzip: 0.26 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/server/graphql.d.ts[39m           [2m 0.35 kB[22m [2m│ gzip: 0.25 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/translation.d.ts[39m                     [2m 0.35 kB[22m [2m│ gzip: 0.21 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mutils/is-directus-error.d.ts[39m                [2m 0.34 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/helpers/custom-endpoint.d.ts[39m           [2m 0.34 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mschema/folder.d.ts[39m                          [2m 0.34 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mauth/utils/memory-storage.d.ts[39m              [2m 0.32 kB[22m [2m│ gzip: 0.20 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/utils/throw-if-empty.d.ts[39m              [2m 0.32 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/utils/get-auth-endpoint.d.ts[39m           [2m 0.32 kB[22m [2m│ gzip: 0.21 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/helpers/with-token.d.ts[39m                [2m 0.29 kB[22m [2m│ gzip: 0.20 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/helpers/with-search.d.ts[39m               [2m 0.28 kB[22m [2m│ gzip: 0.19 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrest/commands/server/ping.d.ts[39m              [2m 0.28 kB[22m [2m│ gzip: 0.22 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrealtime/utils/generate-uid.d.ts[39m            [2m 0.27 kB[22m [2m│ gzip: 0.20 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrealtime/utils/sleep.d.ts[39m                   [2m 0.25 kB[22m [2m│ gzip: 0.20 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mutils/format-fields.d.ts[39m                    [2m 0.20 kB[22m [2m│ gzip: 0.16 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mrealtime/commands/pong.d.ts[39m                 [2m 0.14 kB[22m [2m│ gzip: 0.13 kB[22m
+sdk build: [34mℹ[39m [34m[ESM][39m 491 files, total: 653.57 kB
+sdk build: [32m✔[39m Build complete in [32m2290ms[39m
+sdk build: Done
+packages/types build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m    [2m11.22 kB[22m [2m│ gzip:  2.48 kB[22m
+packages/types build: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m88.80 kB[22m [2m│ gzip: 18.57 kB[22m
+packages/types build: [34mℹ[39m 2 files, total: 100.02 kB
+packages/types build: [32m✔[39m Build complete in [32m4525ms[39m
+packages/types build: Done
+packages/schema-builder build$ tsdown src/index.ts --dts
+packages/storage build$ tsdown src/index.ts --dts
+packages/schema-builder build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/storage build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/schema-builder build: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/schema-builder build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/schema-builder build: [34mℹ[39m Build start
+packages/storage build: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/storage build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/storage build: [34mℹ[39m Build start
+packages/schema-builder build: [34mℹ[39m Cleaning 2 files
+packages/storage build: [34mℹ[39m Cleaning 2 files
+packages/storage build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m    [2m0.72 kB[22m [2m│ gzip: 0.35 kB[22m
+packages/storage build: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m1.64 kB[22m [2m│ gzip: 0.58 kB[22m
+packages/storage build: [34mℹ[39m 2 files, total: 2.36 kB
+packages/storage build: [32m✔[39m Build complete in [32m262ms[39m
+packages/storage build: Done
+tests/mock-license-server build$ tsdown src/index.ts src/run.ts --dts
+packages/schema-builder build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m    [2m19.58 kB[22m [2m│ gzip: 3.19 kB[22m
+packages/schema-builder build: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m 4.36 kB[22m [2m│ gzip: 1.11 kB[22m
+packages/schema-builder build: [34mℹ[39m 2 files, total: 23.94 kB
+packages/schema-builder build: [32m✔[39m Build complete in [32m296ms[39m
+packages/schema-builder build: Done
+tests/mock-license-server build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+tests/mock-license-server build: [34mℹ[39m entry: [34msrc/index.ts, src/run.ts[39m
+tests/mock-license-server build: [34mℹ[39m target: [34mnode22.0.0[39m
+tests/mock-license-server build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+tests/mock-license-server build: [34mℹ[39m Build start
+tests/mock-license-server build: [34mℹ[39m Cleaning 6 files
+tests/mock-license-server build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m           [2m 1.12 kB[22m [2m│ gzip: 0.53 kB[22m
+tests/mock-license-server build: [34mℹ[39m [2mdist/[22m[1mrun.js[22m             [2m 0.12 kB[22m [2m│ gzip: 0.12 kB[22m
+tests/mock-license-server build: [34mℹ[39m [2mdist/[22mapp-C49Oxo-c.js    [2m19.01 kB[22m [2m│ gzip: 4.46 kB[22m
+tests/mock-license-server build: [34mℹ[39m [2mdist/[22mchunk-Bp6m_JJh.js  [2m 0.26 kB[22m [2m│ gzip: 0.20 kB[22m
+tests/mock-license-server build: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m         [2m 1.17 kB[22m [2m│ gzip: 0.51 kB[22m
+tests/mock-license-server build: [34mℹ[39m [2mdist/[22m[32m[1mrun.d.ts[22m[39m           [2m 0.01 kB[22m [2m│ gzip: 0.03 kB[22m
+tests/mock-license-server build: [34mℹ[39m 6 files, total: 21.69 kB
+tests/mock-license-server build: [32m✔[39m Build complete in [32m4566ms[39m
+tests/mock-license-server build: Done
+packages/errors build$ tsdown src/index.ts --dts
+packages/storage-driver-local build$ tsdown src/index.ts --dts
+packages/storage-driver-local build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/errors build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/storage-driver-local build: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/storage-driver-local build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/storage-driver-local build: [34mℹ[39m Build start
+packages/errors build: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/errors build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/errors build: [34mℹ[39m Build start
+packages/errors build: [34mℹ[39m Cleaning 2 files
+packages/storage-driver-local build: [34mℹ[39m Cleaning 2 files
+packages/storage-driver-local build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m    [2m3.66 kB[22m [2m│ gzip: 1.25 kB[22m
+packages/storage-driver-local build: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m1.45 kB[22m [2m│ gzip: 0.55 kB[22m
+packages/storage-driver-local build: [34mℹ[39m 2 files, total: 5.12 kB
+packages/storage-driver-local build: [32m✔[39m Build complete in [32m365ms[39m
+packages/storage-driver-local build: Done
+packages/errors build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m    [2m16.49 kB[22m [2m│ gzip: 4.05 kB[22m
+packages/errors build: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m13.78 kB[22m [2m│ gzip: 2.87 kB[22m
+packages/errors build: [34mℹ[39m 2 files, total: 30.27 kB
+packages/errors build: [32m✔[39m Build complete in [32m480ms[39m
+packages/errors build: Done
+packages/utils build$ pnpm run '/^build:.*/'
+packages/utils build: . build:browser$ tsdown browser/index.ts --tsconfig browser/tsconfig.json --out-dir dist/browser --dts
+packages/utils build: . build:node$ tsdown node/index.ts --tsconfig node/tsconfig.json --out-dir dist/node --dts
+packages/utils build: . build:browser: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/utils build: . build:node: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/utils build: . build:browser: [34mℹ[39m entry: [34mbrowser/index.ts[39m
+packages/utils build: . build:browser: [34mℹ[39m tsconfig: [34mbrowser/tsconfig.json[39m
+packages/utils build: . build:browser: [34mℹ[39m Build start
+packages/utils build: . build:node: [34mℹ[39m entry: [34mnode/index.ts[39m
+packages/utils build: . build:node: [34mℹ[39m tsconfig: [34mnode/tsconfig.json[39m
+packages/utils build: . build:node: [34mℹ[39m Build start
+packages/utils build: . build:node: [34mℹ[39m Cleaning 3 files
+packages/utils build: . build:browser: [34mℹ[39m Cleaning 2 files
+packages/utils build: . build:browser: [34mℹ[39m [2mdist/browser/[22m[1mindex.js[22m    [2m0.44 kB[22m [2m│ gzip: 0.28 kB[22m
+packages/utils build: . build:browser: [34mℹ[39m [2mdist/browser/[22m[32m[1mindex.d.ts[22m[39m  [2m0.32 kB[22m [2m│ gzip: 0.21 kB[22m
+packages/utils build: . build:browser: [34mℹ[39m 2 files, total: 0.76 kB
+packages/utils build: . build:browser: [32m✔[39m Build complete in [32m248ms[39m
+packages/utils build: . build:browser: Done
+packages/utils build: . build:shared$ tsdown shared/index.ts --tsconfig shared/tsconfig.json --out-dir dist/shared --dts
+packages/utils build: . build:node: [34mℹ[39m [2mdist/node/[22m[1mindex.js[22m           [2m11.03 kB[22m [2m│ gzip: 3.49 kB[22m
+packages/utils build: . build:node: [34mℹ[39m [2mdist/node/[22mchunk-076AhbV_.js  [2m 1.03 kB[22m [2m│ gzip: 0.52 kB[22m
+packages/utils build: . build:node: [34mℹ[39m [2mdist/node/[22m[32m[1mindex.d.ts[22m[39m         [2m 6.17 kB[22m [2m│ gzip: 1.96 kB[22m
+packages/utils build: . build:node: [34mℹ[39m 3 files, total: 18.23 kB
+packages/utils build: . build:node: [32m✔[39m Build complete in [32m329ms[39m
+packages/utils build: . build:node: Done
+packages/utils build: . build:shared: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/utils build: . build:shared: [34mℹ[39m entry: [34mshared/index.ts[39m
+packages/utils build: . build:shared: [34mℹ[39m tsconfig: [34mshared/tsconfig.json[39m
+packages/utils build: . build:shared: [34mℹ[39m Build start
+packages/utils build: . build:shared: [34mℹ[39m Cleaning 2 files
+packages/utils build: . build:shared: [34mℹ[39m [2mdist/shared/[22m[1mindex.js[22m    [2m72.08 kB[22m [2m│ gzip: 17.83 kB[22m
+packages/utils build: . build:shared: [34mℹ[39m [2mdist/shared/[22m[32m[1mindex.d.ts[22m[39m  [2m15.40 kB[22m [2m│ gzip:  4.50 kB[22m
+packages/utils build: . build:shared: [34mℹ[39m 2 files, total: 87.48 kB
+packages/utils build: . build:shared: [32m✔[39m Build complete in [32m406ms[39m
+packages/utils build: . build:shared: Done
+packages/utils build: Done
+packages/env build$ tsdown src/index.ts --dts
+packages/extensions build$ pnpm run '/^build:.*/'
+packages/env build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/env build: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/env build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/env build: [34mℹ[39m Build start
+packages/env build: [34mℹ[39m Cleaning 2 files
+packages/env build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m    [2m23.44 kB[22m [2m│ gzip: 6.55 kB[22m
+packages/env build: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m 0.17 kB[22m [2m│ gzip: 0.14 kB[22m
+packages/env build: [34mℹ[39m 2 files, total: 23.61 kB
+packages/env build: [32m✔[39m Build complete in [32m312ms[39m
+packages/env build: Done
+packages/memory build$ tsdown src/index.ts --dts
+packages/memory build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/memory build: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/memory build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/memory build: [34mℹ[39m Build start
+packages/memory build: [34mℹ[39m Cleaning 2 files
+packages/extensions build: . build:node$ tsdown src/node.ts --tsconfig src/node/tsconfig.json --out-dir dist --dts
+packages/extensions build: . build:shared$ tsdown src/index.ts --tsconfig src/tsconfig.json --out-dir dist --dts
+packages/extensions build: . build:node: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/memory build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m    [2m16.38 kB[22m [2m│ gzip: 3.92 kB[22m
+packages/memory build: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m15.61 kB[22m [2m│ gzip: 2.91 kB[22m
+packages/memory build: [34mℹ[39m 2 files, total: 31.98 kB
+packages/memory build: [32m✔[39m Build complete in [32m434ms[39m
+packages/extensions build: . build:shared: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/memory build: Done
+packages/pressure build$ tsdown src/index.ts --dts
+packages/extensions build: . build:node: [34mℹ[39m entry: [34msrc/node.ts[39m
+packages/extensions build: . build:node: [34mℹ[39m tsconfig: [34msrc/node/tsconfig.json[39m
+packages/extensions build: . build:node: [34mℹ[39m Build start
+packages/extensions build: . build:node: [34mℹ[39m Cleaning 4 files
+packages/extensions build: . build:shared: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/extensions build: . build:shared: [34mℹ[39m tsconfig: [34msrc/tsconfig.json[39m
+packages/extensions build: . build:shared: [34mℹ[39m Build start
+packages/pressure build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/pressure build: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/pressure build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/pressure build: [34mℹ[39m Build start
+packages/pressure build: [34mℹ[39m Cleaning 2 files
+packages/pressure build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m    [2m2.20 kB[22m [2m│ gzip: 0.76 kB[22m
+packages/pressure build: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m0.92 kB[22m [2m│ gzip: 0.38 kB[22m
+packages/pressure build: [34mℹ[39m 2 files, total: 3.12 kB
+packages/pressure build: [32m✔[39m Build complete in [32m398ms[39m
+packages/pressure build: Done
+packages/storage-driver-azure build$ tsdown src/index.ts --dts
+packages/storage-driver-azure build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/storage-driver-azure build: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/storage-driver-azure build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/storage-driver-azure build: [34mℹ[39m Build start
+packages/storage-driver-azure build: [34mℹ[39m Cleaning 2 files
+packages/storage-driver-azure build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m    [2m3.53 kB[22m [2m│ gzip: 1.26 kB[22m
+packages/storage-driver-azure build: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m1.55 kB[22m [2m│ gzip: 0.58 kB[22m
+packages/storage-driver-azure build: [34mℹ[39m 2 files, total: 5.08 kB
+packages/storage-driver-azure build: [32m✔[39m Build complete in [32m579ms[39m
+packages/storage-driver-azure build: Done
+packages/storage-driver-cloudinary build$ tsdown src/index.ts --dts
+packages/storage-driver-cloudinary build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/storage-driver-cloudinary build: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/storage-driver-cloudinary build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/storage-driver-cloudinary build: [34mℹ[39m Build start
+packages/storage-driver-cloudinary build: [34mℹ[39m Cleaning 2 files
+packages/storage-driver-cloudinary build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m    [2m12.91 kB[22m [2m│ gzip: 3.68 kB[22m
+packages/storage-driver-cloudinary build: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m 2.83 kB[22m [2m│ gzip: 1.08 kB[22m
+packages/storage-driver-cloudinary build: [34mℹ[39m 2 files, total: 15.74 kB
+packages/storage-driver-cloudinary build: [32m✔[39m Build complete in [32m421ms[39m
+packages/storage-driver-cloudinary build: Done
+packages/storage-driver-gcs build$ tsdown src/index.ts --dts
+packages/storage-driver-gcs build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/storage-driver-gcs build: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/storage-driver-gcs build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/storage-driver-gcs build: [34mℹ[39m Build start
+packages/storage-driver-gcs build: [34mℹ[39m Cleaning 2 files
+packages/storage-driver-gcs build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m    [2m3.31 kB[22m [2m│ gzip: 1.22 kB[22m
+packages/storage-driver-gcs build: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m1.49 kB[22m [2m│ gzip: 0.56 kB[22m
+packages/storage-driver-gcs build: [34mℹ[39m 2 files, total: 4.80 kB
+packages/storage-driver-gcs build: [32m✔[39m Build complete in [32m677ms[39m
+packages/storage-driver-gcs build: Done
+packages/storage-driver-s3 build$ tsdown src/index.ts --dts
+packages/storage-driver-s3 build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/storage-driver-s3 build: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/storage-driver-s3 build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/storage-driver-s3 build: [34mℹ[39m Build start
+packages/storage-driver-s3 build: [34mℹ[39m Cleaning 2 files
+packages/storage-driver-s3 build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m    [2m11.68 kB[22m [2m│ gzip: 3.26 kB[22m
+packages/storage-driver-s3 build: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m 2.21 kB[22m [2m│ gzip: 0.81 kB[22m
+packages/storage-driver-s3 build: [34mℹ[39m 2 files, total: 13.88 kB
+packages/storage-driver-s3 build: [32m✔[39m Build complete in [32m624ms[39m
+packages/storage-driver-s3 build: Done
+packages/storage-driver-supabase build$ tsdown src/index.ts --dts
+packages/storage-driver-supabase build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/storage-driver-supabase build: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/storage-driver-supabase build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/storage-driver-supabase build: [34mℹ[39m Build start
+packages/storage-driver-supabase build: [34mℹ[39m Cleaning 2 files
+packages/storage-driver-supabase build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m    [2m6.33 kB[22m [2m│ gzip: 2.23 kB[22m
+packages/storage-driver-supabase build: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m1.78 kB[22m [2m│ gzip: 0.65 kB[22m
+packages/storage-driver-supabase build: [34mℹ[39m 2 files, total: 8.11 kB
+packages/storage-driver-supabase build: [32m✔[39m Build complete in [32m671ms[39m
+packages/storage-driver-supabase build: Done
+packages/themes build$ tsdown
+packages/extensions build: . build:shared: [34mℹ[39m [2mdist/[22m[1mindex.js[22m    [2m 4.69 kB[22m [2m│ gzip: 1.23 kB[22m
+packages/extensions build: . build:shared: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m16.88 kB[22m [2m│ gzip: 2.30 kB[22m
+packages/extensions build: . build:shared: [34mℹ[39m 2 files, total: 21.57 kB
+packages/themes build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/extensions build: . build:shared: [32m✔[39m Build complete in [32m6835ms[39m
+packages/extensions build: . build:shared: Done
+packages/extensions build: . build:node: [34mℹ[39m [2mdist/[22m[1mnode.js[22m    [2m11.02 kB[22m [2m│ gzip: 2.75 kB[22m
+packages/extensions build: . build:node: [34mℹ[39m [2mdist/[22m[32m[1mnode.d.ts[22m[39m  [2m17.62 kB[22m [2m│ gzip: 2.48 kB[22m
+packages/extensions build: . build:node: [34mℹ[39m 2 files, total: 28.64 kB
+packages/extensions build: . build:node: [32m✔[39m Build complete in [32m7825ms[39m
+packages/extensions build: . build:node: Done
+packages/extensions build: Done
+packages/validation build$ tsdown src/index.ts --dts
+packages/themes build: [34mℹ[39m Using tsdown config: [4m/home/jean/dev/Hippocast/dev/deps/directus-cms-2/packages/themes/tsdown.config.ts[24m
+packages/themes build: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/themes build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/themes build: [34mℹ[39m Build start
+packages/themes build: [34mℹ[39m Cleaning 2 files
+packages/validation build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/validation build: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/validation build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/validation build: [34mℹ[39m Build start
+packages/validation build: [34mℹ[39m Cleaning 2 files
+packages/validation build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m    [2m5.20 kB[22m [2m│ gzip: 1.19 kB[22m
+packages/validation build: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m1.13 kB[22m [2m│ gzip: 0.43 kB[22m
+packages/validation build: [34mℹ[39m 2 files, total: 6.33 kB
+packages/validation build: [32m✔[39m Build complete in [32m733ms[39m
+packages/validation build: Done
+packages/visual-editing build$ NODE_ENV=production tsdown
+packages/visual-editing build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/visual-editing build: [34mℹ[39m Using tsdown config: [4m/home/jean/dev/Hippocast/dev/deps/directus-cms-2/packages/visual-editing/tsdown.config.js[24m
+packages/visual-editing build: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/visual-editing build: [34mℹ[39m target: [34mes2022[39m
+packages/visual-editing build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/visual-editing build: [34mℹ[39m entry: [34msrc/index.ts, src/types.ts[39m
+packages/visual-editing build: [34mℹ[39m target: [34mes2022[39m
+packages/visual-editing build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/visual-editing build: [34mℹ[39m Build start
+packages/visual-editing build: [34mℹ[39m Cleaning 14 files
+packages/visual-editing build: [34mℹ[39m [2mdist/[22m[1mvisual-editing.js[22m      [2m20.34 kB[22m [2m│ gzip:  5.77 kB[22m
+packages/visual-editing build: [34mℹ[39m [2mdist/[22mvisual-editing.js.map  [2m50.05 kB[22m [2m│ gzip: 12.45 kB[22m
+packages/visual-editing build: [34mℹ[39m 2 files, total: 70.39 kB
+packages/visual-editing build: [32m✔[39m Build complete in [32m11113ms[39m
+packages/visual-editing build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mindex.cjs[22m      [2m20.33 kB[22m [2m│ gzip:  5.78 kB[22m
+packages/visual-editing build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[1mtypes.cjs[22m      [2m 0.00 kB[22m [2m│ gzip:  0.02 kB[22m
+packages/visual-editing build: [34mℹ[39m [33m[CJS][39m [2mdist/[22mindex.cjs.map  [2m50.04 kB[22m [2m│ gzip: 12.45 kB[22m
+packages/visual-editing build: [34mℹ[39m [33m[CJS][39m 3 files, total: 70.37 kB
+packages/visual-editing build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mindex.js[22m                [2m19.82 kB[22m [2m│ gzip:  5.51 kB[22m
+packages/visual-editing build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[1mtypes.js[22m                [2m 0.01 kB[22m [2m│ gzip:  0.03 kB[22m
+packages/visual-editing build: [34mℹ[39m [34m[ESM][39m [2mdist/[22mindex.js.map            [2m50.03 kB[22m [2m│ gzip: 12.44 kB[22m
+packages/visual-editing build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m              [2m 0.93 kB[22m [2m│ gzip:  0.44 kB[22m
+packages/visual-editing build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32m[1mtypes.d.ts[22m[39m              [2m 0.49 kB[22m [2m│ gzip:  0.24 kB[22m
+packages/visual-editing build: [34mℹ[39m [34m[ESM][39m [2mdist/[22m[32mdirectus-y7i0rChz.d.ts[39m  [2m 1.64 kB[22m [2m│ gzip:  0.63 kB[22m
+packages/visual-editing build: [34mℹ[39m [34m[ESM][39m 6 files, total: 72.91 kB
+packages/visual-editing build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mindex.d.cts[22m[39m              [2m0.93 kB[22m [2m│ gzip: 0.44 kB[22m
+packages/visual-editing build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32m[1mtypes.d.cts[22m[39m              [2m0.49 kB[22m [2m│ gzip: 0.24 kB[22m
+packages/visual-editing build: [34mℹ[39m [33m[CJS][39m [2mdist/[22m[32mdirectus-CyWNkLfU.d.cts[39m  [2m1.64 kB[22m [2m│ gzip: 0.63 kB[22m
+packages/visual-editing build: [34mℹ[39m [33m[CJS][39m 3 files, total: 3.06 kB
+packages/visual-editing build: [32m✔[39m Build complete in [32m11332ms[39m
+packages/visual-editing build: Done
+tests/sandbox build$ tsdown src/index.ts src/cli.ts --dts --unbundle && copyfiles src/docker/*.yml dist -u 1
+tests/sandbox build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+tests/sandbox build: [34mℹ[39m entry: [34msrc/cli.ts, src/index.ts[39m
+tests/sandbox build: [34mℹ[39m target: [34mnode22.0.0[39m
+tests/sandbox build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+tests/sandbox build: [34mℹ[39m Build start
+tests/sandbox build: [34mℹ[39m Cleaning 38 files
+packages/themes build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m    [2m37.72 kB[22m [2m│ gzip: 6.25 kB[22m
+packages/themes build: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m73.20 kB[22m [2m│ gzip: 3.13 kB[22m
+packages/themes build: [34mℹ[39m 2 files, total: 110.91 kB
+packages/themes build: [32m✔[39m Build complete in [32m17353ms[39m
+packages/themes build: Done
+tests/sandbox build: [34mℹ[39m [2mdist/[22m[1mcli.js[22m             [2m 2.63 kB[22m [2m│ gzip: 1.22 kB[22m
+tests/sandbox build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m           [2m 0.18 kB[22m [2m│ gzip: 0.10 kB[22m
+tests/sandbox build: [34mℹ[39m [2mdist/[22mconfig.js          [2m 8.37 kB[22m [2m│ gzip: 3.86 kB[22m
+tests/sandbox build: [34mℹ[39m [2mdist/[22msandbox.js         [2m 5.72 kB[22m [2m│ gzip: 1.79 kB[22m
+tests/sandbox build: [34mℹ[39m [2mdist/[22msteps/api.js       [2m 5.01 kB[22m [2m│ gzip: 1.67 kB[22m
+tests/sandbox build: [34mℹ[39m [2mdist/[22msteps/docker.js    [2m 2.90 kB[22m [2m│ gzip: 1.16 kB[22m
+tests/sandbox build: [34mℹ[39m [2mdist/[22msteps/schema.js    [2m 2.90 kB[22m [2m│ gzip: 1.11 kB[22m
+tests/sandbox build: [34mℹ[39m [2mdist/[22msteps/database.js  [2m 2.26 kB[22m [2m│ gzip: 1.00 kB[22m
+tests/sandbox build: [34mℹ[39m [2mdist/[22mlogger.js          [2m 1.67 kB[22m [2m│ gzip: 0.72 kB[22m
+tests/sandbox build: [34mℹ[39m [2mdist/[22msteps/app.js       [2m 1.37 kB[22m [2m│ gzip: 0.71 kB[22m
+tests/sandbox build: [34mℹ[39m [2mdist/[22msteps/license.js   [2m 0.95 kB[22m [2m│ gzip: 0.53 kB[22m
+tests/sandbox build: [34mℹ[39m [2mdist/[22mfind-directus.js   [2m 0.67 kB[22m [2m│ gzip: 0.36 kB[22m
+tests/sandbox build: [34mℹ[39m [2mdist/[22mkill.js            [2m 0.35 kB[22m [2m│ gzip: 0.26 kB[22m
+tests/sandbox build: [34mℹ[39m [2mdist/[22mport.js            [2m 0.35 kB[22m [2m│ gzip: 0.21 kB[22m
+tests/sandbox build: [34mℹ[39m [2mdist/[22msteps/index.js     [2m 0.23 kB[22m [2m│ gzip: 0.15 kB[22m
+tests/sandbox build: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m         [2m 0.33 kB[22m [2m│ gzip: 0.14 kB[22m
+tests/sandbox build: [34mℹ[39m [2mdist/[22m[32m[1mcli.d.ts[22m[39m           [2m 0.01 kB[22m [2m│ gzip: 0.03 kB[22m
+tests/sandbox build: [34mℹ[39m [2mdist/[22m[32mconfig.d.ts[39m        [2m12.54 kB[22m [2m│ gzip: 3.41 kB[22m
+tests/sandbox build: [34mℹ[39m [2mdist/[22m[32msandbox.d.ts[39m       [2m 3.59 kB[22m [2m│ gzip: 1.35 kB[22m
+tests/sandbox build: [34mℹ[39m [2mdist/[22m[32mlogger.d.ts[39m        [2m 0.62 kB[22m [2m│ gzip: 0.31 kB[22m
+tests/sandbox build: [34mℹ[39m [2mdist/[22m[32msteps/api.d.ts[39m     [2m 0.22 kB[22m [2m│ gzip: 0.16 kB[22m
+tests/sandbox build: [34mℹ[39m [2mdist/[22m[32mport.d.ts[39m          [2m 0.14 kB[22m [2m│ gzip: 0.12 kB[22m
+tests/sandbox build: [34mℹ[39m 22 files, total: 53.01 kB
+tests/sandbox build: [32m✔[39m Build complete in [32m8952ms[39m
+tests/sandbox build: Done
+packages/extensions-registry build$ tsdown src/index.ts --dts
+packages/composables build$ tsdown src/index.ts --dts
+packages/composables build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/extensions-registry build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+packages/composables build: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/composables build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/composables build: [34mℹ[39m Build start
+packages/composables build: [34mℹ[39m Cleaning 2 files
+packages/extensions-registry build: [34mℹ[39m entry: [34msrc/index.ts[39m
+packages/extensions-registry build: [34mℹ[39m tsconfig: [34mtsconfig.json[39m
+packages/extensions-registry build: [34mℹ[39m Build start
+packages/extensions-registry build: [34mℹ[39m Cleaning 2 files
+packages/extensions-registry build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m    [2m12.59 kB[22m [2m│ gzip: 2.90 kB[22m
+packages/extensions-registry build: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m 9.70 kB[22m [2m│ gzip: 2.21 kB[22m
+packages/extensions-registry build: [34mℹ[39m 2 files, total: 22.28 kB
+packages/extensions-registry build: [32m✔[39m Build complete in [32m5957ms[39m
+packages/extensions-registry build: Done
+packages/composables build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m    [2m51.19 kB[22m [2m│ gzip: 13.50 kB[22m
+packages/composables build: [34mℹ[39m [2mdist/[22m[32m[1mindex.d.ts[22m[39m  [2m38.76 kB[22m [2m│ gzip:  9.69 kB[22m
+packages/composables build: [34mℹ[39m 2 files, total: 89.94 kB
+packages/composables build: [32m✔[39m Build complete in [32m6968ms[39m
+packages/composables build: Done
+packages/extensions-sdk build$ tsc --project tsconfig.prod.json
+packages/extensions-sdk build: Done
+app build$ vite build
+app build: vite v8.0.8 building client environment for production...
+app build: [2K
+app build: transforming...✓ 5451 modules transformed.
+app build: rendering chunks...
+app build: computing gzip size...
+app build: dist/index.html                                             3.37 kB │ gzip:     1.04 kB
+app build: dist/assets/FiraMono-Medium-CE-6Frqh.woff2                 16.14 kB
+app build: dist/assets/FiraMono-Medium-CjwgnWCQ.woff                  21.27 kB
+app build: dist/assets/merriweather-light-MAZijcp-.woff2              23.59 kB
+app build: dist/assets/merriweather-regular-D4NWdWaV.woff2            23.86 kB
+app build: dist/assets/merriweather-bold-Ehu1LSIs.woff2               24.17 kB
+app build: dist/assets/merriweather-italic-DQHU05JA.woff2             27.18 kB
+app build: dist/assets/merriweather-light-_dgfXFiJ.woff               30.76 kB
+app build: dist/assets/merriweather-regular-B5k5JYwq.woff             31.07 kB
+app build: dist/assets/merriweather-bold-CQICjned.woff                31.45 kB
+app build: dist/assets/merriweather-italic-DDdpEp2m.woff              35.07 kB
+app build: dist/assets/Inter-Black-DQ32R15S.woff2                     93.18 kB
+app build: dist/assets/Inter-Bold-d8J9BkrN.woff2                      95.92 kB
+app build: dist/assets/Inter-Regular-C2oJmTkV.woff2                  100.12 kB
+app build: dist/assets/Inter-Medium-IZr8HYrM.woff2                   106.72 kB
+app build: dist/assets/Inter-SemiBold-1vGiIFm-.woff2                 107.23 kB
+app build: dist/assets/Inter-MediumItalic-eHnJB7Jg.woff2             112.50 kB
+app build: dist/assets/Inter-Black-tY25MZ8m.woff                     124.67 kB
+app build: dist/assets/Inter-Bold-DebvEmVN.woff                      128.00 kB
+app build: dist/assets/Inter-Regular-C9wQxk6G.woff                   134.65 kB
+app build: dist/assets/Inter-Medium-DosJTVus.woff                    142.83 kB
+app build: dist/assets/Inter-SemiBold-CUDcKm_l.woff                  143.24 kB
+app build: dist/assets/Inter-MediumItalic-C-HF1KIs.woff              149.18 kB
+app build: dist/assets/sprite-Cvp8IOkP.svg                           155.48 kB │ gzip:    71.09 kB
+app build: dist/assets/material-symbols-ClwuWZXz.woff2               391.12 kB
+app build: dist/assets/shader-background-80ZVAjjP.css                  0.08 kB │ gzip:     0.09 kB
+app build: dist/assets/collection-Dk6lM6ZC.css                         0.14 kB │ gzip:     0.12 kB
+app build: dist/assets/item-CnUpJxoa.css                               0.24 kB │ gzip:     0.15 kB
+app build: dist/assets/show-hint-C8Xz_jHS.css                          0.42 kB │ gzip:     0.27 kB
+app build: dist/assets/v-breadcrumb-DCBNEsz6.css                       1.33 kB │ gzip:     0.34 kB
+app build: dist/assets/index-CccQUi3x.css                             52.97 kB │ gzip:    10.83 kB
+app build: dist/assets/input-rich-text-html-BRMnfiGn.css              86.09 kB │ gzip:    13.56 kB
+app build: dist/assets/router-iF_q9PLj.css                           643.13 kB │ gzip:    90.74 kB
+app build: dist/assets/sw-KE-qXGiKV9_.js                               0.03 kB │ gzip:     0.05 kB
+app build: dist/assets/sw-TZ-CnOIWxqJ.js                               0.03 kB │ gzip:     0.05 kB
+app build: dist/assets/tg-TJ-BakVIwRq.js                               0.03 kB │ gzip:     0.05 kB
+app build: dist/assets/css-DqVvV93_.js                                 0.05 kB │ gzip:     0.07 kB
+app build: dist/assets/xml-egRN_nZh.js                                 0.05 kB │ gzip:     0.07 kB
+app build: dist/assets/markdown-DJ4-4_WW.js                            0.06 kB │ gzip:     0.08 kB
+app build: dist/assets/htmlmixed-Cl_n0j3V.js                           0.06 kB │ gzip:     0.08 kB
+app build: dist/assets/javascript-Du7kr3gt.js                          0.06 kB │ gzip:     0.08 kB
+app build: dist/assets/matchbrackets-Bk9-2WAB.js                       0.06 kB │ gzip:     0.08 kB
+app build: dist/assets/_plugin-vue_export-helper-BPRVag0c.js           0.08 kB │ gzip:     0.09 kB
+app build: dist/assets/private-DuU0FiQA.js                             0.13 kB │ gzip:     0.12 kB
+app build: dist/assets/normalizeDates-_qLytDxr.js                      0.14 kB │ gzip:     0.14 kB
+app build: dist/assets/isSameWeek-CDufBCS3.js                          0.16 kB │ gzip:     0.15 kB
+app build: dist/assets/formatRelative-CJjVzlSN.js                      0.18 kB │ gzip:     0.15 kB
+app build: dist/assets/en-au-hRnc6VZH.js                               0.22 kB │ gzip:     0.19 kB
+app build: dist/assets/en-gb-C9udJ3Z3.js                               0.22 kB │ gzip:     0.19 kB
+app build: dist/assets/en-nz-B3hv_7ZL.js                               0.22 kB │ gzip:     0.19 kB
+app build: dist/assets/ug-QbmEXkNo.js                                  0.23 kB │ gzip:     0.20 kB
+app build: dist/assets/zh-tw-C9HmZ5ur.js                               0.25 kB │ gzip:     0.23 kB
+app build: dist/assets/ko-D7NEVxdG.js                                  0.26 kB │ gzip:     0.23 kB
+app build: dist/assets/nl-wSm2FcUN.js                                  0.27 kB │ gzip:     0.21 kB
+app build: dist/assets/es-us-Dx3FRxOh.js                               0.27 kB │ gzip:     0.22 kB
+app build: dist/assets/af-BTs3iB1D.js                                  0.27 kB │ gzip:     0.21 kB
+app build: dist/assets/nn-D3vRUkeg.js                                  0.27 kB │ gzip:     0.21 kB
+app build: dist/assets/tr-CS6ILzQV.js                                  0.27 kB │ gzip:     0.22 kB
+app build: dist/assets/da-B-MEhEKB.js                                  0.27 kB │ gzip:     0.21 kB
+app build: dist/assets/cy-BFS3IO2G.js                                  0.27 kB │ gzip:     0.21 kB
+app build: dist/assets/vue-i18n.B5UH7b7k.entry.js                      0.28 kB │ gzip:     0.19 kB
+app build: dist/assets/eo-Du4BSgLA.js                                  0.28 kB │ gzip:     0.22 kB
+app build: dist/assets/eu-sEQYJn3D.js                                  0.28 kB │ gzip:     0.21 kB
+app build: dist/assets/hu-C-qcWY_r.js                                  0.28 kB │ gzip:     0.23 kB
+app build: dist/assets/ja-BfcsVOgL.js                                  0.28 kB │ gzip:     0.25 kB
+app build: dist/assets/pt-B1WLAtaF.js                                  0.28 kB │ gzip:     0.22 kB
+app build: dist/assets/uz-DSXlP8V4.js                                  0.28 kB │ gzip:     0.22 kB
+app build: dist/assets/sl-DkeQgbIx.js                                  0.28 kB │ gzip:     0.22 kB
+app build: dist/assets/zh-cn-C0ohVtQe.js                               0.28 kB │ gzip:     0.25 kB
+app build: dist/assets/ca-CsOPZ_m1.js                                  0.28 kB │ gzip:     0.22 kB
+app build: dist/assets/id-D1QtA5_z.js                                  0.29 kB │ gzip:     0.22 kB
+app build: dist/assets/lb-LFf19OVu.js                                  0.29 kB │ gzip:     0.23 kB
+app build: dist/assets/is-D_gDkVmJ.js                                  0.29 kB │ gzip:     0.23 kB
+app build: dist/assets/lt-Byc0p4Cj.js                                  0.29 kB │ gzip:     0.24 kB
+app build: dist/assets/fr-ca-CPM_IDfz.js                               0.29 kB │ gzip:     0.23 kB
+app build: dist/assets/lv-PtfJLk6s.js                                  0.29 kB │ gzip:     0.24 kB
+app build: dist/assets/cs-B3dSviC_.js                                  0.30 kB │ gzip:     0.25 kB
+app build: dist/assets/hr-DAn_Kg6o.js                                  0.30 kB │ gzip:     0.24 kB
+app build: dist/assets/sr-tVHNV5Rd.js                                  0.30 kB │ gzip:     0.25 kB
+app build: dist/assets/et-ChnyBl5q.js                                  0.30 kB │ gzip:     0.24 kB
+app build: dist/assets/fi-BWY6q94n.js                                  0.30 kB │ gzip:     0.23 kB
+app build: dist/assets/it-otaxqSvW.js                                  0.30 kB │ gzip:     0.23 kB
+app build: dist/assets/pl-N8TRegn9.js                                  0.30 kB │ gzip:     0.24 kB
+app build: dist/assets/sq-BuQKkC1e.js                                  0.30 kB │ gzip:     0.24 kB
+app build: dist/assets/bs-B5YmJBLb.js                                  0.30 kB │ gzip:     0.24 kB
+app build: dist/assets/fr-ch-BTExyOYY.js                               0.31 kB │ gzip:     0.24 kB
+app build: dist/assets/ro-DLry5YD_.js                                  0.31 kB │ gzip:     0.25 kB
+app build: dist/assets/az-DGu44bff.js                                  0.31 kB │ gzip:     0.25 kB
+app build: dist/assets/sk-T51TH_d7.js                                  0.31 kB │ gzip:     0.25 kB
+app build: dist/assets/he-BrUyQmzJ.js                                  0.32 kB │ gzip:     0.24 kB
+app build: dist/assets/ms-BxJ8hxWI.js                                  0.32 kB │ gzip:     0.24 kB
+app build: dist/assets/vi-D9Sb4ckm.js                                  0.32 kB │ gzip:     0.28 kB
+app build: dist/assets/fr-CcR8PxOS.js                                  0.33 kB │ gzip:     0.25 kB
+app build: dist/assets/ar-ra6Lymv8.js                                  0.34 kB │ gzip:     0.26 kB
+app build: dist/assets/ar-dz-Cew_tcJ1.js                               0.34 kB │ gzip:     0.26 kB
+app build: dist/assets/ar-sa-CmNDw3-N.js                               0.34 kB │ gzip:     0.26 kB
+app build: dist/assets/ar-tn-BYlxCKbM.js                               0.34 kB │ gzip:     0.26 kB
+app build: dist/assets/ar-kw-B2M51nK0.js                               0.34 kB │ gzip:     0.26 kB
+app build: dist/assets/ar-ly-twptYaHT.js                               0.34 kB │ gzip:     0.26 kB
+app build: dist/assets/ar-ma-8FjywR9W.js                               0.34 kB │ gzip:     0.26 kB
+app build: dist/assets/bg-BatNRend.js                                  0.34 kB │ gzip:     0.28 kB
+app build: dist/assets/fa-CI1yybjH.js                                  0.35 kB │ gzip:     0.27 kB
+app build: dist/assets/mk-CIBWm-jB.js                                  0.36 kB │ gzip:     0.28 kB
+app build: dist/assets/kk-D-JMx-16.js                                  0.36 kB │ gzip:     0.30 kB
+app build: dist/assets/sr-cyrl-CVtPayK7.js                             0.37 kB │ gzip:     0.29 kB
+app build: dist/assets/ru-C9__VK3N.js                                  0.37 kB │ gzip:     0.29 kB
+app build: dist/assets/hy-am-wRaXYM23.js                               0.40 kB │ gzip:     0.30 kB
+app build: dist/assets/uk-DO55DCol.js                                  0.40 kB │ gzip:     0.31 kB
+app build: dist/assets/bn-BGj9TKoR.js                                  0.41 kB │ gzip:     0.28 kB
+app build: dist/assets/el-CMAe18EB.js                                  0.41 kB │ gzip:     0.31 kB
+app build: dist/assets/ne-ecC0b62M.js                                  0.43 kB │ gzip:     0.30 kB
+app build: dist/assets/ka-CCx8J_h-.js                                  0.44 kB │ gzip:     0.29 kB
+app build: dist/assets/hi-w4xMvy_W.js                                  0.46 kB │ gzip:     0.32 kB
+app build: dist/assets/pinia.DDXwdHfS.entry.js                         0.47 kB │ gzip:     0.28 kB
+app build: dist/assets/nb-nLtUikXc.js                                  0.47 kB │ gzip:     0.31 kB
+app build: dist/assets/ta-in-CIAw_ceP.js                               0.51 kB │ gzip:     0.32 kB
+app build: dist/assets/th-CTpMwRHS.js                                  0.53 kB │ gzip:     0.31 kB
+app build: dist/assets/@directus_extensions-sdk.DMFsX5i2.entry.js      0.56 kB │ gzip:     0.31 kB
+app build: dist/assets/diff-Dy4L2x5S.js                                0.62 kB │ gzip:     0.40 kB
+app build: dist/assets/gl-DO4cAejx.js                                  0.64 kB │ gzip:     0.37 kB
+app build: dist/assets/es-gYuQpOq5.js                                  0.64 kB │ gzip:     0.38 kB
+app build: dist/assets/startOfWeek-B4r3gx00.js                         0.65 kB │ gzip:     0.40 kB
+app build: dist/assets/sv-u7bw-EOf.js                                  0.65 kB │ gzip:     0.40 kB
+app build: dist/assets/vue-router.D--RaA9R.entry.js                    0.67 kB │ gzip:     0.35 kB
+app build: dist/assets/fr-ooegxKU2.js                                  0.69 kB │ gzip:     0.37 kB
+app build: dist/assets/pt-br-BQYA44bR.js                               0.70 kB │ gzip:     0.40 kB
+app build: dist/assets/fr-CA-D42JZwPA.js                               0.70 kB │ gzip:     0.37 kB
+app build: dist/assets/en-GB-Pa2B1kxJ.js                               0.70 kB │ gzip:     0.36 kB
+app build: dist/assets/en-ZA-Djgd9AWD.js                               0.71 kB │ gzip:     0.37 kB
+app build: dist/assets/en-AU-Bkkk1EBX.js                               0.71 kB │ gzip:     0.37 kB
+app build: dist/assets/en-NZ-CKHxjre3.js                               0.71 kB │ gzip:     0.37 kB
+app build: dist/assets/en-IN-b6TRRbSP.js                               0.71 kB │ gzip:     0.37 kB
+app build: dist/assets/haskell-literate-CvIeWG9i.js                    0.77 kB │ gzip:     0.43 kB
+app build: dist/assets/en-US-BZ1bcVcv.js                               0.77 kB │ gzip:     0.41 kB
+app build: dist/assets/de-Bq4hnOlx.js                                  0.78 kB │ gzip:     0.45 kB
+app build: dist/assets/de-at-2EHL0Pd3.js                               0.78 kB │ gzip:     0.45 kB
+app build: dist/assets/chunk-BGWvJHEH.js                               0.81 kB │ gzip:     0.46 kB
+app build: dist/assets/fr-CH-DktbVAZp.js                               0.85 kB │ gzip:     0.46 kB
+app build: dist/assets/si-LK-DnP9H9S3.js                               0.91 kB │ gzip:     0.48 kB
+app build: dist/assets/autorefresh-rrKk-mFQ.js                         0.92 kB │ gzip:     0.44 kB
+app build: dist/assets/brainfuck-CVrsq8xZ.js                           0.92 kB │ gzip:     0.49 kB
+app build: dist/assets/v-breadcrumb-C5FAd-P0.js                        0.97 kB │ gzip:     0.52 kB
+app build: dist/assets/properties-BrcPIk0g.js                          1.02 kB │ gzip:     0.51 kB
+app build: dist/assets/cmake-CmZGUonW.js                               1.09 kB │ gzip:     0.62 kB
+app build: dist/assets/formatDistance-wjQCT5kM.js                      1.09 kB │ gzip:     0.38 kB
+app build: dist/assets/protobuf-BRmgSwss.js                            1.15 kB │ gzip:     0.69 kB
+app build: dist/assets/htmlembedded-LKI8-jKb.js                        1.15 kB │ gzip:     0.52 kB
+app build: dist/assets/yaml-frontmatter-cDa0I_Rk.js                    1.20 kB │ gzip:     0.59 kB
+app build: dist/assets/solr-9Sbjzz1I.js                                1.24 kB │ gzip:     0.65 kB
+app build: dist/assets/asciiarmor-Df_CTItf.js                          1.27 kB │ gzip:     0.59 kB
+app build: dist/assets/http-bdFtTBN5.js                                1.32 kB │ gzip:     0.66 kB
+app build: dist/assets/troff-6bfMf-hH.js                               1.35 kB │ gzip:     0.61 kB
+app build: dist/assets/buildMatchPatternFn-MrHfURTm.js                 1.37 kB │ gzip:     0.55 kB
+app build: dist/assets/overlay-Brdtfl3a.js                             1.38 kB │ gzip:     0.57 kB
+app build: dist/assets/tornado-7y0JneFK.js                             1.39 kB │ gzip:     0.77 kB
+app build: dist/assets/active-line-DT4DvNTm.js                         1.42 kB │ gzip:     0.66 kB
+app build: dist/assets/spreadsheet-D8VIucGM.js                         1.45 kB │ gzip:     0.69 kB
+app build: dist/assets/toml-DVkBnrd6.js                                1.45 kB │ gzip:     0.66 kB
+app build: dist/assets/handlebars-aRbT3XIl.js                          1.56 kB │ gzip:     0.69 kB
+app build: dist/assets/mbox-yntLskb_.js                                1.72 kB │ gzip:     0.82 kB
+app build: dist/assets/en-CA-DGu_kgOT.js                               1.75 kB │ gzip:     0.68 kB
+app build: dist/assets/pegjs-BAwbj0c6.js                               1.75 kB │ gzip:     0.80 kB
+app build: dist/assets/mark-selection-D_mmsd0H.js                      1.84 kB │ gzip:     0.83 kB
+app build: dist/assets/yaml-CzkeyJD2.js                                1.85 kB │ gzip:     0.89 kB
+app build: dist/assets/sieve-DxEw8yIL.js                               1.92 kB │ gzip:     0.91 kB
+app build: dist/assets/eiffel-CqRtp7Ir.js                              1.98 kB │ gzip:     1.05 kB
+app build: dist/assets/factor-Cc7z89Da.js                              1.98 kB │ gzip:     0.77 kB
+app build: dist/assets/rpm-Ci7PqN72.js                                 1.98 kB │ gzip:     0.98 kB
+app build: dist/assets/z80-Ck93jYiJ.js                                 2.08 kB │ gzip:     0.95 kB
+app build: dist/assets/vue-D_Pe6tjB.js                                 2.10 kB │ gzip:     0.86 kB
+app build: dist/assets/mumps-s9-pWH7Y.js                               2.14 kB │ gzip:     1.11 kB
+app build: dist/assets/elm-B_D9dZPD.js                                 2.17 kB │ gzip:     0.96 kB
+app build: dist/assets/mathematica-C_NNhDKM.js                         2.19 kB │ gzip:     0.94 kB
+app build: dist/assets/item-DsAHr_oq.js                                2.21 kB │ gzip:     1.04 kB
+app build: dist/assets/twig-C5x_AcME.js                                2.21 kB │ gzip:     1.00 kB
+app build: dist/assets/dockerfile-Bl2QE_0w.js                          2.24 kB │ gzip:     0.82 kB
+app build: dist/assets/turtle-CfkQmQCF.js                              2.25 kB │ gzip:     1.03 kB
+app build: dist/assets/de-j3jYfczG.js                                  2.27 kB │ gzip:     0.82 kB
+app build: dist/assets/smalltalk-DvhGDbeQ.js                           2.28 kB │ gzip:     0.99 kB
+app build: dist/assets/de-AT-D5PLGRwL.js                               2.28 kB │ gzip:     0.82 kB
+app build: dist/assets/haml-BA-vUGtM.js                                2.36 kB │ gzip:     0.92 kB
+app build: dist/assets/fcl-CPhZvEAh.js                                 2.38 kB │ gzip:     1.12 kB
+app build: dist/assets/dtd-DaBlCwZ2.js                                 2.40 kB │ gzip:     1.03 kB
+app build: dist/assets/octave-alUCMrdr.js                              2.41 kB │ gzip:     1.24 kB
+app build: dist/assets/multiplex-Bd3fkcbc.js                           2.42 kB │ gzip:     1.00 kB
+app build: dist/assets/yacas-D6gYCyvy.js                               2.44 kB │ gzip:     1.23 kB
+app build: dist/assets/rust-DVjCtMQ1.js                                2.46 kB │ gzip:     1.11 kB
+app build: dist/assets/jsx-CgSWq4RH.js                                 2.49 kB │ gzip:     1.11 kB
+app build: dist/assets/ntriples-BmEYf_6E.js                            2.49 kB │ gzip:     0.91 kB
+app build: dist/assets/pascal-BUqNhcgi.js                              2.49 kB │ gzip:     1.28 kB
+app build: dist/assets/commonlisp-B6eoiptD.js                          2.63 kB │ gzip:     1.26 kB
+app build: dist/assets/ebnf-C3Ri8Q-A.js                                2.63 kB │ gzip:     1.11 kB
+app build: dist/assets/dart-Bn64gGNx.js                                2.63 kB │ gzip:     1.26 kB
+app build: dist/assets/tcl-CxvwvF7g.js                                 2.64 kB │ gzip:     1.37 kB
+app build: dist/assets/apl-DHsTKqr9.js                                 2.74 kB │ gzip:     1.50 kB
+app build: dist/assets/shell-Bigen_yO.js                               2.77 kB │ gzip:     1.37 kB
+app build: dist/assets/gfm-fCsmN8LV.js                                 2.77 kB │ gzip:     1.59 kB
+app build: dist/assets/webidl-BR0quszy.js                              2.79 kB │ gzip:     1.40 kB
+app build: dist/assets/jinja2-hjhBbrnC.js                              2.79 kB │ gzip:     1.18 kB
+app build: dist/assets/puppet-CcDVwfwI.js                              2.85 kB │ gzip:     1.35 kB
+app build: dist/assets/match-highlighter-Bm3gwsVB.js                   2.86 kB │ gzip:     1.25 kB
+app build: dist/assets/pig-D5kIdPp_.js                                 2.95 kB │ gzip:     1.60 kB
+app build: dist/assets/forth-CO_Dj080.js                               2.99 kB │ gzip:     1.51 kB
+app build: dist/assets/velocity-D2YGVMvq.js                            3.03 kB │ gzip:     1.26 kB
+app build: dist/assets/htmlmixed-m-_QXh5s.js                           3.04 kB │ gzip:     1.37 kB
+app build: dist/assets/smarty-CQ7CmtM-.js                              3.07 kB │ gzip:     1.29 kB
+app build: dist/assets/tiddlywiki-CVXB0MXk.js                          3.07 kB │ gzip:     1.23 kB
+app build: dist/assets/go-wyIQlmZ7.js                                  3.12 kB │ gzip:     1.47 kB
+app build: dist/assets/matchbrackets-DoTWPY-w.js                       3.19 kB │ gzip:     1.41 kB
+app build: dist/assets/oz-DE2rYGtQ.js                                  3.22 kB │ gzip:     1.42 kB
+app build: dist/assets/km-KH-hdwaM_-C.js                               3.22 kB │ gzip:     1.19 kB
+app build: dist/assets/r-S3mwnW2d.js                                   3.38 kB │ gzip:     1.54 kB
+app build: dist/assets/javascript-hint-Bpvl8MO5.js                     3.39 kB │ gzip:     1.53 kB
+app build: dist/assets/modelica-CRjrr9AI.js                            3.39 kB │ gzip:     1.57 kB
+app build: dist/assets/stex-C6VtdomM.js                                3.41 kB │ gzip:     1.30 kB
+app build: dist/assets/lua-7R_DwzLH.js                                 3.48 kB │ gzip:     1.58 kB
+app build: dist/assets/tiki-CrDR2s9_.js                                3.59 kB │ gzip:     1.45 kB
+app build: dist/assets/wast-CF-dPAP_.js                                3.61 kB │ gzip:     1.72 kB
+app build: dist/assets/vhdl-Isglz_ZE.js                                3.62 kB │ gzip:     1.66 kB
+app build: dist/assets/sparql-p-9MHpPl.js                              3.64 kB │ gzip:     1.75 kB
+app build: dist/assets/collection-Cp5ITxW2.js                          3.76 kB │ gzip:     1.58 kB
+app build: dist/assets/cypher-BsVX0HNM.js                              3.79 kB │ gzip:     1.83 kB
+app build: dist/assets/mscgen-B_Sk4Ipc.js                              3.94 kB │ gzip:     1.16 kB
+app build: dist/assets/q-D_-WUZP-.js                                   3.97 kB │ gzip:     1.83 kB
+app build: dist/assets/match-BXJ8D8Ql.js                               3.98 kB │ gzip:     1.36 kB
+app build: dist/assets/vb-Fp3sJdzu.js                                  4.00 kB │ gzip:     1.98 kB
+app build: dist/assets/d-DSgjpw-o.js                                   4.05 kB │ gzip:     1.85 kB
+app build: dist/assets/swift-YKCUvrDN.js                               4.07 kB │ gzip:     1.96 kB
+app build: dist/assets/simple-jPEbwGDv.js                              4.15 kB │ gzip:     1.76 kB
+app build: dist/assets/fortran-DGp86ChZ.js                             4.18 kB │ gzip:     2.10 kB
+app build: dist/assets/asn.1-CpTisD6b.js                               4.26 kB │ gzip:     2.14 kB
+app build: dist/assets/coffeescript-CK3rZsyD.js                        4.30 kB │ gzip:     1.87 kB
+app build: dist/assets/dylan-K0sAWAwb.js                               4.31 kB │ gzip:     1.77 kB
+app build: dist/assets/asterisk-DNpNKg3c.js                            4.38 kB │ gzip:     1.89 kB
+app build: dist/assets/groovy-BYvuzRET.js                              4.42 kB │ gzip:     1.90 kB
+app build: dist/assets/ttcn-cfg-CnVo_wXv.js                            4.46 kB │ gzip:     1.90 kB
+app build: dist/assets/livescript-CW2_Q0L1.js                          4.47 kB │ gzip:     1.80 kB
+app build: dist/assets/gas-Cjy6QWM6.js                                 4.62 kB │ gzip:     1.40 kB
+app build: dist/assets/haskell-D0aDYE_n.js                             4.64 kB │ gzip:     2.12 kB
+app build: dist/assets/vue.C7rYGRBh.entry.js                           4.66 kB │ gzip:     2.04 kB
+app build: dist/assets/django-pOjob0kc.js                              4.67 kB │ gzip:     1.73 kB
+app build: dist/assets/match-palDOzSO.js                               4.76 kB │ gzip:     1.75 kB
+app build: dist/assets/sass-BT5-3QYl.js                                4.80 kB │ gzip:     1.77 kB
+app build: dist/assets/match-SYZ4sGzC.js                               4.88 kB │ gzip:     1.43 kB
+app build: dist/assets/nl-BE-CBEIpVZg.js                               4.98 kB │ gzip:     1.80 kB
+app build: dist/assets/nl-BOsXpaPa.js                                  4.98 kB │ gzip:     1.79 kB
+app build: dist/assets/ht-Cn78P9_W.js                                  4.99 kB │ gzip:     1.80 kB
+app build: dist/assets/nb-k3DZOwUK.js                                  5.07 kB │ gzip:     1.78 kB
+app build: dist/assets/ko-DPlm0PEt.js                                  5.14 kB │ gzip:     1.76 kB
+app build: dist/assets/mllike-DPsNvTwW.js                              5.16 kB │ gzip:     1.70 kB
+app build: dist/assets/nn-CUttO-zM.js                                  5.17 kB │ gzip:     1.85 kB
+app build: dist/assets/eo-BzHXXKtR.js                                  5.20 kB │ gzip:     1.87 kB
+app build: dist/assets/uz-D-lIRlbP.js                                  5.27 kB │ gzip:     1.78 kB
+app build: dist/assets/crystal-Cerkj_k8.js                             5.33 kB │ gzip:     2.25 kB
+app build: dist/assets/ecl-CeEofczh.js                                 5.41 kB │ gzip:     2.45 kB
+app build: dist/assets/ms-CF-LoyYB.js                                  5.43 kB │ gzip:     1.77 kB
+app build: dist/assets/id-CKg2-Xm8.js                                  5.44 kB │ gzip:     1.77 kB
+app build: dist/assets/ruby-D499qwME.js                                5.44 kB │ gzip:     2.35 kB
+app build: dist/assets/hu-CMHTdRwX.js                                  5.49 kB │ gzip:     2.08 kB
+app build: dist/assets/sq-dBGeLLaV.js                                  5.49 kB │ gzip:     1.91 kB
+app build: dist/assets/ttcn-HmPlSdGo.js                                5.51 kB │ gzip:     2.43 kB
+app build: dist/assets/af-D4O8hich.js                                  5.51 kB │ gzip:     1.88 kB
+app build: dist/assets/da-8adL70DF.js                                  5.56 kB │ gzip:     1.86 kB
+app build: dist/assets/ja-BkFrZsVC.js                                  5.63 kB │ gzip:     1.97 kB
+app build: dist/assets/zh-TW-lg5R8974.js                               5.63 kB │ gzip:     1.96 kB
+app build: dist/assets/julia-Ct6ZcaBY.js                               5.64 kB │ gzip:     2.36 kB
+app build: dist/assets/ro-CMcQcwaf.js                                  5.65 kB │ gzip:     1.92 kB
+app build: dist/assets/sv-ClcPDVSS.js                                  5.67 kB │ gzip:     1.98 kB
+app build: dist/assets/gl-CV63sDsQ.js                                  5.75 kB │ gzip:     1.96 kB
+app build: dist/assets/mt-DPJ7sqvD.js                                  5.77 kB │ gzip:     2.00 kB
+app build: dist/assets/pt-BR-B6OBzQb7.js                               5.78 kB │ gzip:     2.02 kB
+app build: dist/assets/tr-C1HhVNLS.js                                  5.79 kB │ gzip:     2.06 kB
+app build: dist/assets/is-ECk4xxUb.js                                  5.79 kB │ gzip:     1.94 kB
+app build: dist/assets/vbscript-BRiCcJ9z.js                            5.80 kB │ gzip:     2.74 kB
+app build: dist/assets/zh-CN-Q6RUPJQk.js                               5.86 kB │ gzip:     2.05 kB
+app build: dist/assets/es-CODnI8GY.js                                  5.89 kB │ gzip:     1.97 kB
+app build: dist/assets/pt-CNysoFi7.js                                  5.91 kB │ gzip:     1.94 kB
+app build: dist/assets/it-DhQ0XKwM.js                                  6.09 kB │ gzip:     1.98 kB
+app build: dist/assets/eu-BsIgYcYK.js                                  6.11 kB │ gzip:     1.92 kB
+app build: dist/assets/gd-BH3sLmh6.js                                  6.15 kB │ gzip:     2.13 kB
+app build: dist/assets/xml-DJvWE0pu.js                                 6.15 kB │ gzip:     2.42 kB
+app build: dist/assets/cy-MmRjCZnN.js                                  6.23 kB │ gzip:     2.13 kB
+app build: dist/assets/mirc-CuMJuHxd.js                                6.23 kB │ gzip:     2.88 kB
+app build: dist/assets/fi-XbcHIuqv.js                                  6.32 kB │ gzip:     2.07 kB
+app build: dist/assets/mk-CVxJyW_A.js                                  6.38 kB │ gzip:     2.18 kB
+app build: dist/assets/cobol-JlFWc3ww.js                               6.54 kB │ gzip:     3.20 kB
+app build: dist/assets/az-DlQ_Earc.js                                  6.59 kB │ gzip:     2.21 kB
+app build: dist/assets/python-BhE3ecfP.js                              6.60 kB │ gzip:     2.85 kB
+app build: dist/assets/ca-Cxxn1o7N.js                                  6.61 kB │ gzip:     2.15 kB
+app build: dist/assets/xquery-C0eGjm0i.js                              6.62 kB │ gzip:     2.74 kB
+app build: dist/assets/scheme-3anVpK9X.js                              6.66 kB │ gzip:     2.54 kB
+app build: dist/assets/rst-8Ub8qpYt.js                                 6.68 kB │ gzip:     2.22 kB
+app build: dist/assets/ug-D8pReAsq.js                                  6.75 kB │ gzip:     1.92 kB
+app build: dist/assets/bg-Mulgeu_P.js                                  6.85 kB │ gzip:     2.44 kB
+app build: dist/assets/hy-CsDEumfM.js                                  6.96 kB │ gzip:     2.19 kB
+app build: dist/assets/et-HW2PD0hJ.js                                  6.98 kB │ gzip:     1.99 kB
+app build: dist/assets/fa-IR-ClBrcJAM.js                               7.01 kB │ gzip:     2.20 kB
+app build: dist/assets/nsis-DiP5Q745.js                                7.13 kB │ gzip:     3.16 kB
+app build: dist/assets/textile-D1SjnpgG.js                             7.16 kB │ gzip:     2.60 kB
+app build: dist/assets/vi-D39UhA5v.js                                  7.37 kB │ gzip:     2.37 kB
+app build: dist/assets/lb-DJwO_AXU.js                                  7.45 kB │ gzip:     2.27 kB
+app build: dist/assets/el-CvjPFCk9.js                                  7.48 kB │ gzip:     2.51 kB
+app build: dist/assets/gu-rFohmfIh.js                                  7.57 kB │ gzip:     2.07 kB
+app build: dist/assets/he-CSXLQUIJ.js                                  7.58 kB │ gzip:     2.38 kB
+app build: dist/assets/pinia-Dha9e2A4.js                               7.59 kB │ gzip:     3.33 kB
+app build: dist/assets/slim-XcmIZULs.js                                7.61 kB │ gzip:     2.77 kB
+app build: dist/assets/lt-DGARkdtE.js                                  7.67 kB │ gzip:     2.43 kB
+app build: dist/assets/ar-SA-Da0BAXMb.js                               7.68 kB │ gzip:     2.20 kB
+app build: dist/assets/ar-MA-C_-ABz05.js                               7.70 kB │ gzip:     2.21 kB
+app build: dist/assets/nginx-CngkS_V1.js                               7.74 kB │ gzip:     2.88 kB
+app build: dist/assets/ar-DZ-ci3YKnK_.js                               7.82 kB │ gzip:     2.25 kB
+app build: dist/assets/sr-Latn-ZvJ3AQd8.js                             7.92 kB │ gzip:     2.24 kB
+app build: dist/assets/sk-c_Xdqa8X.js                                  7.99 kB │ gzip:     2.55 kB
+app build: dist/assets/ku-TR-C2XGzEwI.js                               8.03 kB │ gzip:     2.83 kB
+app build: dist/assets/powershell-Chpfqyox.js                          8.04 kB │ gzip:     3.46 kB
+app build: dist/assets/fo-FO-BphmKyCo.js                               8.17 kB │ gzip:     3.13 kB
+app build: dist/assets/erlang-lArHHQZb.js                              8.19 kB │ gzip:     3.06 kB
+app build: dist/assets/hr-CuYfK9lx.js                                  8.20 kB │ gzip:     2.34 kB
+app build: dist/assets/pl-8LGtbcfF.js                                  8.24 kB │ gzip:     2.59 kB
+app build: dist/assets/pug-DwyoMf0b.js                                 8.25 kB │ gzip:     2.57 kB
+app build: dist/assets/haxe-Bj-55ZG1.js                                8.31 kB │ gzip:     3.11 kB
+app build: dist/assets/hi-RI0R3Xw9.js                                  8.48 kB │ gzip:     2.30 kB
+app build: dist/assets/lv-ikw94PI8.js                                  8.57 kB │ gzip:     2.34 kB
+app build: dist/assets/mn-DPobE3UJ.js                                  8.65 kB │ gzip:     2.38 kB
+app build: dist/assets/th-DAHUrvAD.js                                  8.88 kB │ gzip:     2.24 kB
+app build: dist/assets/ka-DiUGLJDF.js                                  9.02 kB │ gzip:     2.12 kB
+app build: dist/assets/sr-BPxe06rw.js                                  9.58 kB │ gzip:     2.47 kB
+app build: dist/assets/sas-Cat3yFCy.js                                 9.61 kB │ gzip:     4.26 kB
+app build: dist/assets/clojure-D9T2gtrD.js                             9.82 kB │ gzip:     4.23 kB
+app build: dist/assets/bn-DbN_DH1F.js                                 10.06 kB │ gzip:     2.44 kB
+app build: dist/assets/perl-B2uh33FK.js                               10.09 kB │ gzip:     3.68 kB
+app build: dist/assets/idl-tS6gq3MR.js                                10.15 kB │ gzip:     4.58 kB
+app build: dist/assets/af-ZA-BPP7V9Fi.js                              10.21 kB │ gzip:     3.72 kB
+app build: dist/assets/matchesonscrollbar-zxqEd-Y1.js                 10.27 kB │ gzip:     3.59 kB
+app build: dist/assets/te-IN-CPs7Nycw.js                              10.47 kB │ gzip:     3.35 kB
+app build: dist/assets/gherkin-DGMU0gAj.js                            10.47 kB │ gzip:     5.30 kB
+app build: dist/assets/cs-0Dp4I4wL.js                                 10.51 kB │ gzip:     2.58 kB
+app build: dist/assets/soy-9neEGK7N.js                                10.53 kB │ gzip:     3.43 kB
+app build: dist/assets/sl-BNjLHa8M.js                                 10.61 kB │ gzip:     2.62 kB
+app build: dist/assets/show-hint-nAaOPrAV.js                          10.77 kB │ gzip:     3.90 kB
+app build: dist/assets/jsonlint-BlkFxg9U.js                           10.96 kB │ gzip:     4.16 kB
+app build: dist/assets/verilog-BFwvtYRO.js                            10.96 kB │ gzip:     4.46 kB
+app build: dist/assets/te-DAnCMIEd.js                                 11.14 kB │ gzip:     2.29 kB
+app build: dist/assets/kn-BcuIj3q7.js                                 11.95 kB │ gzip:     2.36 kB
+app build: dist/assets/kk-bz6ZIKRl.js                                 12.13 kB │ gzip:     2.86 kB
+app build: dist/assets/uk-DTAiWMie.js                                 12.46 kB │ gzip:     3.09 kB
+app build: dist/assets/ru-B4K6uhtR.js                                 12.50 kB │ gzip:     3.05 kB
+app build: dist/assets/be-C4cTy5D5.js                                 12.77 kB │ gzip:     3.12 kB
+app build: dist/assets/bn-IN-DedjvW3g.js                              12.93 kB │ gzip:     3.93 kB
+app build: dist/assets/ta-BxBgCo6t.js                                 12.99 kB │ gzip:     2.54 kB
+app build: dist/assets/ms-MY-rVQxcT6F.js                              13.11 kB │ gzip:     4.74 kB
+app build: dist/assets/php-2-IlUexc.js                                14.07 kB │ gzip:     5.38 kB
+app build: dist/assets/az-AZ-Bt2nMfm_.js                              15.41 kB │ gzip:     5.25 kB
+app build: dist/assets/sr-SP-Bjb_wbrQ.js                              15.55 kB │ gzip:     5.68 kB
+app build: dist/assets/javascript-DeCwosis.js                         18.05 kB │ gzip:     6.07 kB
+app build: dist/assets/dist-DNNWDJ0b.js                               20.01 kB │ gzip:     7.94 kB
+app build: dist/assets/clike-D5EaA81k.js                              21.14 kB │ gzip:     7.51 kB
+app build: dist/assets/is-IS-DdA4Olku.js                              22.90 kB │ gzip:     8.51 kB
+app build: dist/assets/stylus-BGAnxPc4.js                             23.93 kB │ gzip:     8.81 kB
+app build: dist/assets/css-DdLwSjm5.js                                25.18 kB │ gzip:     8.44 kB
+app build: dist/assets/vue-router-BA3aOc4G.js                         26.58 kB │ gzip:    10.17 kB
+app build: dist/assets/he-IL-DAQq--bB.js                              27.52 kB │ gzip:     8.87 kB
+app build: dist/assets/markdown-DaNpzyRG.js                           27.96 kB │ gzip:     9.09 kB
+app build: dist/assets/el-GR-qllfToic.js                              35.14 kB │ gzip:    10.51 kB
+app build: dist/assets/hi-IN--8Yz4kcx.js                              37.07 kB │ gzip:    10.78 kB
+app build: dist/assets/uz-UZ-BKi4djBB.js                              37.38 kB │ gzip:    11.69 kB
+app build: dist/assets/sql-CYTSbiYD.js                                47.55 kB │ gzip:    14.12 kB
+app build: dist/assets/vue-i18n-CmTqtH5D.js                           48.74 kB │ gzip:    16.50 kB
+app build: dist/assets/no-NO-DY4-UsWI.js                              53.01 kB │ gzip:    17.21 kB
+app build: dist/assets/eo-UY-Deg_L9aE.js                              57.17 kB │ gzip:    18.63 kB
+app build: dist/assets/index.Cw6m-0bT.entry.js                        61.87 kB │ gzip:    22.05 kB
+app build: dist/assets/br-FR-CRoM-1LK.js                              62.85 kB │ gzip:    20.03 kB
+app build: dist/assets/sr-CS-B6gw1pFw.js                              64.36 kB │ gzip:    21.38 kB
+app build: dist/assets/sl-SI-CyDCmS_x.js                              71.34 kB │ gzip:    23.86 kB
+app build: dist/assets/et-EE-BwFl2zCu.js                              74.75 kB │ gzip:    24.96 kB
+app build: dist/assets/vi-VN-Cb9w_ZZM.js                              75.08 kB │ gzip:    23.63 kB
+app build: dist/assets/pt-PT-B1kWn6XU.js                              80.15 kB │ gzip:    25.40 kB
+app build: dist/assets/en-CA-C2cBM1Gw.js                              80.27 kB │ gzip:    25.76 kB
+app build: dist/assets/id-ID-DLKXQNOt.js                              83.90 kB │ gzip:    27.02 kB
+app build: dist/assets/fi-FI-ChA0iJ9b.js                              89.74 kB │ gzip:    29.31 kB
+app build: dist/assets/ca-ES-C-s01dWm.js                              91.98 kB │ gzip:    29.65 kB
+app build: dist/assets/ro-RO-C-z76fIR.js                              98.23 kB │ gzip:    31.38 kB
+app build: dist/assets/en-GB-Nbrha5X2.js                             101.47 kB │ gzip:    32.40 kB
+app build: dist/assets/bs-BA-CUQn96dF.js                             101.70 kB │ gzip:    32.73 kB
+app build: dist/assets/zh-TW-hMhMzWIO.js                             104.22 kB │ gzip:    35.82 kB
+app build: dist/assets/th-TH-CMONGuWQ.js                             106.80 kB │ gzip:    26.87 kB
+app build: dist/assets/da-DK-ceeSrAMh.js                             106.84 kB │ gzip:    34.54 kB
+app build: dist/assets/sv-SE-BicDOVDl.js                             113.29 kB │ gzip:    36.47 kB
+app build: dist/assets/vue.runtime.esm-bundler-DGm7kVdE.js           122.72 kB │ gzip:    47.16 kB
+app build: dist/assets/hu-HU-DBKpn0Y7.js                             127.05 kB │ gzip:    40.47 kB
+app build: dist/assets/tr-TR-DzFuxL5D.js                             130.35 kB │ gzip:    42.05 kB
+app build: dist/assets/hr-HR-DEvMR_cX.js                             131.14 kB │ gzip:    42.40 kB
+app build: dist/assets/pl-PL-mUkSQ_DK.js                             133.66 kB │ gzip:    43.14 kB
+app build: dist/assets/sk-SK-CFMwnTAt.js                             134.05 kB │ gzip:    43.60 kB
+app build: dist/assets/cs-CZ-GXpdJ3C3.js                             135.06 kB │ gzip:    43.90 kB
+app build: dist/assets/zh-CN-CVHIBH4R.js                             135.43 kB │ gzip:    46.65 kB
+app build: dist/assets/ar-SA-LwyeXGIK.js                             136.67 kB │ gzip:    39.70 kB
+app build: dist/assets/lt-LT-6XF7AC9z.js                             137.33 kB │ gzip:    44.01 kB
+app build: dist/assets/de-DE-BxEB87Hg.js                             137.55 kB │ gzip:    43.35 kB
+app build: dist/assets/sq-AL-BhQcGsnV.js                             137.71 kB │ gzip:    43.81 kB
+app build: dist/assets/kmr-TR-MLfifLrr.js                            137.93 kB │ gzip:    43.01 kB
+app build: dist/assets/it-IT-uZoO8soB.js                             138.04 kB │ gzip:    42.88 kB
+app build: dist/assets/es-ES-Bkwch8k-.js                             140.44 kB │ gzip:    44.33 kB
+app build: dist/assets/es-CL-CgZymiVJ.js                             140.46 kB │ gzip:    44.32 kB
+app build: dist/assets/es-MX-CVrKoUvA.js                             141.24 kB │ gzip:    44.25 kB
+app build: dist/assets/pt-BR-C_Me9Mng.js                             144.31 kB │ gzip:    45.87 kB
+app build: dist/assets/ja-JP-CnThLQQf.js                             145.24 kB │ gzip:    44.18 kB
+app build: dist/assets/nl-NL-B6mMVeUo.js                             146.09 kB │ gzip:    46.77 kB
+app build: dist/assets/ko-KR-CiTEFkg2.js                             146.97 kB │ gzip:    47.05 kB
+app build: dist/assets/ne-NP-Den-W-KQ.js                             148.66 kB │ gzip:    35.14 kB
+app build: dist/assets/fr-CA-Cqvg22gC.js                             149.15 kB │ gzip:    46.32 kB
+app build: dist/assets/fr-FR-BxQk2Psg.js                             149.25 kB │ gzip:    46.30 kB
+app build: dist/assets/es-419-k2lK1LHR.js                            153.04 kB │ gzip:    48.54 kB
+app build: dist/assets/bg-BG-DcGCnLnL.js                             166.85 kB │ gzip:    44.54 kB
+app build: dist/assets/ckb-IR-Cyf0kAxJ.js                            171.07 kB │ gzip:    45.74 kB
+app build: dist/assets/mn-MN-GuVEKzVt.js                             172.58 kB │ gzip:    46.01 kB
+app build: dist/assets/codemirror-CMh_d9Rc.js                        172.76 kB │ gzip:    57.98 kB
+app build: dist/assets/en-US-8zoeQkBi.js                             177.49 kB │ gzip:    56.30 kB
+app build: dist/assets/ru-RU-nIZkcCX2.js                             188.83 kB │ gzip:    52.15 kB
+app build: dist/assets/uk-UA-DKiCOHqE.js                             190.77 kB │ gzip:    53.18 kB
+app build: dist/assets/mr-IN-D8LX7ywz.js                             197.27 kB │ gzip:    48.20 kB
+app build: dist/assets/fa-IR-Ce67vSCq.js                             198.60 kB │ gzip:    56.73 kB
+app build: dist/assets/ka-GE-Ct1NaFic.js                             223.18 kB │ gzip:    48.52 kB
+app build: dist/assets/social-icon-B-XjK-RL.js                       570.97 kB │ gzip:   241.14 kB
+app build: dist/assets/dist-DqCl1BES.js                              623.79 kB │ gzip:   167.26 kB
+app build: dist/assets/input-rich-text-html-nY3RUuq_.js            1,185.33 kB │ gzip:   399.31 kB
+app build: dist/assets/shader-background-DcKsgRYi.js               1,449.13 kB │ gzip:   395.60 kB
+app build: dist/assets/router-P0kYjuEZ.js                          5,738.56 kB │ gzip: 1,573.92 kB
+app build: ✓ built in 22.37s
+app build: [plugin builtin:vite-reporter] 
+app build: (!) Some chunks are larger than 500 kB after minification. Consider:
+app build: - Using dynamic import() to code-split the application
+app build: - Use build.rolldownOptions.output.codeSplitting to improve chunking: https://rolldown.rs/reference/OutputOptions.codeSplitting
+app build: - Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
+app build: [33m[PLUGIN_TIMINGS] Warning:[0m Your build spent significant time in plugins. Here is a breakdown:
+app build:   - yaml (43%)
+app build:   - vite:css (22%)
+app build:   - unhead:use-seo-meta-transform (11%)
+app build:   - vite:vue (9%)
+app build:   - vite:asset (6%)
+app build: See https://rolldown.rs/options/checks#plugintimings for more details.
+app build: Done
+api build$ tsdown && copyfiles "src/**/*.{yaml,liquid,md}" -u 1 dist
+api build: [34mℹ[39m tsdown [2mv0.15.11[22m powered by rolldown [2mv1.0.0-beta.45[22m
+api build: [34mℹ[39m Using tsdown config: [4m/home/jean/dev/Hippocast/dev/deps/directus-cms-2/api/tsdown.config.ts[24m
+api build: [34mℹ[39m entry: [34msrc/app.ts, src/auth.ts, src/cache.ts, src/constants.ts, src/deployment.ts, src/emitter.test-d.ts, src/emitter.ts, src/flows.ts, src/index.ts, src/mailer.ts, src/rate-limiter.ts, src/server.ts, src/start.ts, src/synchronization.ts, src/auth/auth.ts, src/bus/index.ts, src/cli/index.ts, src/cli/load-extensions.ts, src/cli/run.ts, src/controllers/access.ts, src/controllers/activity.ts, src/controllers/assets.ts, src/controllers/auth.ts, src/controllers/collections.ts, src/controllers/comments.ts, src/controllers/dashboards.ts, src/controllers/deployment-webhooks.ts, src/controllers/deployment.ts, src/controllers/extensions.ts, src/controllers/fields.ts, src/controllers/files.ts, src/controllers/flows.ts, src/controllers/folders.ts, src/controllers/graphql.ts, src/controllers/items.ts, src/controllers/license.ts, src/controllers/metrics.ts, src/controllers/not-found.ts, src/controllers/notifications.ts, src/controllers/operations.ts, src/controllers/panels.ts, src/controllers/permissions.ts, src/controllers/policies.ts, src/controllers/presets.ts, src/controllers/relations.ts, src/controllers/revisions.ts, src/controllers/roles.ts, src/controllers/schema.ts, src/controllers/server.ts, src/controllers/settings.ts, src/controllers/shares.ts, src/controllers/translations.ts, src/controllers/tus.ts, src/controllers/users.ts, src/controllers/utils.ts, src/controllers/versions.ts, src/database/index.ts, src/deployment/deployment.ts, src/deployment/index.ts, src/extensions/index.ts, src/extensions/manager.ts, src/license/index.ts, src/license/manager.ts, src/lock/index.ts, src/logger/index.ts, src/logger/logs-stream.ts, src/logger/redact-query.ts, src/metrics/index.ts, src/middleware/authenticate.ts, src/middleware/cache.ts, src/middleware/collection-exists.ts, src/middleware/cors.ts, src/middleware/error-handler.ts, src/middleware/extract-token.ts, src/middleware/graphql.ts, src/middleware/is-admin.ts, src/middleware/is-locked.ts, src/middleware/mcp-oauth-guard.ts, src/middleware/rate-limiter-global.ts, src/middleware/rate-limiter-ip.ts, src/middleware/rate-limiter-registration.ts, src/middleware/request-counter.ts, src/middleware/respond.ts, src/middleware/sanitize-query.ts, src/middleware/schema.ts, src/middleware/use-collection.ts, src/middleware/validate-batch.ts, src/permissions/cache.ts, src/permissions/types.ts, src/redis/index.ts, src/request/agent-with-ip-validation.ts, src/request/index.ts, src/request/is-denied-ip.ts, src/schedules/license.ts, src/schedules/metrics.ts, src/schedules/oauth-cleanup.ts, src/schedules/project.ts, src/schedules/retention.ts, src/schedules/telemetry.ts, src/schedules/tus.ts, src/services/access.ts, src/services/activity.ts, src/services/assets.ts, src/services/authentication.ts, src/services/collections.ts, src/services/comments.ts, src/services/dashboards.ts, src/services/deployment-projects.ts, src/services/deployment-runs.ts, src/services/deployment.ts, src/services/extensions.ts, src/services/fields.ts, src/services/files.ts, src/services/flows.ts, src/services/folders.ts, src/services/import-export.ts, src/services/index.ts, src/services/items.test-d.ts, src/services/items.ts, src/services/meta.ts, src/services/notifications.ts, src/services/operations.ts, src/services/panels.ts, src/services/payload.ts, src/services/permissions.ts, src/services/policies.ts, src/services/presets.ts, src/services/relations.ts, src/services/revisions.ts, src/services/roles.ts, src/services/schema.ts, src/services/server.ts, src/services/settings.ts, src/services/shares.ts, src/services/specifications.ts, src/services/tfa.ts, src/services/translations.ts, src/services/users.ts, src/services/utils.ts, src/services/versions.ts, src/services/websocket.ts, src/storage/get-storage-driver.ts, src/storage/index.ts, src/storage/register-drivers.ts, src/storage/register-locations.ts, src/types/ast.ts, src/types/auth.ts, src/types/collection.ts, src/types/events.ts, src/types/index.ts, src/types/meta.ts, src/types/migration.ts, src/types/revision.ts, src/types/rolemap.ts, src/telemetry/index.ts, src/websocket/authenticate.ts, src/websocket/errors.ts, src/websocket/messages.ts, src/websocket/types.ts, src/utils/apply-diff.ts, src/utils/apply-snapshot.ts, src/utils/async-handler.ts, src/utils/calculate-field-depth.ts, src/utils/compress.ts, src/utils/construct-flow-tree.ts, src/utils/create-admin.ts, src/utils/deep-freeze.ts, src/utils/deep-map-response.ts, src/utils/delete-from-require-cache.ts, src/utils/destroy-piped-stream.ts, src/utils/encrypt.ts, src/utils/extract-function-name.ts, src/utils/filter-items.ts, src/utils/freeze-schema.ts, src/utils/generate-hash.ts, src/utils/generate-translations.ts, src/utils/get-accountability-for-role.ts, src/utils/get-accountability-for-token.ts, src/utils/get-address.ts, src/utils/get-allowed-log-levels.ts, src/utils/get-auth-providers.ts, src/utils/get-cache-headers.ts, src/utils/get-cache-key.ts, src/utils/get-collection-from-alias.ts, src/utils/get-column-path.ts, src/utils/get-config-from-env.ts, src/utils/get-default-index-name.ts, src/utils/get-default-value.ts, src/utils/get-field-relational-depth.ts, src/utils/get-field-system-rows.ts, src/utils/get-graphql-query-and-variables.ts, src/utils/get-graphql-type.ts, src/utils/get-history-filter-query.ts, src/utils/get-ip-from-req.ts, src/utils/get-local-type.ts, src/utils/get-milliseconds.ts, src/utils/get-module-default.ts, src/utils/get-schema.ts, src/utils/get-secret.ts, src/utils/get-service.ts, src/utils/get-snapshot-diff.ts, src/utils/get-snapshot.ts, src/utils/get-string-byte-size.ts, src/utils/get-versioned-hash.ts, src/utils/import-file-url.ts, src/utils/is-admin.ts, src/utils/is-directus-jwt.ts, src/utils/is-field-allowed.ts, src/utils/is-unauthenticated.ts, src/utils/is-url-allowed.ts, src/utils/is-valid-uuid.ts, src/utils/jwt.ts, src/utils/md.ts, src/utils/parse-filter-key.ts, src/utils/parse-numeric-string.ts, src/utils/parse-oauth-scope.ts, src/utils/parse-value.ts, src/utils/permissions-cacheable.ts, src/utils/redact-object.ts, src/utils/reduce-schema.ts, src/utils/require-text.ts, src/utils/require-yaml.ts, src/utils/sanitize-query.ts, src/utils/sanitize-schema.ts, src/utils/schedule.ts, src/utils/should-clear-cache.ts, src/utils/should-skip-cache.ts, src/utils/split-field-path.ts, src/utils/split-fields.ts, src/utils/stall.ts, src/utils/store.ts, src/utils/transaction.ts, src/utils/transformations.ts, src/utils/translations-shared.ts, src/utils/translations-validation.ts, src/utils/url.ts, src/utils/user-name.ts, src/utils/validate-diff.ts, src/utils/validate-env.ts, src/utils/validate-keys.ts, src/utils/validate-query.ts, src/utils/validate-snapshot.ts, src/utils/validate-storage.ts, src/utils/validate-user-count-integrity.ts, src/utils/verify-session-jwt.ts, src/ai/chat/router.ts, src/ai/files/router.ts, src/ai/files/types.ts, src/ai/providers/anthropic-file-support.ts, src/ai/providers/anthropic-tool-search.ts, src/ai/providers/index.ts, src/ai/providers/options.ts, src/ai/providers/registry.ts, src/ai/providers/types.ts, src/ai/mcp/index.ts, src/ai/mcp/server.ts, src/ai/mcp/transport.ts, src/ai/mcp/types.ts, src/ai/mcp/utils.ts, src/ai/devtools/index.ts, src/ai/telemetry/braintrust.ts, src/ai/telemetry/index.ts, src/ai/telemetry/langfuse.ts, src/ai/tools/define-tool.ts, src/ai/tools/index.ts, src/ai/tools/schema.ts, src/ai/tools/types.ts, src/ai/tools/utils.ts, src/auth/drivers/index.ts, src/auth/drivers/ldap.ts, src/auth/drivers/local.ts, src/auth/drivers/oauth2.ts, src/auth/drivers/openid.ts, src/auth/drivers/saml.ts, src/bus/lib/use-bus.ts, src/auth/utils/check-local-disabled.ts, src/auth/utils/check-sso-enabled.ts, src/auth/utils/generate-callback-url.ts, src/auth/utils/resolve-login-redirect.ts, src/cli/utils/create-db-connection.ts, src/cli/utils/drivers.ts, src/controllers/utils/handle-registry-error.ts, src/controllers/mcp/index.ts, src/controllers/mcp/oauth-clients.ts, src/controllers/mcp/oauth-consent-page.ts, src/controllers/mcp/oauth.ts, src/database/errors/translate.ts, src/database/get-ast-from-query/get-ast-from-query.ts, src/database/helpers/index.ts, src/database/helpers/types.ts, src/database/run-ast/run-ast.ts, src/database/run-ast/types.ts, src/database/seeds/run.ts, src/database/migrations/20201028A-remove-collection-foreign-keys.ts, src/database/migrations/20201029A-remove-system-relations.ts, src/database/migrations/20201029B-remove-system-collections.ts, src/database/migrations/20201029C-remove-system-fields.ts, src/database/migrations/20201105A-add-cascade-system-relations.ts, src/database/migrations/20201105B-change-webhook-url-type.ts, src/database/migrations/20210225A-add-relations-sort-field.ts, src/database/migrations/20210304A-remove-locked-fields.ts, src/database/migrations/20210312A-webhooks-collections-text.ts, src/database/migrations/20210331A-add-refresh-interval.ts, src/database/migrations/20210415A-make-filesize-nullable.ts, src/database/migrations/20210416A-add-collections-accountability.ts, src/database/migrations/20210422A-remove-files-interface.ts, src/database/migrations/20210506A-rename-interfaces.ts, src/database/migrations/20210510A-restructure-relations.ts, src/database/migrations/20210518A-add-foreign-key-constraints.ts, src/database/migrations/20210519A-add-system-fk-triggers.ts, src/database/migrations/20210521A-add-collections-icon-color.ts, src/database/migrations/20210525A-add-insights.ts, src/database/migrations/20210608A-add-deep-clone-config.ts, src/database/migrations/20210626A-change-filesize-bigint.ts, src/database/migrations/20210716A-add-conditions-to-fields.ts, src/database/migrations/20210721A-add-default-folder.ts, src/database/migrations/20210802A-replace-groups.ts, src/database/migrations/20210803A-add-required-to-fields.ts, src/database/migrations/20210805A-update-groups.ts, src/database/migrations/20210805B-change-image-metadata-structure.ts, src/database/migrations/20210811A-add-geometry-config.ts, src/database/migrations/20210831A-remove-limit-column.ts, src/database/migrations/20210903A-add-auth-provider.ts, src/database/migrations/20210907A-webhooks-collections-not-null.ts, src/database/migrations/20210910A-move-module-setup.ts, src/database/migrations/20210920A-webhooks-url-not-null.ts, src/database/migrations/20210924A-add-collection-organization.ts, src/database/migrations/20210927A-replace-fields-group.ts, src/database/migrations/20210927B-replace-m2m-interface.ts, src/database/migrations/20210929A-rename-login-action.ts, src/database/migrations/20211007A-update-presets.ts, src/database/migrations/20211009A-add-auth-data.ts, src/database/migrations/20211016A-add-webhook-headers.ts, src/database/migrations/20211103A-set-unique-to-user-token.ts, src/database/migrations/20211103B-update-special-geometry.ts, src/database/migrations/20211104A-remove-collections-listing.ts, src/database/migrations/20211118A-add-notifications.ts, src/database/migrations/20211211A-add-shares.ts, src/database/migrations/20211230A-add-project-descriptor.ts, src/database/migrations/20220303A-remove-default-project-color.ts, src/database/migrations/20220308A-add-bookmark-icon-and-color.ts, src/database/migrations/20220314A-add-translation-strings.ts, src/database/migrations/20220322A-rename-field-typecast-flags.ts, src/database/migrations/20220323A-add-field-validation.ts, src/database/migrations/20220325A-fix-typecast-flags.ts, src/database/migrations/20220325B-add-default-language.ts, src/database/migrations/20220402A-remove-default-value-panel-icon.ts, src/database/migrations/20220429A-add-flows.ts, src/database/migrations/20220429B-add-color-to-insights-icon.ts, src/database/migrations/20220429C-drop-non-null-from-ip-of-activity.ts, src/database/migrations/20220429D-drop-non-null-from-sender-of-notifications.ts, src/database/migrations/20220614A-rename-hook-trigger-to-event.ts, src/database/migrations/20220801A-update-notifications-timestamp-column.ts, src/database/migrations/20220802A-add-custom-aspect-ratios.ts, src/database/migrations/20220826A-add-origin-to-accountability.ts, src/database/migrations/20230401A-update-material-icons.ts, src/database/migrations/20230525A-add-preview-settings.ts, src/database/migrations/20230526A-migrate-translation-strings.ts, src/database/migrations/20230721A-require-shares-fields.ts, src/database/migrations/20230823A-add-content-versioning.ts, src/database/migrations/20230927A-themes.ts, src/database/migrations/20231009A-update-csv-fields-to-text.ts, src/database/migrations/20231009B-update-panel-options.ts, src/database/migrations/20231010A-add-extensions.ts, src/database/migrations/20231215A-add-focalpoints.ts, src/database/migrations/20240122A-add-report-url-fields.ts, src/database/migrations/20240204A-marketplace.ts, src/database/migrations/20240305A-change-useragent-type.ts, src/database/migrations/20240311A-deprecate-webhooks.ts, src/database/migrations/20240422A-public-registration.ts, src/database/migrations/20240515A-add-session-window.ts, src/database/migrations/20240701A-add-tus-data.ts, src/database/migrations/20240716A-update-files-date-fields.ts, src/database/migrations/20240806A-permissions-policies.ts, src/database/migrations/20240817A-update-icon-fields-length.ts, src/database/migrations/20240909A-separate-comments.ts, src/database/migrations/20240909B-consolidate-content-versioning.ts, src/database/migrations/20240924A-migrate-legacy-comments.ts, src/database/migrations/20240924B-populate-versioning-deltas.ts, src/database/migrations/20250224A-visual-editor.ts, src/database/migrations/20250609A-license-banner.ts, src/database/migrations/20250613A-add-project-id.ts, src/database/migrations/20250718A-add-direction.ts, src/database/migrations/20250813A-add-mcp.ts, src/database/migrations/20251012A-add-field-searchable.ts, src/database/migrations/20251014A-add-project-owner.ts, src/database/migrations/20251028A-add-retention-indexes.ts, src/database/migrations/20251103A-add-ai-settings.ts, src/database/migrations/20251224A-remove-webhooks.ts, src/database/migrations/20260110A-add-ai-provider-settings.ts, src/database/migrations/20260113A-add-revisions-index.ts, src/database/migrations/20260128A-add-collaborative-editing.ts, src/database/migrations/20260204A-add-deployment.ts, src/database/migrations/20260211A-add-deployment-webhooks.ts, src/database/migrations/20260217A-null-item-versions.ts, src/database/migrations/20260312A-add-ai-translation-settings.ts, src/database/migrations/20260507A-add-licensing.ts, src/database/migrations/20260512A-add-autosave-revision-interval.ts, src/database/migrations/20260512B-add-mcp-oauth.ts, src/database/migrations/run.ts, src/deployment/drivers/index.ts, src/deployment/drivers/netlify.ts, src/deployment/drivers/vercel.ts, src/extensions/lib/get-extensions-path.ts, src/extensions/lib/get-extensions-settings.ts, src/extensions/lib/get-extensions.ts, src/extensions/lib/get-shared-deps-mapping.ts, src/extensions/lib/wrap-embeds.ts, src/license/entitlements/manager.ts, src/license/utils/compute-license-status.ts, src/license/utils/get-core-grace-expires-at.ts, src/license/utils/get-license-key.ts, src/license/utils/get-license-token.ts, src/license/utils/handle-license-error.ts, src/license/utils/is-in-core-grace-period.ts, src/license/utils/is-sso-bypass-allowed.ts, src/license/utils/use-rpc.ts, src/lock/lib/use-lock.ts, src/metrics/lib/create-metrics.ts, src/metrics/lib/use-metrics.ts, src/metrics/types/metric.ts, src/operations/condition/index.ts, src/operations/exec/index.ts, src/operations/item-create/index.ts, src/operations/item-delete/index.ts, src/operations/item-read/index.ts, src/operations/item-update/index.ts, src/operations/json-web-token/index.ts, src/operations/log/index.ts, src/operations/mail/index.ts, src/operations/mail/rate-limiter.ts, src/operations/notification/index.ts, src/operations/request/index.ts, src/operations/sleep/index.ts, src/operations/throw-error/index.ts, src/operations/transform/index.ts, src/operations/trigger/index.ts, src/permissions/lib/fetch-permissions.ts, src/permissions/lib/fetch-policies.ts, src/permissions/lib/fetch-roles-tree.ts, src/permissions/lib/with-app-minimal-permissions.ts, src/permissions/utils/create-default-accountability.ts, src/permissions/utils/default-permission.ts, src/permissions/utils/extract-required-dynamic-variable-context.ts, src/permissions/utils/fetch-dynamic-variable-data.ts, src/permissions/utils/fetch-raw-permissions.ts, src/permissions/utils/fetch-share-info.ts, src/permissions/utils/filter-policies-by-ip.ts, src/permissions/utils/get-permissions-for-share.ts, src/permissions/utils/get-unaliased-field-key.ts, src/permissions/utils/merge-fields.ts, src/permissions/utils/merge-permissions.ts, src/permissions/utils/process-permissions.ts, src/permissions/utils/with-cache.ts, src/redis/lib/create-redis.ts, src/redis/lib/use-redis.ts, src/redis/utils/redis-config-available.ts, src/services/assets/name-deduper.ts, src/schedules/utils/duration-to-cron.ts, src/services/fields/build-collection-and-field-relations.ts, src/services/fields/get-collection-meta-updates.ts, src/services/fields/get-collection-relation-list.ts, src/services/graphql/index.ts, src/services/graphql/schema-cache.ts, src/services/graphql/subscription.ts, src/services/mail/index.ts, src/services/mail/rate-limiter.ts, src/services/mcp-oauth/cimd.ts, src/services/mcp-oauth/index.ts, src/telemetry/counter/use-buffered-counter.ts, src/telemetry/counter/use-counters.ts, src/services/tus/data-store.ts, src/services/tus/index.ts, src/services/tus/lockers.ts, src/services/tus/server.ts, src/telemetry/lib/get-report.ts, src/telemetry/lib/send-report.ts, src/telemetry/lib/track.ts, src/telemetry/types/report.ts, src/telemetry/utils/check-user-limits.ts, src/telemetry/utils/format-api-request-counts.ts, src/telemetry/utils/get-extension-count.ts, src/telemetry/utils/get-field-count.ts, src/telemetry/utils/get-filesize-sum.ts, src/telemetry/utils/get-item-count.ts, src/telemetry/utils/get-random-wait-time.ts, src/telemetry/utils/get-settings.ts, src/telemetry/utils/get-user-item-count.ts, src/telemetry/utils/should-check-user-limits.ts, src/websocket/collab/calculate-cache-metadata.ts, src/websocket/collab/collab.ts, src/websocket/collab/constants.ts, src/websocket/collab/filter-to-fields.ts, src/websocket/collab/messenger.ts, src/websocket/collab/payload-permissions.ts, src/websocket/collab/permissions-cache.ts, src/websocket/collab/room.ts, src/websocket/collab/store.ts, src/websocket/collab/types.ts, src/websocket/collab/verify-permissions.ts, src/websocket/controllers/base.ts, src/websocket/controllers/graphql.ts, src/websocket/controllers/hooks.ts, src/websocket/controllers/index.ts, src/websocket/controllers/logs.ts, src/websocket/controllers/rest.ts, src/websocket/handlers/heartbeat.ts, src/websocket/handlers/index.ts, src/websocket/handlers/items.ts, src/websocket/handlers/logs.ts, src/websocket/handlers/subscribe.ts, src/websocket/utils/get-expires-at-for-token.ts, src/websocket/utils/items.ts, src/websocket/utils/message.ts, src/websocket/utils/wait-for-message.ts, src/utils/fetch-user-count/fetch-access-lookup.ts, src/utils/fetch-user-count/fetch-access-roles.ts, src/utils/fetch-user-count/fetch-active-users.ts, src/utils/fetch-user-count/fetch-user-count.ts, src/utils/fetch-user-count/get-user-count-query.ts, src/utils/versioning/handle-version.ts, src/utils/versioning/merge-version-data.ts, src/utils/versioning/remove-circular.ts, src/utils/versioning/split-recursive.ts, src/ai/chat/constants/system-prompt.ts, src/ai/chat/controllers/chat.post.ts, src/ai/chat/controllers/object.post.ts, src/ai/chat/lib/create-ui-stream.ts, src/ai/chat/lib/transform-file-parts.ts, src/ai/chat/middleware/load-settings.ts, src/ai/chat/models/chat-request.ts, src/ai/chat/models/object-request.ts, src/ai/chat/models/providers.ts, src/ai/files/adapters/anthropic.ts, src/ai/files/adapters/google.ts, src/ai/files/adapters/index.ts, src/ai/files/adapters/openai.ts, src/ai/chat/utils/add-additional-properties-to-json-schema.ts, src/ai/chat/utils/chat-request-tool-to-ai-sdk-tool.ts, src/ai/chat/utils/fix-error-tool-calls.ts, src/ai/chat/utils/format-context.ts, src/ai/chat/utils/parse-json-schema-7.ts, src/ai/chat/utils/prompt-caching.ts, src/ai/chat/utils/zod-jsonschema7-parser.ts, src/ai/files/controllers/upload.ts, src/ai/files/lib/fetch-provider.ts, src/ai/files/lib/upload-to-provider.ts, src/ai/tools/collections/index.ts, src/ai/tools/fields/index.ts, src/ai/tools/files/index.ts, src/ai/tools/assets/index.ts, src/ai/tools/flows/index.ts, src/ai/tools/folders/index.ts, src/ai/tools/items/index.ts, src/ai/tools/operations/index.ts, src/ai/tools/schema/index.ts, src/ai/tools/relations/index.ts, src/ai/tools/trigger-flow/index.ts, src/ai/tools/system/index.ts, src/cli/commands/cache/clear.ts, src/cli/commands/bootstrap/index.ts, src/cli/commands/database/install.ts, src/cli/commands/database/migrate.ts, src/cli/commands/init/index.ts, src/cli/commands/init/questions.ts, src/cli/commands/count/index.ts, src/cli/commands/roles/create.ts, src/cli/commands/schema/apply.ts, src/cli/commands/schema/snapshot.ts, src/cli/commands/security/key.ts, src/cli/commands/security/secret.ts, src/cli/commands/users/create.ts, src/cli/commands/users/passwd.ts, src/cli/utils/create-env/index.ts, src/database/errors/dialects/mssql.ts, src/database/errors/dialects/mysql.ts, src/database/errors/dialects/oracle.ts, src/database/errors/dialects/postgres.ts, src/database/errors/dialects/sqlite.ts, src/database/errors/dialects/types.ts, src/database/get-ast-from-query/utils/get-allowed-sort.ts, src/database/get-ast-from-query/utils/get-deep-query.ts, src/database/get-ast-from-query/utils/get-related-collection.ts, src/database/helpers/capabilities/index.ts, src/database/helpers/capabilities/types.ts, src/database/helpers/date/index.ts, src/database/helpers/date/types.ts, src/database/get-ast-from-query/lib/convert-wildcards.ts, src/database/get-ast-from-query/lib/parse-fields.ts, src/database/helpers/number/index.ts, src/database/helpers/number/types.ts, src/database/helpers/fn/index.ts, src/database/helpers/fn/types.ts, src/database/helpers/geometry/index.ts, src/database/helpers/geometry/types.ts, src/database/helpers/sequence/index.ts, src/database/helpers/sequence/types.ts, src/database/run-ast/lib/get-db-query.ts, src/database/run-ast/lib/parse-current-level.ts, src/database/helpers/schema/index.ts, src/database/helpers/schema/types.ts, src/database/run-ast/modules/fetch-permitted-ast-root-fields.ts, src/database/run-ast/utils/apply-case-when.ts, src/database/run-ast/utils/apply-function-to-column-name.ts, src/database/run-ast/utils/apply-parent-filters.ts, src/database/run-ast/utils/generate-alias.ts, src/database/run-ast/utils/get-column-pre-processor.ts, src/database/run-ast/utils/get-column.ts, src/database/run-ast/utils/get-field-alias.ts, src/database/run-ast/utils/get-inner-query-column-pre-processor.ts, src/database/run-ast/utils/merge-with-parent-items.ts, src/database/run-ast/utils/remove-temporary-fields.ts, src/database/run-ast/utils/with-preprocess-bindings.ts, src/extensions/lib/installation/index.ts, src/extensions/lib/installation/manager.ts, src/license/entitlements/lib/collections.ts, src/license/entitlements/lib/custom-llms-enabled.ts, src/license/entitlements/lib/custom-permission-rules-enabled.ts, src/license/entitlements/lib/flows.ts, src/license/entitlements/lib/seats.ts, src/license/entitlements/lib/sso-enabled.ts, src/extensions/lib/sync/status.ts, src/extensions/lib/sync/sync.ts, src/extensions/lib/sync/tracker.ts, src/extensions/lib/sync/utils.ts, src/extensions/lib/sandbox/generate-api-extensions-sandbox-entrypoint.ts, src/extensions/lib/sandbox/generate-host-function-reference.ts, src/permissions/modules/fetch-accountability-collection-access/fetch-accountability-collection-access.ts, src/permissions/modules/fetch-accountability-policy-globals/fetch-accountability-policy-globals.ts, src/permissions/modules/fetch-allowed-collections/fetch-allowed-collections.ts, src/permissions/modules/fetch-allowed-field-map/fetch-allowed-field-map.ts, src/permissions/modules/fetch-global-access/fetch-global-access.ts, src/permissions/modules/fetch-allowed-fields/fetch-allowed-fields.ts, src/permissions/modules/fetch-inconsistent-field-map/fetch-inconsistent-field-map.ts, src/permissions/modules/fetch-policies-ip-access/fetch-policies-ip-access.ts, src/permissions/modules/process-ast/process-ast.ts, src/permissions/modules/process-ast/types.ts, src/permissions/modules/process-payload/process-payload.ts, src/permissions/modules/validate-access/validate-access.ts, src/services/files/lib/extract-metadata.ts, src/services/files/lib/get-sharp-instance.ts, src/permissions/modules/validate-remaining-admin/validate-remaining-admin-count.ts, src/permissions/modules/validate-remaining-admin/validate-remaining-admin-users.ts, src/services/files/utils/get-metadata.ts, src/services/files/utils/parse-image-metadata.ts, src/services/graphql/errors/execution.ts, src/services/graphql/errors/format.ts, src/services/graphql/errors/index.ts, src/services/graphql/errors/validation.ts, src/services/graphql/schema/get-types.ts, src/services/graphql/schema/index.ts, src/services/graphql/schema/parse-args.ts, src/services/graphql/schema/parse-query.ts, src/services/graphql/schema/read.ts, src/services/graphql/schema/write.ts, src/services/graphql/resolvers/get-collection-type.ts, src/services/graphql/resolvers/get-field-type.ts, src/services/graphql/resolvers/get-relation-type.ts, src/services/graphql/resolvers/mutation.ts, src/services/graphql/resolvers/query.ts, src/services/graphql/resolvers/system-admin.ts, src/services/graphql/resolvers/system-global.ts, src/services/graphql/resolvers/system.ts, src/services/graphql/types/bigint.ts, src/services/graphql/types/date.ts, src/services/graphql/types/geojson.ts, src/services/graphql/types/hash.ts, src/services/graphql/types/json-filter.ts, src/services/graphql/types/string-or-float.ts, src/services/graphql/types/void.ts, src/services/mcp-oauth/types/error.ts, src/services/graphql/utils/add-path-to-validation-error.ts, src/services/graphql/utils/aggregate-query.ts, src/services/graphql/utils/dedupe-resolvers.ts, src/services/graphql/utils/filter-replace-m2a.ts, src/services/graphql/utils/process-error.ts, src/services/graphql/utils/replace-fragments.ts, src/services/graphql/utils/replace-funcs.ts, src/services/graphql/utils/sanitize-gql-schema.ts, src/services/mcp-oauth/utils/cimd-egress.ts, src/services/mcp-oauth/utils/domain.ts, src/services/mcp-oauth/utils/loopback.ts, src/services/mcp-oauth/utils/redirect.ts, src/services/mcp-oauth/utils/registration-debug.ts, src/services/tus/utils/wait-timeout.ts, src/database/helpers/capabilities/dialects/default.ts, src/database/helpers/capabilities/dialects/mssql.ts, src/database/helpers/capabilities/dialects/mysql.ts, src/database/helpers/capabilities/dialects/oracle.ts, src/database/helpers/capabilities/dialects/postgres.ts, src/database/helpers/capabilities/dialects/sqlite.ts, src/database/helpers/date/dialects/default.ts, src/database/helpers/date/dialects/mssql.ts, src/database/helpers/date/dialects/mysql.ts, src/database/helpers/date/dialects/oracle.ts, src/database/helpers/date/dialects/sqlite.ts, src/database/helpers/number/dialects/default.ts, src/database/helpers/number/dialects/mssql.ts, src/database/helpers/number/dialects/oracle.ts, src/database/helpers/number/dialects/postgres.ts, src/database/helpers/number/dialects/sqlite.ts, src/database/helpers/number/utils/decimal-limit.ts, src/database/helpers/number/utils/maybe-stringify-big-int.ts, src/database/helpers/number/utils/number-in-range.ts, src/database/helpers/fn/dialects/mssql.ts, src/database/helpers/fn/dialects/mysql.ts, src/database/helpers/fn/dialects/oracle.ts, src/database/helpers/fn/dialects/postgres.ts, src/database/helpers/fn/dialects/sqlite.ts, src/database/helpers/fn/json/mysql-json-path.ts, src/database/helpers/fn/json/parse-function.ts, src/database/helpers/fn/json/postgres-json-path.ts, src/database/helpers/geometry/dialects/mssql.ts, src/database/helpers/geometry/dialects/mysql.ts, src/database/helpers/geometry/dialects/oracle.ts, src/database/helpers/geometry/dialects/postgres.ts, src/database/helpers/geometry/dialects/redshift.ts, src/database/helpers/geometry/dialects/sqlite.ts, src/database/helpers/sequence/dialects/default.ts, src/database/helpers/sequence/dialects/postgres.ts, src/database/run-ast/lib/apply-query/add-join.ts, src/database/run-ast/lib/apply-query/aggregate.ts, src/database/run-ast/lib/apply-query/get-filter-path.ts, src/database/run-ast/lib/apply-query/get-operation.ts, src/database/run-ast/lib/apply-query/index.ts, src/database/run-ast/lib/apply-query/join-filter-with-cases.ts, src/database/run-ast/lib/apply-query/normalize-filter.ts, src/database/run-ast/lib/apply-query/pagination.ts, src/database/run-ast/lib/apply-query/search.ts, src/database/run-ast/lib/apply-query/sort.ts, src/database/helpers/schema/dialects/cockroachdb.ts, src/database/helpers/schema/dialects/default.ts, src/database/helpers/schema/dialects/mssql.ts, src/database/helpers/schema/dialects/mysql.ts, src/database/helpers/schema/dialects/oracle.ts, src/database/helpers/schema/dialects/postgres.ts, src/database/helpers/schema/dialects/sqlite.ts, src/database/helpers/schema/utils/prep-query-params.ts, src/extensions/lib/sandbox/register/action.ts, src/extensions/lib/sandbox/register/call-reference.ts, src/extensions/lib/sandbox/register/filter.ts, src/extensions/lib/sandbox/register/index.ts, src/extensions/lib/sandbox/register/operation.ts, src/extensions/lib/sandbox/register/route.ts, src/extensions/lib/sandbox/sdk/index.ts, src/extensions/lib/sandbox/sdk/instantiate.ts, src/extensions/lib/sandbox/sdk/sdk.ts, src/permissions/modules/process-ast/lib/extract-fields-from-children.ts, src/permissions/modules/process-ast/lib/extract-fields-from-query.ts, src/permissions/modules/process-ast/lib/field-map-from-ast.ts, src/permissions/modules/process-ast/lib/get-cases.ts, src/permissions/modules/process-ast/lib/inject-cases.ts, src/permissions/modules/process-ast/utils/collections-in-field-map.ts, src/permissions/modules/process-ast/utils/context-has-dynamic-variables.ts, src/permissions/modules/process-ast/utils/dedupe-access.ts, src/permissions/modules/process-ast/utils/extract-paths-from-query.ts, src/permissions/modules/process-ast/utils/find-related-collection.ts, src/permissions/modules/process-ast/utils/flatten-filter.ts, src/permissions/modules/process-ast/utils/format-a2o-key.ts, src/permissions/modules/process-ast/utils/get-info-for-path.ts, src/permissions/modules/process-ast/utils/has-item-permissions.ts, src/permissions/modules/process-ast/utils/stringify-query-path.ts, src/permissions/modules/process-payload/lib/is-field-nullable.ts, src/permissions/modules/validate-access/lib/validate-collection-access.ts, src/permissions/modules/validate-access/lib/validate-item-access.ts, src/database/run-ast/lib/apply-query/filter/get-filter-type.ts, src/database/run-ast/lib/apply-query/filter/index.ts, src/database/run-ast/lib/apply-query/filter/operator.ts, src/database/run-ast/lib/apply-query/filter/validate-operator.ts, src/extensions/lib/sandbox/sdk/utils/index.ts, src/extensions/lib/sandbox/sdk/utils/wrap.ts, src/permissions/modules/process-ast/utils/validate-path/create-error.ts, src/permissions/modules/process-ast/utils/validate-path/validate-path-existence.ts, src/permissions/modules/process-ast/utils/validate-path/validate-path-permissions.ts, src/extensions/lib/sandbox/sdk/generators/index.ts, src/extensions/lib/sandbox/sdk/generators/log.ts, src/extensions/lib/sandbox/sdk/generators/request.ts, src/extensions/lib/sandbox/sdk/generators/sleep.ts[39m
+api build: [34mℹ[39m target: [34mnode22.0.0[39m
+api build: [34mℹ[39m tsconfig: [34mtsconfig.prod.json[39m
+api build: [34mℹ[39m Build start
+api build: [34mℹ[39m Cleaning 1001 files
+api build: [34mℹ[39m [2mdist/[22m[1mservices/mcp-oauth/index.js[22m                                                                                                                                                    [2m 57.80 kB[22m [2m│ gzip: 14.01 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/items.js[22m                                                                                                                                                              [2m 33.92 kB[22m [2m│ gzip:  6.65 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/payload.js[22m                                                                                                                                                            [2m 29.14 kB[22m [2m│ gzip:  5.73 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/fields.js[22m                                                                                                                                                             [2m 27.75 kB[22m [2m│ gzip:  5.74 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20201029C-remove-system-fields.js[22m                                                                                                                          [2m 27.55 kB[22m [2m│ gzip:  4.88 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/manager.js[22m                                                                                                                                                          [2m 26.53 kB[22m [2m│ gzip:  7.02 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/collections.js[22m                                                                                                                                                        [2m 24.11 kB[22m [2m│ gzip:  4.38 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/import-export.js[22m                                                                                                                                                      [2m 21.29 kB[22m [2m│ gzip:  5.66 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mlicense/manager.js[22m                                                                                                                                                             [2m 18.65 kB[22m [2m│ gzip:  4.37 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/generate-translations.js[22m                                                                                                                                                 [2m 17.68 kB[22m [2m│ gzip:  3.81 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/relations.js[22m                                                                                                                                                          [2m 17.63 kB[22m [2m│ gzip:  3.66 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/schema/read.js[22m                                                                                                                                                [2m 16.99 kB[22m [2m│ gzip:  2.70 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/users.js[22m                                                                                                                                                              [2m 16.89 kB[22m [2m│ gzip:  4.45 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/collab/room.js[22m                                                                                                                                                       [2m 16.83 kB[22m [2m│ gzip:  4.28 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mflows.js[22m                                                                                                                                                                       [2m 15.74 kB[22m [2m│ gzip:  4.00 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/mcp/oauth.js[22m                                                                                                                                                       [2m 15.68 kB[22m [2m│ gzip:  4.66 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mauth/drivers/openid.js[22m                                                                                                                                                         [2m 15.39 kB[22m [2m│ gzip:  4.57 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/authentication.js[22m                                                                                                                                                     [2m 15.38 kB[22m [2m│ gzip:  3.65 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/collab/collab.js[22m                                                                                                                                                     [2m 14.99 kB[22m [2m│ gzip:  3.83 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/resolvers/system.js[22m                                                                                                                                           [2m 14.80 kB[22m [2m│ gzip:  2.67 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/deployment.js[22m                                                                                                                                                         [2m 14.06 kB[22m [2m│ gzip:  3.35 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/versions.js[22m                                                                                                                                                           [2m 14.05 kB[22m [2m│ gzip:  3.62 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/specifications.js[22m                                                                                                                                                     [2m 13.50 kB[22m [2m│ gzip:  3.34 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mapp.js[22m                                                                                                                                                                         [2m 13.30 kB[22m [2m│ gzip:  3.80 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mauth/drivers/oauth2.js[22m                                                                                                                                                         [2m 13.22 kB[22m [2m│ gzip:  4.06 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/files.js[22m                                                                                                                                                              [2m 12.94 kB[22m [2m│ gzip:  3.95 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/resolvers/system-global.js[22m                                                                                                                                    [2m 12.93 kB[22m [2m│ gzip:  2.39 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/deployment.js[22m                                                                                                                                                      [2m 12.64 kB[22m [2m│ gzip:  2.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/controllers/base.js[22m                                                                                                                                                  [2m 12.18 kB[22m [2m│ gzip:  3.39 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/assets.js[22m                                                                                                                                                          [2m 11.75 kB[22m [2m│ gzip:  3.33 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/server.js[22m                                                                                                                                                             [2m 11.70 kB[22m [2m│ gzip:  3.34 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/mcp-oauth/cimd.js[22m                                                                                                                                                     [2m 11.53 kB[22m [2m│ gzip:  3.43 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdeployment/drivers/netlify.js[22m                                                                                                                                                  [2m 11.33 kB[22m [2m│ gzip:  3.25 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/users.js[22m                                                                                                                                                           [2m 11.08 kB[22m [2m│ gzip:  2.08 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mauth/drivers/ldap.js[22m                                                                                                                                                           [2m 10.98 kB[22m [2m│ gzip:  3.26 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/assets.js[22m                                                                                                                                                             [2m 10.48 kB[22m [2m│ gzip:  3.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/mcp/oauth-consent-page.js[22m                                                                                                                                          [2m  9.98 kB[22m [2m│ gzip:  3.65 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/apply-diff.js[22m                                                                                                                                                            [2m  9.93 kB[22m [2m│ gzip:  2.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/mcp/server.js[22m                                                                                                                                                               [2m  9.90 kB[22m [2m│ gzip:  3.16 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/index.js[22m                                                                                                                                                              [2m  9.66 kB[22m [2m│ gzip:  3.14 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/lib/apply-query/filter/operator.js[22m                                                                                                                            [2m  9.47 kB[22m [2m│ gzip:  2.04 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mlicense/entitlements/manager.js[22m                                                                                                                                                [2m  9.23 kB[22m [2m│ gzip:  2.64 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/resolvers/system-admin.js[22m                                                                                                                                     [2m  8.99 kB[22m [2m│ gzip:  1.49 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/tools/schema/index.js[22m                                                                                                                                                       [2m  8.83 kB[22m [2m│ gzip:  2.22 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/lib/get-db-query.js[22m                                                                                                                                           [2m  8.81 kB[22m [2m│ gzip:  2.42 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/tools/schema.js[22m                                                                                                                                                             [2m  8.78 kB[22m [2m│ gzip:  1.53 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdeployment/drivers/vercel.js[22m                                                                                                                                                   [2m  8.56 kB[22m [2m│ gzip:  2.75 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/files.js[22m                                                                                                                                                           [2m  8.48 kB[22m [2m│ gzip:  2.16 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/schema/index.js[22m                                                                                                                                               [2m  8.45 kB[22m [2m│ gzip:  1.81 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/get-ast-from-query/lib/parse-fields.js[22m                                                                                                                                [2m  8.17 kB[22m [2m│ gzip:  2.08 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/validate-query.js[22m                                                                                                                                                        [2m  7.94 kB[22m [2m│ gzip:  2.21 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20240806A-permissions-policies.js[22m                                                                                                                          [2m  7.76 kB[22m [2m│ gzip:  2.10 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/extensions.js[22m                                                                                                                                                      [2m  7.58 kB[22m [2m│ gzip:  1.73 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/auth.js[22m                                                                                                                                                            [2m  7.42 kB[22m [2m│ gzip:  1.84 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/schema/get-types.js[22m                                                                                                                                           [2m  7.19 kB[22m [2m│ gzip:  1.81 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcli/commands/schema/apply.js[22m                                                                                                                                                   [2m  7.18 kB[22m [2m│ gzip:  1.71 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/extensions.js[22m                                                                                                                                                         [2m  7.04 kB[22m [2m│ gzip:  2.00 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/items.js[22m                                                                                                                                                           [2m  6.97 kB[22m [2m│ gzip:  1.24 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/sanitize-query.js[22m                                                                                                                                                        [2m  6.86 kB[22m [2m│ gzip:  1.97 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mauth/drivers/saml.js[22m                                                                                                                                                           [2m  6.82 kB[22m [2m│ gzip:  2.19 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/collab/messenger.js[22m                                                                                                                                                  [2m  6.80 kB[22m [2m│ gzip:  1.72 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mmetrics/lib/create-metrics.js[22m                                                                                                                                                  [2m  6.71 kB[22m [2m│ gzip:  1.95 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/schema/write.js[22m                                                                                                                                               [2m  6.65 kB[22m [2m│ gzip:  1.05 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/versions.js[22m                                                                                                                                                        [2m  6.63 kB[22m [2m│ gzip:  1.40 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/shares.js[22m                                                                                                                                                          [2m  6.62 kB[22m [2m│ gzip:  1.56 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/utils/get-permissions-for-share.js[22m                                                                                                                                 [2m  6.60 kB[22m [2m│ gzip:  1.63 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/tus/data-store.js[22m                                                                                                                                                     [2m  6.55 kB[22m [2m│ gzip:  2.03 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/validate-diff.js[22m                                                                                                                                                         [2m  6.42 kB[22m [2m│ gzip:  1.54 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-schema.js[22m                                                                                                                                                            [2m  6.26 kB[22m [2m│ gzip:  2.11 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/versioning/handle-version.js[22m                                                                                                                                             [2m  6.21 kB[22m [2m│ gzip:  1.90 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-snapshot-diff.js[22m                                                                                                                                                     [2m  6.18 kB[22m [2m│ gzip:  1.32 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/utils.js[22m                                                                                                                                                           [2m  6.13 kB[22m [2m│ gzip:  1.73 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/fields.js[22m                                                                                                                                                          [2m  6.06 kB[22m [2m│ gzip:  1.28 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/permissions.js[22m                                                                                                                                                     [2m  5.86 kB[22m [2m│ gzip:  1.28 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcache.js[22m                                                                                                                                                                       [2m  5.80 kB[22m [2m│ gzip:  1.73 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/lib/apply-query/filter/index.js[22m                                                                                                                               [2m  5.78 kB[22m [2m│ gzip:  1.70 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/permissions.js[22m                                                                                                                                                        [2m  5.66 kB[22m [2m│ gzip:  1.57 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/errors/dialects/mssql.js[22m                                                                                                                                              [2m  5.56 kB[22m [2m│ gzip:  1.58 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/mcp-oauth/utils/cimd-egress.js[22m                                                                                                                                        [2m  5.53 kB[22m [2m│ gzip:  1.83 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/policies.js[22m                                                                                                                                                        [2m  5.48 kB[22m [2m│ gzip:  1.22 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mlogger/index.js[22m                                                                                                                                                                [2m  5.43 kB[22m [2m│ gzip:  1.54 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/handlers/subscribe.js[22m                                                                                                                                                [2m  5.36 kB[22m [2m│ gzip:  1.60 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/collab/permissions-cache.js[22m                                                                                                                                          [2m  5.35 kB[22m [2m│ gzip:  1.80 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/flows.js[22m                                                                                                                                                           [2m  5.27 kB[22m [2m│ gzip:  1.18 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/roles.js[22m                                                                                                                                                           [2m  5.22 kB[22m [2m│ gzip:  1.15 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/comments.js[22m                                                                                                                                                           [2m  5.07 kB[22m [2m│ gzip:  1.69 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/index.js[22m                                                                                                                                                              [2m  5.06 kB[22m [2m│ gzip:  1.09 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mserver.js[22m                                                                                                                                                                      [2m  5.05 kB[22m [2m│ gzip:  1.75 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/utils/merge-with-parent-items.js[22m                                                                                                                              [2m  5.01 kB[22m [2m│ gzip:  1.28 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/tools/items/index.js[22m                                                                                                                                                        [2m  5.01 kB[22m [2m│ gzip:  1.36 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/license.js[22m                                                                                                                                                         [2m  5.01 kB[22m [2m│ gzip:  1.29 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/tools/fields/index.js[22m                                                                                                                                                       [2m  4.97 kB[22m [2m│ gzip:  1.38 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/collab/payload-permissions.js[22m                                                                                                                                        [2m  4.92 kB[22m [2m│ gzip:  1.53 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/chat/utils/format-context.js[22m                                                                                                                                                [2m  4.87 kB[22m [2m│ gzip:  1.70 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/schema/parse-query.js[22m                                                                                                                                         [2m  4.86 kB[22m [2m│ gzip:  1.45 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/translations.js[22m                                                                                                                                                    [2m  4.78 kB[22m [2m│ gzip:  1.01 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/notifications.js[22m                                                                                                                                                   [2m  4.77 kB[22m [2m│ gzip:  1.01 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/folders.js[22m                                                                                                                                                         [2m  4.71 kB[22m [2m│ gzip:  1.01 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/shares.js[22m                                                                                                                                                             [2m  4.70 kB[22m [2m│ gzip:  1.69 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/schema/types.js[22m                                                                                                                                               [2m  4.70 kB[22m [2m│ gzip:  1.59 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/run.js[22m                                                                                                                                                     [2m  4.69 kB[22m [2m│ gzip:  1.55 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/presets.js[22m                                                                                                                                                         [2m  4.68 kB[22m [2m│ gzip:  1.01 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/errors/dialects/mysql.js[22m                                                                                                                                              [2m  4.63 kB[22m [2m│ gzip:  1.26 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/access.js[22m                                                                                                                                                          [2m  4.62 kB[22m [2m│ gzip:  1.01 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/comments.js[22m                                                                                                                                                        [2m  4.62 kB[22m [2m│ gzip:  0.99 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210518A-add-foreign-key-constraints.js[22m                                                                                                                   [2m  4.55 kB[22m [2m│ gzip:  1.37 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20240311A-deprecate-webhooks.js[22m                                                                                                                            [2m  4.52 kB[22m [2m│ gzip:  1.68 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/dashboards.js[22m                                                                                                                                                      [2m  4.52 kB[22m [2m│ gzip:  0.98 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/operations.js[22m                                                                                                                                                      [2m  4.52 kB[22m [2m│ gzip:  0.98 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/utils.js[22m                                                                                                                                                              [2m  4.51 kB[22m [2m│ gzip:  1.36 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/handlers/items.js[22m                                                                                                                                                    [2m  4.51 kB[22m [2m│ gzip:  1.15 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/panels.js[22m                                                                                                                                                          [2m  4.46 kB[22m [2m│ gzip:  0.98 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/run-ast.js[22m                                                                                                                                                    [2m  4.43 kB[22m [2m│ gzip:  1.49 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcli/index.js[22m                                                                                                                                                                   [2m  4.39 kB[22m [2m│ gzip:  1.36 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/get-extensions-settings.js[22m                                                                                                                                      [2m  4.37 kB[22m [2m│ gzip:  1.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210519A-add-system-fk-triggers.js[22m                                                                                                                        [2m  4.36 kB[22m [2m│ gzip:  1.04 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mmiddleware/respond.js[22m                                                                                                                                                          [2m  4.34 kB[22m [2m│ gzip:  1.30 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/deployment-projects.js[22m                                                                                                                                                [2m  4.29 kB[22m [2m│ gzip:  1.39 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/collab/verify-permissions.js[22m                                                                                                                                         [2m  4.28 kB[22m [2m│ gzip:  1.38 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/transformations.js[22m                                                                                                                                                       [2m  4.26 kB[22m [2m│ gzip:  1.36 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/mcp-oauth/utils/redirect.js[22m                                                                                                                                           [2m  4.17 kB[22m [2m│ gzip:  1.41 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20260512B-add-mcp-oauth.js[22m                                                                                                                                 [2m  4.15 kB[22m [2m│ gzip:  0.81 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/mcp-oauth/utils/registration-debug.js[22m                                                                                                                                 [2m  4.10 kB[22m [2m│ gzip:  1.30 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/server.js[22m                                                                                                                                                          [2m  4.05 kB[22m [2m│ gzip:  1.36 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mlicense/entitlements/lib/seats.js[22m                                                                                                                                              [2m  4.05 kB[22m [2m│ gzip:  1.30 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/utils/items.js[22m                                                                                                                                                       [2m  4.00 kB[22m [2m│ gzip:  0.90 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/relations.js[22m                                                                                                                                                       [2m  3.96 kB[22m [2m│ gzip:  0.90 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/schema/dialects/mysql.js[22m                                                                                                                                      [2m  3.94 kB[22m [2m│ gzip:  1.50 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/handlers/logs.js[22m                                                                                                                                                     [2m  3.88 kB[22m [2m│ gzip:  1.27 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtelemetry/counter/use-buffered-counter.js[22m                                                                                                                                      [2m  3.88 kB[22m [2m│ gzip:  1.44 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/chat/utils/prompt-caching.js[22m                                                                                                                                                [2m  3.84 kB[22m [2m│ gzip:  1.39 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/installation/manager.js[22m                                                                                                                                         [2m  3.75 kB[22m [2m│ gzip:  1.35 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/schema/dialects/oracle.js[22m                                                                                                                                     [2m  3.74 kB[22m [2m│ gzip:  1.38 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/collections.js[22m                                                                                                                                                     [2m  3.72 kB[22m [2m│ gzip:  0.85 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/mail/index.js[22m                                                                                                                                                         [2m  3.71 kB[22m [2m│ gzip:  1.40 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/controllers/graphql.js[22m                                                                                                                                               [2m  3.71 kB[22m [2m│ gzip:  1.27 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/lib/apply-query/add-join.js[22m                                                                                                                                   [2m  3.71 kB[22m [2m│ gzip:  1.04 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcli/commands/init/index.js[22m                                                                                                                                                     [2m  3.68 kB[22m [2m│ gzip:  1.38 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/schema.js[22m                                                                                                                                                          [2m  3.67 kB[22m [2m│ gzip:  1.18 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/redact-object.js[22m                                                                                                                                                         [2m  3.67 kB[22m [2m│ gzip:  1.34 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/process-payload/process-payload.js[22m                                                                                                                         [2m  3.63 kB[22m [2m│ gzip:  1.19 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mconstants.js[22m                                                                                                                                                                   [2m  3.59 kB[22m [2m│ gzip:  1.24 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/collab/calculate-cache-metadata.js[22m                                                                                                                                   [2m  3.58 kB[22m [2m│ gzip:  1.25 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/validate-access/lib/validate-item-access.js[22m                                                                                                                [2m  3.54 kB[22m [2m│ gzip:  1.09 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-service.js[22m                                                                                                                                                           [2m  3.51 kB[22m [2m│ gzip:  0.82 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/tools/files/index.js[22m                                                                                                                                                        [2m  3.42 kB[22m [2m│ gzip:  1.08 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/get-ast-from-query/lib/convert-wildcards.js[22m                                                                                                                           [2m  3.42 kB[22m [2m│ gzip:  1.06 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mschedules/retention.js[22m                                                                                                                                                         [2m  3.39 kB[22m [2m│ gzip:  1.24 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/tus/server.js[22m                                                                                                                                                         [2m  3.38 kB[22m [2m│ gzip:  1.26 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-local-type.js[22m                                                                                                                                                        [2m  3.38 kB[22m [2m│ gzip:  1.07 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/tools/folders/index.js[22m                                                                                                                                                      [2m  3.36 kB[22m [2m│ gzip:  0.98 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/deployment-webhooks.js[22m                                                                                                                                             [2m  3.31 kB[22m [2m│ gzip:  1.15 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/sandbox/generate-api-extensions-sandbox-entrypoint.js[22m                                                                                                           [2m  3.31 kB[22m [2m│ gzip:  0.90 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20240204A-marketplace.js[22m                                                                                                                                   [2m  3.30 kB[22m [2m│ gzip:  1.02 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mauth/drivers/local.js[22m                                                                                                                                                          [2m  3.29 kB[22m [2m│ gzip:  1.25 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/messages.js[22m                                                                                                                                                          [2m  3.28 kB[22m [2m│ gzip:  0.79 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/sync/sync.js[22m                                                                                                                                                    [2m  3.26 kB[22m [2m│ gzip:  1.18 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/controllers/hooks.js[22m                                                                                                                                                 [2m  3.23 kB[22m [2m│ gzip:  0.82 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/files/controllers/upload.js[22m                                                                                                                                                 [2m  3.19 kB[22m [2m│ gzip:  1.24 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/index.js[22m                                                                                                                                                      [2m  3.17 kB[22m [2m│ gzip:  1.09 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mmiddleware/error-handler.js[22m                                                                                                                                                    [2m  3.17 kB[22m [2m│ gzip:  1.20 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/utils/remove-temporary-fields.js[22m                                                                                                                              [2m  3.12 kB[22m [2m│ gzip:  0.88 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/tools/relations/index.js[22m                                                                                                                                                    [2m  3.09 kB[22m [2m│ gzip:  0.95 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20211007A-update-presets.js[22m                                                                                                                                [2m  3.07 kB[22m [2m│ gzip:  0.83 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/utils/merge-permissions.js[22m                                                                                                                                         [2m  3.05 kB[22m [2m│ gzip:  0.96 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/deployment-runs.js[22m                                                                                                                                                    [2m  3.02 kB[22m [2m│ gzip:  1.10 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/lib/apply-query/index.js[22m                                                                                                                                      [2m  3.00 kB[22m [2m│ gzip:  1.05 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/settings.js[22m                                                                                                                                                           [2m  2.98 kB[22m [2m│ gzip:  0.87 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20201029A-remove-system-relations.js[22m                                                                                                                       [2m  2.97 kB[22m [2m│ gzip:  0.67 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/files/utils/get-metadata.js[22m                                                                                                                                           [2m  2.96 kB[22m [2m│ gzip:  0.97 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mauth.js[22m                                                                                                                                                                        [2m  2.95 kB[22m [2m│ gzip:  1.03 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/subscription.js[22m                                                                                                                                               [2m  2.93 kB[22m [2m│ gzip:  1.01 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/folders.js[22m                                                                                                                                                            [2m  2.92 kB[22m [2m│ gzip:  1.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/fn/dialects/postgres.js[22m                                                                                                                                       [2m  2.90 kB[22m [2m│ gzip:  0.88 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/resolvers/mutation.js[22m                                                                                                                                         [2m  2.90 kB[22m [2m│ gzip:  0.89 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20220429A-add-flows.js[22m                                                                                                                                     [2m  2.89 kB[22m [2m│ gzip:  0.96 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/telemetry/langfuse.js[22m                                                                                                                                                       [2m  2.87 kB[22m [2m│ gzip:  0.98 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/lib/apply-query/sort.js[22m                                                                                                                                       [2m  2.87 kB[22m [2m│ gzip:  0.98 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/lib/apply-query/search.js[22m                                                                                                                                     [2m  2.86 kB[22m [2m│ gzip:  1.06 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/resolvers/query.js[22m                                                                                                                                            [2m  2.86 kB[22m [2m│ gzip:  1.17 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/chat/utils/parse-json-schema-7.js[22m                                                                                                                                           [2m  2.85 kB[22m [2m│ gzip:  1.16 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/providers/anthropic-file-support.js[22m                                                                                                                                         [2m  2.83 kB[22m [2m│ gzip:  1.18 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/roles.js[22m                                                                                                                                                              [2m  2.83 kB[22m [2m│ gzip:  0.91 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/utils/fetch-dynamic-variable-data.js[22m                                                                                                                               [2m  2.83 kB[22m [2m│ gzip:  0.84 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/tools/collections/index.js[22m                                                                                                                                                  [2m  2.81 kB[22m [2m│ gzip:  0.96 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1msynchronization.js[22m                                                                                                                                                             [2m  2.80 kB[22m [2m│ gzip:  0.92 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/errors/dialects/postgres.js[22m                                                                                                                                           [2m  2.80 kB[22m [2m│ gzip:  0.80 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/tools/flows/index.js[22m                                                                                                                                                        [2m  2.79 kB[22m [2m│ gzip:  0.93 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/fn/json/parse-function.js[22m                                                                                                                                     [2m  2.79 kB[22m [2m│ gzip:  1.11 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-snapshot.js[22m                                                                                                                                                          [2m  2.78 kB[22m [2m│ gzip:  0.87 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/tus/lockers.js[22m                                                                                                                                                        [2m  2.77 kB[22m [2m│ gzip:  1.19 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/tools/operations/index.js[22m                                                                                                                                                   [2m  2.74 kB[22m [2m│ gzip:  0.86 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/authenticate.js[22m                                                                                                                                                      [2m  2.72 kB[22m [2m│ gzip:  0.88 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/chat/controllers/object.post.js[22m                                                                                                                                             [2m  2.72 kB[22m [2m│ gzip:  1.04 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/chat/lib/create-ui-stream.js[22m                                                                                                                                                [2m  2.71 kB[22m [2m│ gzip:  0.99 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/capabilities/dialects/mssql.js[22m                                                                                                                                [2m  2.70 kB[22m [2m│ gzip:  1.29 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1memitter.js[22m                                                                                                                                                                     [2m  2.68 kB[22m [2m│ gzip:  0.86 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtelemetry/lib/get-report.js[22m                                                                                                                                                    [2m  2.68 kB[22m [2m│ gzip:  0.97 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/utils/sanitize-gql-schema.js[22m                                                                                                                                  [2m  2.67 kB[22m [2m│ gzip:  1.00 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mmiddleware/cache.js[22m                                                                                                                                                            [2m  2.66 kB[22m [2m│ gzip:  0.92 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/fn/dialects/sqlite.js[22m                                                                                                                                         [2m  2.64 kB[22m [2m│ gzip:  0.71 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/mcp/oauth-clients.js[22m                                                                                                                                               [2m  2.63 kB[22m [2m│ gzip:  0.74 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/tfa.js[22m                                                                                                                                                                [2m  2.62 kB[22m [2m│ gzip:  0.86 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/policies.js[22m                                                                                                                                                           [2m  2.61 kB[22m [2m│ gzip:  0.89 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/telemetry/index.js[22m                                                                                                                                                          [2m  2.60 kB[22m [2m│ gzip:  0.98 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/sanitize-schema.js[22m                                                                                                                                                       [2m  2.60 kB[22m [2m│ gzip:  0.72 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/seeds/run.js[22m                                                                                                                                                          [2m  2.57 kB[22m [2m│ gzip:  0.95 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/utils/get-column.js[22m                                                                                                                                           [2m  2.56 kB[22m [2m│ gzip:  1.03 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-column-path.js[22m                                                                                                                                                       [2m  2.54 kB[22m [2m│ gzip:  0.96 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/fn/dialects/oracle.js[22m                                                                                                                                         [2m  2.54 kB[22m [2m│ gzip:  0.77 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/utils/filter-replace-m2a.js[22m                                                                                                                                   [2m  2.54 kB[22m [2m│ gzip:  0.71 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/validate-user-count-integrity.js[22m                                                                                                                                         [2m  2.54 kB[22m [2m│ gzip:  0.86 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/fields/get-collection-meta-updates.js[22m                                                                                                                                 [2m  2.52 kB[22m [2m│ gzip:  0.80 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/handlers/heartbeat.js[22m                                                                                                                                                [2m  2.50 kB[22m [2m│ gzip:  0.93 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/chat/constants/system-prompt.js[22m                                                                                                                                             [2m  2.49 kB[22m [2m│ gzip:  1.31 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/fetch-user-count/fetch-user-count.js[22m                                                                                                                                     [2m  2.47 kB[22m [2m│ gzip:  0.78 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/validate-snapshot.js[22m                                                                                                                                                     [2m  2.47 kB[22m [2m│ gzip:  0.82 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/chat/models/chat-request.js[22m                                                                                                                                                 [2m  2.47 kB[22m [2m│ gzip:  0.78 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/url.js[22m                                                                                                                                                                   [2m  2.44 kB[22m [2m│ gzip:  0.86 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/chat/controllers/chat.post.js[22m                                                                                                                                               [2m  2.43 kB[22m [2m│ gzip:  1.00 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/fn/dialects/mssql.js[22m                                                                                                                                          [2m  2.43 kB[22m [2m│ gzip:  0.74 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-accountability-for-token.js[22m                                                                                                                                          [2m  2.39 kB[22m [2m│ gzip:  0.79 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210506A-rename-interfaces.js[22m                                                                                                                             [2m  2.39 kB[22m [2m│ gzip:  0.89 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/deep-map-response.js[22m                                                                                                                                                     [2m  2.38 kB[22m [2m│ gzip:  0.86 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdeployment.js[22m                                                                                                                                                                  [2m  2.37 kB[22m [2m│ gzip:  0.94 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/translations-shared.js[22m                                                                                                                                                   [2m  2.37 kB[22m [2m│ gzip:  0.84 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20201029B-remove-system-collections.js[22m                                                                                                                     [2m  2.36 kB[22m [2m│ gzip:  0.88 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcli/commands/bootstrap/index.js[22m                                                                                                                                                [2m  2.35 kB[22m [2m│ gzip:  0.91 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20201105A-add-cascade-system-relations.js[22m                                                                                                                  [2m  2.35 kB[22m [2m│ gzip:  0.67 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/meta.js[22m                                                                                                                                                               [2m  2.34 kB[22m [2m│ gzip:  0.87 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/lib/apply-query/normalize-filter.js[22m                                                                                                                           [2m  2.33 kB[22m [2m│ gzip:  1.01 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mauth/utils/resolve-login-redirect.js[22m                                                                                                                                           [2m  2.32 kB[22m [2m│ gzip:  0.91 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/utils/apply-parent-filters.js[22m                                                                                                                                 [2m  2.31 kB[22m [2m│ gzip:  0.69 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/tus.js[22m                                                                                                                                                             [2m  2.29 kB[22m [2m│ gzip:  0.86 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/sandbox/sdk/generators/request.js[22m                                                                                                                               [2m  2.28 kB[22m [2m│ gzip:  0.73 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/schema/dialects/mssql.js[22m                                                                                                                                      [2m  2.27 kB[22m [2m│ gzip:  1.01 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210805B-change-image-metadata-structure.js[22m                                                                                                               [2m  2.25 kB[22m [2m│ gzip:  0.64 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/encrypt.js[22m                                                                                                                                                               [2m  2.21 kB[22m [2m│ gzip:  0.83 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/schema/dialects/cockroachdb.js[22m                                                                                                                                [2m  2.20 kB[22m [2m│ gzip:  1.01 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1moperations/item-update/index.js[22m                                                                                                                                                [2m  2.17 kB[22m [2m│ gzip:  0.71 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1moperations/exec/index.js[22m                                                                                                                                                       [2m  2.17 kB[22m [2m│ gzip:  0.90 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/reduce-schema.js[22m                                                                                                                                                         [2m  2.16 kB[22m [2m│ gzip:  0.64 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20230927A-themes.js[22m                                                                                                                                        [2m  2.15 kB[22m [2m│ gzip:  0.63 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20230526A-migrate-translation-strings.js[22m                                                                                                                   [2m  2.15 kB[22m [2m│ gzip:  0.78 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/notifications.js[22m                                                                                                                                                      [2m  2.14 kB[22m [2m│ gzip:  0.87 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/fn/types.js[22m                                                                                                                                                   [2m  2.13 kB[22m [2m│ gzip:  0.92 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/files/utils/parse-image-metadata.js[22m                                                                                                                                   [2m  2.12 kB[22m [2m│ gzip:  0.88 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/utils/dedupe-resolvers.js[22m                                                                                                                                     [2m  2.11 kB[22m [2m│ gzip:  0.88 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/process-ast/lib/extract-fields-from-query.js[22m                                                                                                               [2m  2.11 kB[22m [2m│ gzip:  0.89 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20240924A-migrate-legacy-comments.js[22m                                                                                                                       [2m  2.09 kB[22m [2m│ gzip:  0.77 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/fields/build-collection-and-field-relations.js[22m                                                                                                                        [2m  2.07 kB[22m [2m│ gzip:  0.59 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/utils/get-column-pre-processor.js[22m                                                                                                                             [2m  2.06 kB[22m [2m│ gzip:  0.76 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/fn/dialects/mysql.js[22m                                                                                                                                          [2m  2.05 kB[22m [2m│ gzip:  0.68 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20240909A-separate-comments.js[22m                                                                                                                             [2m  2.04 kB[22m [2m│ gzip:  0.76 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/lib/parse-current-level.js[22m                                                                                                                                    [2m  2.03 kB[22m [2m│ gzip:  0.76 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/files/adapters/google.js[22m                                                                                                                                                    [2m  2.01 kB[22m [2m│ gzip:  0.93 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/sync/tracker.js[22m                                                                                                                                                 [2m  2.00 kB[22m [2m│ gzip:  0.76 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mmailer.js[22m                                                                                                                                                                      [2m  2.00 kB[22m [2m│ gzip:  0.81 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/utils/extract-required-dynamic-variable-context.js[22m                                                                                                                 [2m  1.99 kB[22m [2m│ gzip:  0.55 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/transaction.js[22m                                                                                                                                                           [2m  1.98 kB[22m [2m│ gzip:  0.92 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mmiddleware/graphql.js[22m                                                                                                                                                          [2m  1.98 kB[22m [2m│ gzip:  0.81 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/schema.js[22m                                                                                                                                                             [2m  1.97 kB[22m [2m│ gzip:  0.65 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mmiddleware/authenticate.js[22m                                                                                                                                                     [2m  1.97 kB[22m [2m│ gzip:  0.77 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/revisions.js[22m                                                                                                                                                          [2m  1.96 kB[22m [2m│ gzip:  0.79 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20231009B-update-panel-options.js[22m                                                                                                                          [2m  1.96 kB[22m [2m│ gzip:  0.53 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/tools/assets/index.js[22m                                                                                                                                                       [2m  1.96 kB[22m [2m│ gzip:  0.86 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/process-ast/process-ast.js[22m                                                                                                                                 [2m  1.95 kB[22m [2m│ gzip:  0.54 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/tools/trigger-flow/index.js[22m                                                                                                                                                 [2m  1.92 kB[22m [2m│ gzip:  0.88 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/capabilities/types.js[22m                                                                                                                                         [2m  1.92 kB[22m [2m│ gzip:  0.99 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mmiddleware/rate-limiter-global.js[22m                                                                                                                                              [2m  1.92 kB[22m [2m│ gzip:  0.76 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20230721A-require-shares-fields.js[22m                                                                                                                         [2m  1.91 kB[22m [2m│ gzip:  0.69 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/providers/registry.js[22m                                                                                                                                                       [2m  1.91 kB[22m [2m│ gzip:  0.63 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/process-ast/lib/extract-fields-from-children.js[22m                                                                                                            [2m  1.90 kB[22m [2m│ gzip:  0.52 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210927A-replace-fields-group.js[22m                                                                                                                          [2m  1.90 kB[22m [2m│ gzip:  0.61 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1moperations/item-delete/index.js[22m                                                                                                                                                [2m  1.89 kB[22m [2m│ gzip:  0.66 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1moperations/item-read/index.js[22m                                                                                                                                                  [2m  1.89 kB[22m [2m│ gzip:  0.66 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/capabilities/dialects/sqlite.js[22m                                                                                                                               [2m  1.89 kB[22m [2m│ gzip:  0.99 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/sync/utils.js[22m                                                                                                                                                   [2m  1.86 kB[22m [2m│ gzip:  0.77 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/create-admin.js[22m                                                                                                                                                          [2m  1.83 kB[22m [2m│ gzip:  0.65 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1memitter.test-d.js[22m                                                                                                                                                              [2m  1.83 kB[22m [2m│ gzip:  0.61 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20201028A-remove-collection-foreign-keys.js[22m                                                                                                                [2m  1.82 kB[22m [2m│ gzip:  0.34 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/fetch-accountability-collection-access/fetch-accountability-collection-access.js[22m                                                                           [2m  1.81 kB[22m [2m│ gzip:  0.73 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/controllers/rest.js[22m                                                                                                                                                  [2m  1.80 kB[22m [2m│ gzip:  0.71 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/controllers/logs.js[22m                                                                                                                                                  [2m  1.78 kB[22m [2m│ gzip:  0.81 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-cache-key.js[22m                                                                                                                                                         [2m  1.77 kB[22m [2m│ gzip:  0.80 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/fn/json/postgres-json-path.js[22m                                                                                                                                 [2m  1.77 kB[22m [2m│ gzip:  0.83 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/activity.js[22m                                                                                                                                                        [2m  1.77 kB[22m [2m│ gzip:  0.62 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1moperations/notification/index.js[22m                                                                                                                                               [2m  1.75 kB[22m [2m│ gzip:  0.63 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/resolvers/get-field-type.js[22m                                                                                                                                   [2m  1.74 kB[22m [2m│ gzip:  0.68 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/process-ast/lib/inject-cases.js[22m                                                                                                                            [2m  1.73 kB[22m [2m│ gzip:  0.67 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mlicense/entitlements/lib/custom-permission-rules-enabled.js[22m                                                                                                                    [2m  1.73 kB[22m [2m│ gzip:  0.66 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/process-ast/utils/extract-paths-from-query.js[22m                                                                                                              [2m  1.70 kB[22m [2m│ gzip:  0.74 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20260204A-add-deployment.js[22m                                                                                                                                [2m  1.70 kB[22m [2m│ gzip:  0.45 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20220322A-rename-field-typecast-flags.js[22m                                                                                                                   [2m  1.69 kB[22m [2m│ gzip:  0.52 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mlicense/entitlements/lib/sso-enabled.js[22m                                                                                                                                        [2m  1.68 kB[22m [2m│ gzip:  0.72 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/chat/middleware/load-settings.js[22m                                                                                                                                            [2m  1.68 kB[22m [2m│ gzip:  0.51 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20260110A-add-ai-provider-settings.js[22m                                                                                                                      [2m  1.67 kB[22m [2m│ gzip:  0.52 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/chat/utils/add-additional-properties-to-json-schema.js[22m                                                                                                                      [2m  1.67 kB[22m [2m│ gzip:  0.60 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/sandbox/register/route.js[22m                                                                                                                                       [2m  1.65 kB[22m [2m│ gzip:  0.64 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20231009A-update-csv-fields-to-text.js[22m                                                                                                                     [2m  1.63 kB[22m [2m│ gzip:  0.59 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/revisions.js[22m                                                                                                                                                       [2m  1.63 kB[22m [2m│ gzip:  0.57 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/mcp/index.js[22m                                                                                                                                                       [2m  1.61 kB[22m [2m│ gzip:  0.65 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/geometry/types.js[22m                                                                                                                                             [2m  1.61 kB[22m [2m│ gzip:  0.54 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20240817A-update-icon-fields-length.js[22m                                                                                                                     [2m  1.59 kB[22m [2m│ gzip:  0.39 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcli/commands/roles/create.js[22m                                                                                                                                                   [2m  1.57 kB[22m [2m│ gzip:  0.58 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/validate-access/validate-access.js[22m                                                                                                                         [2m  1.56 kB[22m [2m│ gzip:  0.66 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20251028A-add-retention-indexes.js[22m                                                                                                                         [2m  1.56 kB[22m [2m│ gzip:  0.59 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/sandbox/sdk/instantiate.js[22m                                                                                                                                      [2m  1.56 kB[22m [2m│ gzip:  0.69 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcli/commands/schema/snapshot.js[22m                                                                                                                                                [2m  1.55 kB[22m [2m│ gzip:  0.65 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mlicense/entitlements/lib/collections.js[22m                                                                                                                                        [2m  1.55 kB[22m [2m│ gzip:  0.61 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/calculate-field-depth.js[22m                                                                                                                                                 [2m  1.54 kB[22m [2m│ gzip:  0.70 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/settings.js[22m                                                                                                                                                        [2m  1.53 kB[22m [2m│ gzip:  0.55 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20211211A-add-shares.js[22m                                                                                                                                    [2m  1.53 kB[22m [2m│ gzip:  0.54 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1moperations/item-create/index.js[22m                                                                                                                                                [2m  1.52 kB[22m [2m│ gzip:  0.56 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/types/json-filter.js[22m                                                                                                                                          [2m  1.52 kB[22m [2m│ gzip:  0.63 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/get-ast-from-query/get-ast-from-query.js[22m                                                                                                                              [2m  1.51 kB[22m [2m│ gzip:  0.65 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1moperations/trigger/index.js[22m                                                                                                                                                    [2m  1.51 kB[22m [2m│ gzip:  0.56 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/chat/utils/chat-request-tool-to-ai-sdk-tool.js[22m                                                                                                                              [2m  1.51 kB[22m [2m│ gzip:  0.64 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/utils/fetch-raw-permissions.js[22m                                                                                                                                     [2m  1.51 kB[22m [2m│ gzip:  0.56 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcli/commands/init/questions.js[22m                                                                                                                                                 [2m  1.50 kB[22m [2m│ gzip:  0.54 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20260113A-add-revisions-index.js[22m                                                                                                                           [2m  1.50 kB[22m [2m│ gzip:  0.58 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1moperations/json-web-token/index.js[22m                                                                                                                                             [2m  1.50 kB[22m [2m│ gzip:  0.46 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/translations.js[22m                                                                                                                                                       [2m  1.50 kB[22m [2m│ gzip:  0.58 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20230823A-add-content-versioning.js[22m                                                                                                                        [2m  1.49 kB[22m [2m│ gzip:  0.51 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-ip-from-req.js[22m                                                                                                                                                       [2m  1.49 kB[22m [2m│ gzip:  0.76 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mlicense/utils/handle-license-error.js[22m                                                                                                                                          [2m  1.49 kB[22m [2m│ gzip:  0.67 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/errors.js[22m                                                                                                                                                            [2m  1.48 kB[22m [2m│ gzip:  0.58 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/access.js[22m                                                                                                                                                             [2m  1.48 kB[22m [2m│ gzip:  0.46 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/lib/fetch-permissions.js[22m                                                                                                                                           [2m  1.47 kB[22m [2m│ gzip:  0.49 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mauth/utils/generate-callback-url.js[22m                                                                                                                                            [2m  1.47 kB[22m [2m│ gzip:  0.65 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-default-value.js[22m                                                                                                                                                     [2m  1.46 kB[22m [2m│ gzip:  0.56 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/errors/translate.js[22m                                                                                                                                                   [2m  1.45 kB[22m [2m│ gzip:  0.56 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210525A-add-insights.js[22m                                                                                                                                  [2m  1.45 kB[22m [2m│ gzip:  0.48 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mmiddleware/validate-batch.js[22m                                                                                                                                                   [2m  1.45 kB[22m [2m│ gzip:  0.61 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcli/utils/create-env/index.js[22m                                                                                                                                                  [2m  1.44 kB[22m [2m│ gzip:  0.67 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210802A-replace-groups.js[22m                                                                                                                                [2m  1.44 kB[22m [2m│ gzip:  0.57 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/resolvers/get-relation-type.js[22m                                                                                                                                [2m  1.44 kB[22m [2m│ gzip:  0.56 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-config-from-env.js[22m                                                                                                                                                   [2m  1.43 kB[22m [2m│ gzip:  0.59 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20260211A-add-deployment-webhooks.js[22m                                                                                                                       [2m  1.43 kB[22m [2m│ gzip:  0.40 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/geometry/dialects/oracle.js[22m                                                                                                                                   [2m  1.43 kB[22m [2m│ gzip:  0.56 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/errors/dialects/sqlite.js[22m                                                                                                                                             [2m  1.42 kB[22m [2m│ gzip:  0.61 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/utils/generate-alias.js[22m                                                                                                                                       [2m  1.42 kB[22m [2m│ gzip:  0.59 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/sandbox/sdk/utils/wrap.js[22m                                                                                                                                       [2m  1.41 kB[22m [2m│ gzip:  0.72 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/schema/dialects/postgres.js[22m                                                                                                                                   [2m  1.41 kB[22m [2m│ gzip:  0.67 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/metrics.js[22m                                                                                                                                                         [2m  1.40 kB[22m [2m│ gzip:  0.63 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/websocket.js[22m                                                                                                                                                          [2m  1.40 kB[22m [2m│ gzip:  0.57 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/utils/aggregate-query.js[22m                                                                                                                                      [2m  1.39 kB[22m [2m│ gzip:  0.55 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/permissions-cacheable.js[22m                                                                                                                                                 [2m  1.39 kB[22m [2m│ gzip:  0.57 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mlicense/utils/get-core-grace-expires-at.js[22m                                                                                                                                     [2m  1.38 kB[22m [2m│ gzip:  0.66 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcli/utils/create-db-connection.js[22m                                                                                                                                              [2m  1.36 kB[22m [2m│ gzip:  0.61 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/flows.js[22m                                                                                                                                                              [2m  1.35 kB[22m [2m│ gzip:  0.47 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20251014A-add-project-owner.js[22m                                                                                                                             [2m  1.33 kB[22m [2m│ gzip:  0.55 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mmiddleware/rate-limiter-registration.js[22m                                                                                                                                        [2m  1.32 kB[22m [2m│ gzip:  0.58 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtelemetry/utils/get-settings.js[22m                                                                                                                                                [2m  1.32 kB[22m [2m│ gzip:  0.54 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/modules/fetch-permitted-ast-root-fields.js[22m                                                                                                                    [2m  1.31 kB[22m [2m│ gzip:  0.60 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/schema/parse-args.js[22m                                                                                                                                          [2m  1.31 kB[22m [2m│ gzip:  0.65 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/fetch-user-count/fetch-access-lookup.js[22m                                                                                                                                  [2m  1.31 kB[22m [2m│ gzip:  0.40 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtelemetry/utils/get-item-count.js[22m                                                                                                                                              [2m  1.29 kB[22m [2m│ gzip:  0.61 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/graphql.js[22m                                                                                                                                                         [2m  1.29 kB[22m [2m│ gzip:  0.44 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/fetch-inconsistent-field-map/fetch-inconsistent-field-map.js[22m                                                                                               [2m  1.29 kB[22m [2m│ gzip:  0.55 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20250224A-visual-editor.js[22m                                                                                                                                 [2m  1.29 kB[22m [2m│ gzip:  0.53 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/validate-storage.js[22m                                                                                                                                                      [2m  1.27 kB[22m [2m│ gzip:  0.56 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/lib/fetch-policies.js[22m                                                                                                                                              [2m  1.27 kB[22m [2m│ gzip:  0.59 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/fetch-global-access/fetch-global-access.js[22m                                                                                                                 [2m  1.27 kB[22m [2m│ gzip:  0.50 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1moperations/request/index.js[22m                                                                                                                                                    [2m  1.27 kB[22m [2m│ gzip:  0.57 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-cache-headers.js[22m                                                                                                                                                     [2m  1.27 kB[22m [2m│ gzip:  0.64 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/versioning/split-recursive.js[22m                                                                                                                                            [2m  1.27 kB[22m [2m│ gzip:  0.43 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/controllers/index.js[22m                                                                                                                                                 [2m  1.27 kB[22m [2m│ gzip:  0.39 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mmiddleware/rate-limiter-ip.js[22m                                                                                                                                                  [2m  1.26 kB[22m [2m│ gzip:  0.58 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcli/commands/users/passwd.js[22m                                                                                                                                                   [2m  1.24 kB[22m [2m│ gzip:  0.57 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/utils/wait-for-message.js[22m                                                                                                                                            [2m  1.24 kB[22m [2m│ gzip:  0.43 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/devtools/index.js[22m                                                                                                                                                           [2m  1.23 kB[22m [2m│ gzip:  0.54 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mschedules/metrics.js[22m                                                                                                                                                           [2m  1.23 kB[22m [2m│ gzip:  0.60 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/schema/dialects/sqlite.js[22m                                                                                                                                     [2m  1.23 kB[22m [2m│ gzip:  0.59 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/handlers/index.js[22m                                                                                                                                                    [2m  1.23 kB[22m [2m│ gzip:  0.43 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcli/commands/cache/clear.js[22m                                                                                                                                                    [2m  1.22 kB[22m [2m│ gzip:  0.59 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mrequest/is-denied-ip.js[22m                                                                                                                                                        [2m  1.22 kB[22m [2m│ gzip:  0.53 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/resolvers/get-collection-type.js[22m                                                                                                                              [2m  1.21 kB[22m [2m│ gzip:  0.52 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/get-shared-deps-mapping.js[22m                                                                                                                                      [2m  1.21 kB[22m [2m│ gzip:  0.63 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mmiddleware/extract-token.js[22m                                                                                                                                                    [2m  1.21 kB[22m [2m│ gzip:  0.57 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/geometry/dialects/mssql.js[22m                                                                                                                                    [2m  1.21 kB[22m [2m│ gzip:  0.51 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/chat/lib/transform-file-parts.js[22m                                                                                                                                            [2m  1.20 kB[22m [2m│ gzip:  0.60 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210903A-add-auth-provider.js[22m                                                                                                                             [2m  1.20 kB[22m [2m│ gzip:  0.42 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1moperations/mail/index.js[22m                                                                                                                                                       [2m  1.20 kB[22m [2m│ gzip:  0.59 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/should-skip-cache.js[22m                                                                                                                                                     [2m  1.19 kB[22m [2m│ gzip:  0.59 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/capabilities/dialects/mysql.js[22m                                                                                                                                [2m  1.18 kB[22m [2m│ gzip:  0.69 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/mail/rate-limiter.js[22m                                                                                                                                                  [2m  1.17 kB[22m [2m│ gzip:  0.51 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1moperations/mail/rate-limiter.js[22m                                                                                                                                                [2m  1.17 kB[22m [2m│ gzip:  0.51 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mschedules/telemetry.js[22m                                                                                                                                                         [2m  1.17 kB[22m [2m│ gzip:  0.57 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210510A-restructure-relations.js[22m                                                                                                                         [2m  1.16 kB[22m [2m│ gzip:  0.43 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/fetch-allowed-fields/fetch-allowed-fields.js[22m                                                                                                               [2m  1.15 kB[22m [2m│ gzip:  0.52 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/types/bigint.js[22m                                                                                                                                               [2m  1.15 kB[22m [2m│ gzip:  0.49 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-graphql-type.js[22m                                                                                                                                                      [2m  1.15 kB[22m [2m│ gzip:  0.43 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mrate-limiter.js[22m                                                                                                                                                                [2m  1.15 kB[22m [2m│ gzip:  0.50 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mlogger/logs-stream.js[22m                                                                                                                                                          [2m  1.14 kB[22m [2m│ gzip:  0.52 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20211118A-add-notifications.js[22m                                                                                                                             [2m  1.13 kB[22m [2m│ gzip:  0.47 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/utils/replace-fragments.js[22m                                                                                                                                    [2m  1.13 kB[22m [2m│ gzip:  0.46 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-accountability-for-role.js[22m                                                                                                                                           [2m  1.12 kB[22m [2m│ gzip:  0.46 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/tools/utils.js[22m                                                                                                                                                              [2m  1.12 kB[22m [2m│ gzip:  0.60 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mlicense/utils/compute-license-status.js[22m                                                                                                                                        [2m  1.12 kB[22m [2m│ gzip:  0.49 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mschedules/license.js[22m                                                                                                                                                           [2m  1.11 kB[22m [2m│ gzip:  0.43 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/schema/index.js[22m                                                                                                                                               [2m  1.11 kB[22m [2m│ gzip:  0.38 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/chat/utils/fix-error-tool-calls.js[22m                                                                                                                                          [2m  1.11 kB[22m [2m│ gzip:  0.57 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/capabilities/index.js[22m                                                                                                                                         [2m  1.11 kB[22m [2m│ gzip:  0.35 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/get-ast-from-query/utils/get-allowed-sort.js[22m                                                                                                                          [2m  1.10 kB[22m [2m│ gzip:  0.45 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/sandbox/generate-host-function-reference.js[22m                                                                                                                     [2m  1.10 kB[22m [2m│ gzip:  0.52 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20240716A-update-files-date-fields.js[22m                                                                                                                      [2m  1.09 kB[22m [2m│ gzip:  0.41 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/utils/process-error.js[22m                                                                                                                                        [2m  1.09 kB[22m [2m│ gzip:  0.44 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/geometry/index.js[22m                                                                                                                                             [2m  1.09 kB[22m [2m│ gzip:  0.36 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-field-relational-depth.js[22m                                                                                                                                            [2m  1.08 kB[22m [2m│ gzip:  0.47 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20220325A-fix-typecast-flags.js[22m                                                                                                                            [2m  1.07 kB[22m [2m│ gzip:  0.51 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/utils/with-cache.js[22m                                                                                                                                                [2m  1.07 kB[22m [2m│ gzip:  0.53 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mmiddleware/request-counter.js[22m                                                                                                                                                  [2m  1.07 kB[22m [2m│ gzip:  0.51 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/files/lib/upload-to-provider.js[22m                                                                                                                                             [2m  1.07 kB[22m [2m│ gzip:  0.39 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/fetch-policies-ip-access/fetch-policies-ip-access.js[22m                                                                                                       [2m  1.07 kB[22m [2m│ gzip:  0.46 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/is-valid-uuid.js[22m                                                                                                                                                         [2m  1.06 kB[22m [2m│ gzip:  0.60 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/fields/get-collection-relation-list.js[22m                                                                                                                                [2m  1.05 kB[22m [2m│ gzip:  0.45 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/process-ast/lib/get-cases.js[22m                                                                                                                               [2m  1.05 kB[22m [2m│ gzip:  0.49 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210225A-add-relations-sort-field.js[22m                                                                                                                      [2m  1.04 kB[22m [2m│ gzip:  0.51 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/process-ast/utils/validate-path/validate-path-permissions.js[22m                                                                                               [2m  1.04 kB[22m [2m│ gzip:  0.45 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/mcp/utils.js[22m                                                                                                                                                                [2m  1.04 kB[22m [2m│ gzip:  0.59 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/fetch-allowed-field-map/fetch-allowed-field-map.js[22m                                                                                                         [2m  1.03 kB[22m [2m│ gzip:  0.42 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/schema/utils/prep-query-params.js[22m                                                                                                                             [2m  1.03 kB[22m [2m│ gzip:  0.52 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/providers/options.js[22m                                                                                                                                                        [2m  1.03 kB[22m [2m│ gzip:  0.46 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mmiddleware/collection-exists.js[22m                                                                                                                                                [2m  1.03 kB[22m [2m│ gzip:  0.44 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/telemetry/braintrust.js[22m                                                                                                                                                     [2m  1.02 kB[22m [2m│ gzip:  0.47 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/index.js[22m                                                                                                                                                      [2m  1.02 kB[22m [2m│ gzip:  0.33 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcli/commands/users/create.js[22m                                                                                                                                                   [2m  1.01 kB[22m [2m│ gzip:  0.47 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20240924B-populate-versioning-deltas.js[22m                                                                                                                    [2m  1.01 kB[22m [2m│ gzip:  0.52 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mrequest/agent-with-ip-validation.js[22m                                                                                                                                            [2m  1.01 kB[22m [2m│ gzip:  0.49 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20211103B-update-special-geometry.js[22m                                                                                                                       [2m  1.01 kB[22m [2m│ gzip:  0.31 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/tools/index.js[22m                                                                                                                                                              [2m  1.01 kB[22m [2m│ gzip:  0.37 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/utils/apply-case-when.js[22m                                                                                                                                      [2m  1.01 kB[22m [2m│ gzip:  0.53 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/construct-flow-tree.js[22m                                                                                                                                                   [2m  1.01 kB[22m [2m│ gzip:  0.38 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mschedules/utils/duration-to-cron.js[22m                                                                                                                                            [2m  1.01 kB[22m [2m│ gzip:  0.56 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/store.js[22m                                                                                                                                                                 [2m  0.99 kB[22m [2m│ gzip:  0.49 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/files/lib/extract-metadata.js[22m                                                                                                                                         [2m  0.99 kB[22m [2m│ gzip:  0.44 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/number/index.js[22m                                                                                                                                               [2m  0.98 kB[22m [2m│ gzip:  0.35 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/process-ast/utils/validate-path/create-error.js[22m                                                                                                            [2m  0.98 kB[22m [2m│ gzip:  0.39 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/fetch-user-count/fetch-access-roles.js[22m                                                                                                                                   [2m  0.98 kB[22m [2m│ gzip:  0.45 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/split-field-path.js[22m                                                                                                                                                      [2m  0.97 kB[22m [2m│ gzip:  0.48 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-default-index-name.js[22m                                                                                                                                                [2m  0.96 kB[22m [2m│ gzip:  0.57 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mschedules/project.js[22m                                                                                                                                                           [2m  0.96 kB[22m [2m│ gzip:  0.45 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/process-ast/utils/dedupe-access.js[22m                                                                                                                         [2m  0.95 kB[22m [2m│ gzip:  0.52 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtelemetry/lib/track.js[22m                                                                                                                                                         [2m  0.95 kB[22m [2m│ gzip:  0.49 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/lib/apply-query/aggregate.js[22m                                                                                                                                  [2m  0.94 kB[22m [2m│ gzip:  0.40 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/tools/system/index.js[22m                                                                                                                                                       [2m  0.94 kB[22m [2m│ gzip:  0.47 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/sequence/index.js[22m                                                                                                                                             [2m  0.93 kB[22m [2m│ gzip:  0.31 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-auth-providers.js[22m                                                                                                                                                    [2m  0.93 kB[22m [2m│ gzip:  0.43 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/not-found.js[22m                                                                                                                                                       [2m  0.93 kB[22m [2m│ gzip:  0.48 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mlicense/entitlements/lib/flows.js[22m                                                                                                                                              [2m  0.93 kB[22m [2m│ gzip:  0.44 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/date/index.js[22m                                                                                                                                                 [2m  0.93 kB[22m [2m│ gzip:  0.34 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/types/string-or-float.js[22m                                                                                                                                      [2m  0.92 kB[22m [2m│ gzip:  0.42 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/sandbox/register/operation.js[22m                                                                                                                                   [2m  0.92 kB[22m [2m│ gzip:  0.42 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/activity.js[22m                                                                                                                                                           [2m  0.91 kB[22m [2m│ gzip:  0.45 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210805A-update-groups.js[22m                                                                                                                                 [2m  0.90 kB[22m [2m│ gzip:  0.40 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mschedules/oauth-cleanup.js[22m                                                                                                                                                     [2m  0.90 kB[22m [2m│ gzip:  0.46 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/validate-keys.js[22m                                                                                                                                                         [2m  0.90 kB[22m [2m│ gzip:  0.42 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/files/adapters/anthropic.js[22m                                                                                                                                                 [2m  0.90 kB[22m [2m│ gzip:  0.51 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/fn/index.js[22m                                                                                                                                                   [2m  0.89 kB[22m [2m│ gzip:  0.34 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/sync/status.js[22m                                                                                                                                                  [2m  0.89 kB[22m [2m│ gzip:  0.41 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/lib/apply-query/filter/get-filter-type.js[22m                                                                                                                     [2m  0.89 kB[22m [2m│ gzip:  0.42 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/stall.js[22m                                                                                                                                                                 [2m  0.89 kB[22m [2m│ gzip:  0.49 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/freeze-schema.js[22m                                                                                                                                                         [2m  0.88 kB[22m [2m│ gzip:  0.31 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/process-ast/utils/flatten-filter.js[22m                                                                                                                        [2m  0.88 kB[22m [2m│ gzip:  0.42 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/sequence/dialects/postgres.js[22m                                                                                                                                 [2m  0.87 kB[22m [2m│ gzip:  0.51 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20251224A-remove-webhooks.js[22m                                                                                                                               [2m  0.87 kB[22m [2m│ gzip:  0.40 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/providers/anthropic-tool-search.js[22m                                                                                                                                          [2m  0.87 kB[22m [2m│ gzip:  0.47 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/sandbox/register/filter.js[22m                                                                                                                                      [2m  0.87 kB[22m [2m│ gzip:  0.40 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/is-url-allowed.js[22m                                                                                                                                                        [2m  0.86 kB[22m [2m│ gzip:  0.45 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/cache.js[22m                                                                                                                                                           [2m  0.86 kB[22m [2m│ gzip:  0.46 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/jwt.js[22m                                                                                                                                                                   [2m  0.86 kB[22m [2m│ gzip:  0.40 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtelemetry/utils/get-user-item-count.js[22m                                                                                                                                         [2m  0.86 kB[22m [2m│ gzip:  0.44 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/utils/apply-function-to-column-name.js[22m                                                                                                                        [2m  0.86 kB[22m [2m│ gzip:  0.47 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdeployment/deployment.js[22m                                                                                                                                                       [2m  0.86 kB[22m [2m│ gzip:  0.44 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/utils/get-inner-query-column-pre-processor.js[22m                                                                                                                 [2m  0.85 kB[22m [2m│ gzip:  0.45 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mauth/auth.js[22m                                                                                                                                                                   [2m  0.85 kB[22m [2m│ gzip:  0.42 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtelemetry/counter/use-counters.js[22m                                                                                                                                              [2m  0.84 kB[22m [2m│ gzip:  0.44 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mbus/lib/use-bus.js[22m                                                                                                                                                             [2m  0.84 kB[22m [2m│ gzip:  0.45 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20250813A-add-mcp.js[22m                                                                                                                                       [2m  0.84 kB[22m [2m│ gzip:  0.31 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/files/lib/fetch-provider.js[22m                                                                                                                                                 [2m  0.83 kB[22m [2m│ gzip:  0.44 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/sandbox/register/action.js[22m                                                                                                                                      [2m  0.83 kB[22m [2m│ gzip:  0.38 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mschedules/tus.js[22m                                                                                                                                                               [2m  0.83 kB[22m [2m│ gzip:  0.42 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1moperations/condition/index.js[22m                                                                                                                                                  [2m  0.82 kB[22m [2m│ gzip:  0.40 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mlicense/utils/use-rpc.js[22m                                                                                                                                                       [2m  0.82 kB[22m [2m│ gzip:  0.48 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20240422A-public-registration.js[22m                                                                                                                           [2m  0.81 kB[22m [2m│ gzip:  0.34 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/utils/replace-funcs.js[22m                                                                                                                                        [2m  0.81 kB[22m [2m│ gzip:  0.43 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/files/adapters/openai.js[22m                                                                                                                                                    [2m  0.80 kB[22m [2m│ gzip:  0.48 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/utils/get-unaliased-field-key.js[22m                                                                                                                                   [2m  0.80 kB[22m [2m│ gzip:  0.37 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mlicense/utils/is-sso-bypass-allowed.js[22m                                                                                                                                         [2m  0.79 kB[22m [2m│ gzip:  0.42 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/verify-session-jwt.js[22m                                                                                                                                                    [2m  0.79 kB[22m [2m│ gzip:  0.46 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20220325B-add-default-language.js[22m                                                                                                                          [2m  0.79 kB[22m [2m│ gzip:  0.35 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcontrollers/utils/handle-registry-error.js[22m                                                                                                                                     [2m  0.79 kB[22m [2m│ gzip:  0.34 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/lib/apply-query/filter/validate-operator.js[22m                                                                                                                   [2m  0.79 kB[22m [2m│ gzip:  0.36 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/apply-snapshot.js[22m                                                                                                                                                        [2m  0.78 kB[22m [2m│ gzip:  0.32 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mmiddleware/sanitize-query.js[22m                                                                                                                                                   [2m  0.78 kB[22m [2m│ gzip:  0.36 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/errors/dialects/oracle.js[22m                                                                                                                                             [2m  0.77 kB[22m [2m│ gzip:  0.40 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20250613A-add-project-id.js[22m                                                                                                                                [2m  0.77 kB[22m [2m│ gzip:  0.36 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/utils/merge-fields.js[22m                                                                                                                                              [2m  0.77 kB[22m [2m│ gzip:  0.29 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtelemetry/utils/check-user-limits.js[22m                                                                                                                                           [2m  0.77 kB[22m [2m│ gzip:  0.35 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/split-fields.js[22m                                                                                                                                                          [2m  0.77 kB[22m [2m│ gzip:  0.40 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/geometry/dialects/postgres.js[22m                                                                                                                                 [2m  0.76 kB[22m [2m│ gzip:  0.44 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtelemetry/lib/send-report.js[22m                                                                                                                                                   [2m  0.76 kB[22m [2m│ gzip:  0.48 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/filter-items.js[22m                                                                                                                                                          [2m  0.76 kB[22m [2m│ gzip:  0.33 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mstorage/register-locations.js[22m                                                                                                                                                  [2m  0.76 kB[22m [2m│ gzip:  0.40 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/items.test-d.js[22m                                                                                                                                                       [2m  0.75 kB[22m [2m│ gzip:  0.41 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mlock/lib/use-lock.js[22m                                                                                                                                                           [2m  0.74 kB[22m [2m│ gzip:  0.40 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/validate-access/lib/validate-collection-access.js[22m                                                                                                          [2m  0.74 kB[22m [2m│ gzip:  0.38 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/utils/message.js[22m                                                                                                                                                     [2m  0.74 kB[22m [2m│ gzip:  0.42 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/operations.js[22m                                                                                                                                                         [2m  0.73 kB[22m [2m│ gzip:  0.29 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20230401A-update-material-icons.js[22m                                                                                                                         [2m  0.72 kB[22m [2m│ gzip:  0.33 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/fetch-user-count/get-user-count-query.js[22m                                                                                                                                 [2m  0.72 kB[22m [2m│ gzip:  0.32 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/utils/with-preprocess-bindings.js[22m                                                                                                                             [2m  0.71 kB[22m [2m│ gzip:  0.33 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20260507A-add-licensing.js[22m                                                                                                                                 [2m  0.71 kB[22m [2m│ gzip:  0.29 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-history-filter-query.js[22m                                                                                                                                              [2m  0.71 kB[22m [2m│ gzip:  0.37 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/sandbox/register/call-reference.js[22m                                                                                                                              [2m  0.70 kB[22m [2m│ gzip:  0.43 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210721A-add-default-folder.js[22m                                                                                                                            [2m  0.70 kB[22m [2m│ gzip:  0.37 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/chat/models/providers.js[22m                                                                                                                                                    [2m  0.70 kB[22m [2m│ gzip:  0.27 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210924A-add-collection-organization.js[22m                                                                                                                   [2m  0.69 kB[22m [2m│ gzip:  0.35 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/schedule.js[22m                                                                                                                                                              [2m  0.69 kB[22m [2m│ gzip:  0.36 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/mcp-oauth/types/error.js[22m                                                                                                                                              [2m  0.69 kB[22m [2m│ gzip:  0.40 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mauth/utils/check-local-disabled.js[22m                                                                                                                                             [2m  0.69 kB[22m [2m│ gzip:  0.37 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/parse-filter-key.js[22m                                                                                                                                                      [2m  0.69 kB[22m [2m│ gzip:  0.40 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/mcp-oauth/utils/domain.js[22m                                                                                                                                             [2m  0.69 kB[22m [2m│ gzip:  0.40 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mlicense/entitlements/lib/custom-llms-enabled.js[22m                                                                                                                                [2m  0.68 kB[22m [2m│ gzip:  0.37 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcli/load-extensions.js[22m                                                                                                                                                         [2m  0.68 kB[22m [2m│ gzip:  0.36 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/number/utils/number-in-range.js[22m                                                                                                                               [2m  0.68 kB[22m [2m│ gzip:  0.36 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/schema/dialects/default.js[22m                                                                                                                                    [2m  0.68 kB[22m [2m│ gzip:  0.31 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcli/commands/database/migrate.js[22m                                                                                                                                               [2m  0.68 kB[22m [2m│ gzip:  0.32 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-field-system-rows.js[22m                                                                                                                                                 [2m  0.68 kB[22m [2m│ gzip:  0.33 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcli/commands/count/index.js[22m                                                                                                                                                    [2m  0.67 kB[22m [2m│ gzip:  0.34 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mstorage/register-drivers.js[22m                                                                                                                                                    [2m  0.67 kB[22m [2m│ gzip:  0.35 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/sandbox/sdk/sdk.js[22m                                                                                                                                              [2m  0.67 kB[22m [2m│ gzip:  0.32 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mmiddleware/mcp-oauth-guard.js[22m                                                                                                                                                  [2m  0.67 kB[22m [2m│ gzip:  0.40 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/fetch-allowed-collections/fetch-allowed-collections.js[22m                                                                                                     [2m  0.66 kB[22m [2m│ gzip:  0.32 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20240305A-change-useragent-type.js[22m                                                                                                                         [2m  0.66 kB[22m [2m│ gzip:  0.32 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/process-ast/utils/validate-path/validate-path-existence.js[22m                                                                                                 [2m  0.66 kB[22m [2m│ gzip:  0.32 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/chat/models/object-request.js[22m                                                                                                                                               [2m  0.66 kB[22m [2m│ gzip:  0.38 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/assets/name-deduper.js[22m                                                                                                                                                [2m  0.66 kB[22m [2m│ gzip:  0.37 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mlicense/utils/get-license-token.js[22m                                                                                                                                             [2m  0.65 kB[22m [2m│ gzip:  0.35 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mrequest/index.js[22m                                                                                                                                                               [2m  0.65 kB[22m [2m│ gzip:  0.30 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mauth/utils/check-sso-enabled.js[22m                                                                                                                                                [2m  0.64 kB[22m [2m│ gzip:  0.34 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/utils/add-path-to-validation-error.js[22m                                                                                                                         [2m  0.64 kB[22m [2m│ gzip:  0.34 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210626A-change-filesize-bigint.js[22m                                                                                                                        [2m  0.64 kB[22m [2m│ gzip:  0.31 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mlicense/utils/get-license-key.js[22m                                                                                                                                               [2m  0.63 kB[22m [2m│ gzip:  0.35 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210907A-webhooks-collections-not-null.js[22m                                                                                                                 [2m  0.63 kB[22m [2m│ gzip:  0.31 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20260312A-add-ai-translation-settings.js[22m                                                                                                                   [2m  0.62 kB[22m [2m│ gzip:  0.28 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mstorage/index.js[22m                                                                                                                                                               [2m  0.61 kB[22m [2m│ gzip:  0.31 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/fn/json/mysql-json-path.js[22m                                                                                                                                    [2m  0.61 kB[22m [2m│ gzip:  0.40 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/fetch-accountability-policy-globals/fetch-accountability-policy-globals.js[22m                                                                                 [2m  0.61 kB[22m [2m│ gzip:  0.32 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mstorage/get-storage-driver.js[22m                                                                                                                                                  [2m  0.60 kB[22m [2m│ gzip:  0.29 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/lib/apply-query/get-operation.js[22m                                                                                                                              [2m  0.60 kB[22m [2m│ gzip:  0.35 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/get-extensions.js[22m                                                                                                                                               [2m  0.59 kB[22m [2m│ gzip:  0.30 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/should-clear-cache.js[22m                                                                                                                                                    [2m  0.59 kB[22m [2m│ gzip:  0.35 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/deep-freeze.js[22m                                                                                                                                                           [2m  0.59 kB[22m [2m│ gzip:  0.32 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/errors/format.js[22m                                                                                                                                              [2m  0.59 kB[22m [2m│ gzip:  0.30 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtelemetry/utils/get-extension-count.js[22m                                                                                                                                         [2m  0.59 kB[22m [2m│ gzip:  0.32 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1moperations/throw-error/index.js[22m                                                                                                                                                [2m  0.59 kB[22m [2m│ gzip:  0.32 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/number/dialects/mssql.js[22m                                                                                                                                      [2m  0.58 kB[22m [2m│ gzip:  0.33 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mmiddleware/is-locked.js[22m                                                                                                                                                        [2m  0.58 kB[22m [2m│ gzip:  0.33 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/utils/process-permissions.js[22m                                                                                                                                       [2m  0.58 kB[22m [2m│ gzip:  0.25 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/lib/with-app-minimal-permissions.js[22m                                                                                                                                [2m  0.58 kB[22m [2m│ gzip:  0.29 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/chat/router.js[22m                                                                                                                                                              [2m  0.58 kB[22m [2m│ gzip:  0.25 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20220826A-add-origin-to-accountability.js[22m                                                                                                                  [2m  0.58 kB[22m [2m│ gzip:  0.25 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/get-ast-from-query/utils/get-related-collection.js[22m                                                                                                                    [2m  0.58 kB[22m [2m│ gzip:  0.26 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210920A-webhooks-url-not-null.js[22m                                                                                                                         [2m  0.57 kB[22m [2m│ gzip:  0.30 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/date/dialects/oracle.js[22m                                                                                                                                       [2m  0.57 kB[22m [2m│ gzip:  0.31 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtelemetry/utils/format-api-request-counts.js[22m                                                                                                                                   [2m  0.57 kB[22m [2m│ gzip:  0.33 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/date/dialects/sqlite.js[22m                                                                                                                                       [2m  0.56 kB[22m [2m│ gzip:  0.31 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/geometry/dialects/mysql.js[22m                                                                                                                                    [2m  0.56 kB[22m [2m│ gzip:  0.32 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20240122A-add-report-url-fields.js[22m                                                                                                                         [2m  0.56 kB[22m [2m│ gzip:  0.26 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mauth/drivers/index.js[22m                                                                                                                                                          [2m  0.56 kB[22m [2m│ gzip:  0.18 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/process-ast/lib/field-map-from-ast.js[22m                                                                                                                      [2m  0.55 kB[22m [2m│ gzip:  0.28 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210910A-move-module-setup.js[22m                                                                                                                             [2m  0.55 kB[22m [2m│ gzip:  0.24 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/date/dialects/mysql.js[22m                                                                                                                                        [2m  0.55 kB[22m [2m│ gzip:  0.29 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/get-ast-from-query/utils/get-deep-query.js[22m                                                                                                                            [2m  0.55 kB[22m [2m│ gzip:  0.35 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210312A-webhooks-collections-text.js[22m                                                                                                                     [2m  0.54 kB[22m [2m│ gzip:  0.33 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mmiddleware/cors.js[22m                                                                                                                                                             [2m  0.54 kB[22m [2m│ gzip:  0.33 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20250609A-license-banner.js[22m                                                                                                                                [2m  0.54 kB[22m [2m│ gzip:  0.31 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mredis/lib/use-redis.js[22m                                                                                                                                                         [2m  0.53 kB[22m [2m│ gzip:  0.29 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/utils/fetch-share-info.js[22m                                                                                                                                          [2m  0.53 kB[22m [2m│ gzip:  0.30 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20251103A-add-ai-settings.js[22m                                                                                                                               [2m  0.53 kB[22m [2m│ gzip:  0.25 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20201105B-change-webhook-url-type.js[22m                                                                                                                       [2m  0.52 kB[22m [2m│ gzip:  0.33 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/validate-remaining-admin/validate-remaining-admin-users.js[22m                                                                                                 [2m  0.52 kB[22m [2m│ gzip:  0.27 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20220303A-remove-default-project-color.js[22m                                                                                                                  [2m  0.52 kB[22m [2m│ gzip:  0.28 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/sandbox/sdk/generators/log.js[22m                                                                                                                                   [2m  0.52 kB[22m [2m│ gzip:  0.32 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/delete-from-require-cache.js[22m                                                                                                                                             [2m  0.52 kB[22m [2m│ gzip:  0.29 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcli/commands/database/install.js[22m                                                                                                                                               [2m  0.51 kB[22m [2m│ gzip:  0.26 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20220402A-remove-default-value-panel-icon.js[22m                                                                                                               [2m  0.50 kB[22m [2m│ gzip:  0.28 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mmiddleware/is-admin.js[22m                                                                                                                                                         [2m  0.50 kB[22m [2m│ gzip:  0.30 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/generate-hash.js[22m                                                                                                                                                         [2m  0.50 kB[22m [2m│ gzip:  0.27 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/date/types.js[22m                                                                                                                                                 [2m  0.50 kB[22m [2m│ gzip:  0.28 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/number/dialects/postgres.js[22m                                                                                                                                   [2m  0.50 kB[22m [2m│ gzip:  0.29 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/geometry/dialects/redshift.js[22m                                                                                                                                 [2m  0.49 kB[22m [2m│ gzip:  0.31 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/lib/apply-query/get-filter-path.js[22m                                                                                                                            [2m  0.49 kB[22m [2m│ gzip:  0.31 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20220801A-update-notifications-timestamp-column.js[22m                                                                                                         [2m  0.49 kB[22m [2m│ gzip:  0.27 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/number/utils/decimal-limit.js[22m                                                                                                                                 [2m  0.49 kB[22m [2m│ gzip:  0.28 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/sandbox/sdk/generators/sleep.js[22m                                                                                                                                 [2m  0.48 kB[22m [2m│ gzip:  0.30 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/geometry/dialects/sqlite.js[22m                                                                                                                                   [2m  0.48 kB[22m [2m│ gzip:  0.32 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/compress.js[22m                                                                                                                                                              [2m  0.48 kB[22m [2m│ gzip:  0.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-allowed-log-levels.js[22m                                                                                                                                                [2m  0.48 kB[22m [2m│ gzip:  0.30 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210416A-add-collections-accountability.js[22m                                                                                                                [2m  0.47 kB[22m [2m│ gzip:  0.26 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20220308A-add-bookmark-icon-and-color.js[22m                                                                                                                   [2m  0.47 kB[22m [2m│ gzip:  0.27 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/versioning/remove-circular.js[22m                                                                                                                                            [2m  0.47 kB[22m [2m│ gzip:  0.29 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210415A-make-filesize-nullable.js[22m                                                                                                                        [2m  0.46 kB[22m [2m│ gzip:  0.26 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtelemetry/utils/should-check-user-limits.js[22m                                                                                                                                    [2m  0.46 kB[22m [2m│ gzip:  0.28 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mredis/lib/create-redis.js[22m                                                                                                                                                      [2m  0.46 kB[22m [2m│ gzip:  0.27 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/number/dialects/oracle.js[22m                                                                                                                                     [2m  0.46 kB[22m [2m│ gzip:  0.29 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/number/dialects/sqlite.js[22m                                                                                                                                     [2m  0.46 kB[22m [2m│ gzip:  0.29 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtelemetry/utils/get-field-count.js[22m                                                                                                                                             [2m  0.46 kB[22m [2m│ gzip:  0.28 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20231215A-add-focalpoints.js[22m                                                                                                                               [2m  0.45 kB[22m [2m│ gzip:  0.24 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/process-ast/utils/find-related-collection.js[22m                                                                                                               [2m  0.45 kB[22m [2m│ gzip:  0.25 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mredis/utils/redis-config-available.js[22m                                                                                                                                          [2m  0.45 kB[22m [2m│ gzip:  0.30 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mmetrics/lib/use-metrics.js[22m                                                                                                                                                     [2m  0.45 kB[22m [2m│ gzip:  0.25 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/is-unauthenticated.js[22m                                                                                                                                                    [2m  0.45 kB[22m [2m│ gzip:  0.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/translations-validation.js[22m                                                                                                                                               [2m  0.45 kB[22m [2m│ gzip:  0.29 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/lib/apply-query/pagination.js[22m                                                                                                                                 [2m  0.44 kB[22m [2m│ gzip:  0.24 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/collab/filter-to-fields.js[22m                                                                                                                                           [2m  0.44 kB[22m [2m│ gzip:  0.30 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20260128A-add-collaborative-editing.js[22m                                                                                                                     [2m  0.44 kB[22m [2m│ gzip:  0.25 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/parse-numeric-string.js[22m                                                                                                                                                  [2m  0.44 kB[22m [2m│ gzip:  0.25 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/schema-cache.js[22m                                                                                                                                               [2m  0.43 kB[22m [2m│ gzip:  0.30 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcli/utils/drivers.js[22m                                                                                                                                                           [2m  0.43 kB[22m [2m│ gzip:  0.30 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20220323A-add-field-validation.js[22m                                                                                                                          [2m  0.43 kB[22m [2m│ gzip:  0.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/extract-function-name.js[22m                                                                                                                                                 [2m  0.43 kB[22m [2m│ gzip:  0.29 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-address.js[22m                                                                                                                                                           [2m  0.43 kB[22m [2m│ gzip:  0.27 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/files/router.js[22m                                                                                                                                                             [2m  0.43 kB[22m [2m│ gzip:  0.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210927B-replace-m2m-interface.js[22m                                                                                                                         [2m  0.43 kB[22m [2m│ gzip:  0.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/tus/utils/wait-timeout.js[22m                                                                                                                                             [2m  0.43 kB[22m [2m│ gzip:  0.24 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20240701A-add-tus-data.js[22m                                                                                                                                  [2m  0.42 kB[22m [2m│ gzip:  0.24 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/validate-env.js[22m                                                                                                                                                          [2m  0.42 kB[22m [2m│ gzip:  0.26 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20260512A-add-autosave-revision-interval.js[22m                                                                                                                [2m  0.42 kB[22m [2m│ gzip:  0.24 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210811A-add-geometry-config.js[22m                                                                                                                           [2m  0.42 kB[22m [2m│ gzip:  0.24 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/process-payload/lib/is-field-nullable.js[22m                                                                                                                   [2m  0.41 kB[22m [2m│ gzip:  0.28 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/capabilities/dialects/postgres.js[22m                                                                                                                             [2m  0.41 kB[22m [2m│ gzip:  0.25 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/files/lib/get-sharp-instance.js[22m                                                                                                                                       [2m  0.41 kB[22m [2m│ gzip:  0.31 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/sandbox/register/index.js[22m                                                                                                                                       [2m  0.41 kB[22m [2m│ gzip:  0.15 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210608A-add-deep-clone-config.js[22m                                                                                                                         [2m  0.40 kB[22m [2m│ gzip:  0.24 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/chat/utils/zod-jsonschema7-parser.js[22m                                                                                                                                        [2m  0.40 kB[22m [2m│ gzip:  0.27 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mlogger/redact-query.js[22m                                                                                                                                                         [2m  0.40 kB[22m [2m│ gzip:  0.27 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/parse-oauth-scope.js[22m                                                                                                                                                     [2m  0.40 kB[22m [2m│ gzip:  0.28 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20211230A-add-project-descriptor.js[22m                                                                                                                        [2m  0.40 kB[22m [2m│ gzip:  0.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20220429D-drop-non-null-from-sender-of-notifications.js[22m                                                                                                    [2m  0.39 kB[22m [2m│ gzip:  0.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/is-directus-jwt.js[22m                                                                                                                                                       [2m  0.39 kB[22m [2m│ gzip:  0.27 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/number/types.js[22m                                                                                                                                               [2m  0.39 kB[22m [2m│ gzip:  0.25 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20250718A-add-direction.js[22m                                                                                                                                 [2m  0.39 kB[22m [2m│ gzip:  0.24 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20251012A-add-field-searchable.js[22m                                                                                                                          [2m  0.39 kB[22m [2m│ gzip:  0.24 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/utils/filter-policies-by-ip.js[22m                                                                                                                                     [2m  0.39 kB[22m [2m│ gzip:  0.24 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/import-file-url.js[22m                                                                                                                                                       [2m  0.39 kB[22m [2m│ gzip:  0.25 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20231010A-add-extensions.js[22m                                                                                                                                [2m  0.39 kB[22m [2m│ gzip:  0.24 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20260217A-null-item-versions.js[22m                                                                                                                            [2m  0.39 kB[22m [2m│ gzip:  0.22 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mlicense/utils/is-in-core-grace-period.js[22m                                                                                                                                       [2m  0.39 kB[22m [2m│ gzip:  0.25 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20220802A-add-custom-aspect-ratios.js[22m                                                                                                                      [2m  0.38 kB[22m [2m│ gzip:  0.22 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210304A-remove-locked-fields.js[22m                                                                                                                          [2m  0.38 kB[22m [2m│ gzip:  0.24 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20220314A-add-translation-strings.js[22m                                                                                                                       [2m  0.38 kB[22m [2m│ gzip:  0.22 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20230525A-add-preview-settings.js[22m                                                                                                                          [2m  0.38 kB[22m [2m│ gzip:  0.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/lib/apply-query/join-filter-with-cases.js[22m                                                                                                                     [2m  0.38 kB[22m [2m│ gzip:  0.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1moperations/log/index.js[22m                                                                                                                                                        [2m  0.38 kB[22m [2m│ gzip:  0.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/process-ast/utils/get-info-for-path.js[22m                                                                                                                     [2m  0.38 kB[22m [2m│ gzip:  0.26 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/validate-remaining-admin/validate-remaining-admin-count.js[22m                                                                                                 [2m  0.38 kB[22m [2m│ gzip:  0.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210521A-add-collections-icon-color.js[22m                                                                                                                    [2m  0.38 kB[22m [2m│ gzip:  0.22 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20240515A-add-session-window.js[22m                                                                                                                            [2m  0.38 kB[22m [2m│ gzip:  0.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210803A-add-required-to-fields.js[22m                                                                                                                        [2m  0.37 kB[22m [2m│ gzip:  0.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/collab/constants.js[22m                                                                                                                                                  [2m  0.37 kB[22m [2m│ gzip:  0.20 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210331A-add-refresh-interval.js[22m                                                                                                                          [2m  0.37 kB[22m [2m│ gzip:  0.22 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20220429B-add-color-to-insights-icon.js[22m                                                                                                                    [2m  0.37 kB[22m [2m│ gzip:  0.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-secret.js[22m                                                                                                                                                            [2m  0.37 kB[22m [2m│ gzip:  0.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/date/dialects/mssql.js[22m                                                                                                                                        [2m  0.37 kB[22m [2m│ gzip:  0.24 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/lib/fetch-roles-tree.js[22m                                                                                                                                            [2m  0.37 kB[22m [2m│ gzip:  0.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/is-field-allowed.js[22m                                                                                                                                                      [2m  0.37 kB[22m [2m│ gzip:  0.21 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20211104A-remove-collections-listing.js[22m                                                                                                                    [2m  0.37 kB[22m [2m│ gzip:  0.22 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210831A-remove-limit-column.js[22m                                                                                                                           [2m  0.37 kB[22m [2m│ gzip:  0.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/process-ast/utils/collections-in-field-map.js[22m                                                                                                              [2m  0.37 kB[22m [2m│ gzip:  0.24 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/mcp-oauth/utils/loopback.js[22m                                                                                                                                           [2m  0.37 kB[22m [2m│ gzip:  0.25 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-collection-from-alias.js[22m                                                                                                                                             [2m  0.37 kB[22m [2m│ gzip:  0.24 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20220429C-drop-non-null-from-ip-of-activity.js[22m                                                                                                             [2m  0.37 kB[22m [2m│ gzip:  0.22 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/destroy-piped-stream.js[22m                                                                                                                                                  [2m  0.36 kB[22m [2m│ gzip:  0.24 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210716A-add-conditions-to-fields.js[22m                                                                                                                      [2m  0.36 kB[22m [2m│ gzip:  0.22 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20240909B-consolidate-content-versioning.js[22m                                                                                                                [2m  0.36 kB[22m [2m│ gzip:  0.22 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210929A-rename-login-action.js[22m                                                                                                                           [2m  0.36 kB[22m [2m│ gzip:  0.21 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/versioning/merge-version-data.js[22m                                                                                                                                         [2m  0.35 kB[22m [2m│ gzip:  0.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20211103A-set-unique-to-user-token.js[22m                                                                                                                      [2m  0.35 kB[22m [2m│ gzip:  0.22 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20211016A-add-webhook-headers.js[22m                                                                                                                           [2m  0.35 kB[22m [2m│ gzip:  0.21 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mmiddleware/schema.js[22m                                                                                                                                                           [2m  0.35 kB[22m [2m│ gzip:  0.21 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/parse-value.js[22m                                                                                                                                                           [2m  0.35 kB[22m [2m│ gzip:  0.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-milliseconds.js[22m                                                                                                                                                      [2m  0.35 kB[22m [2m│ gzip:  0.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20220614A-rename-hook-trigger-to-event.js[22m                                                                                                                  [2m  0.35 kB[22m [2m│ gzip:  0.22 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20211009A-add-auth-data.js[22m                                                                                                                                 [2m  0.34 kB[22m [2m│ gzip:  0.21 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mmiddleware/use-collection.js[22m                                                                                                                                                   [2m  0.34 kB[22m [2m│ gzip:  0.20 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/types/void.js[22m                                                                                                                                                 [2m  0.34 kB[22m [2m│ gzip:  0.22 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/get-extensions-path.js[22m                                                                                                                                          [2m  0.34 kB[22m [2m│ gzip:  0.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1moperations/transform/index.js[22m                                                                                                                                                  [2m  0.34 kB[22m [2m│ gzip:  0.21 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/collab/store.js[22m                                                                                                                                                      [2m  0.33 kB[22m [2m│ gzip:  0.25 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/wrap-embeds.js[22m                                                                                                                                                  [2m  0.33 kB[22m [2m│ gzip:  0.25 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1moperations/sleep/index.js[22m                                                                                                                                                      [2m  0.33 kB[22m [2m│ gzip:  0.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/utils/get-field-alias.js[22m                                                                                                                                      [2m  0.32 kB[22m [2m│ gzip:  0.22 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/user-name.js[22m                                                                                                                                                             [2m  0.32 kB[22m [2m│ gzip:  0.18 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/capabilities/dialects/oracle.js[22m                                                                                                                               [2m  0.31 kB[22m [2m│ gzip:  0.20 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/utils/get-expires-at-for-token.js[22m                                                                                                                                    [2m  0.31 kB[22m [2m│ gzip:  0.21 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/index.js[22m                                                                                                                                                            [2m  0.30 kB[22m [2m│ gzip:  0.16 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/types/geojson.js[22m                                                                                                                                              [2m  0.30 kB[22m [2m│ gzip:  0.20 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtelemetry/utils/get-random-wait-time.js[22m                                                                                                                                        [2m  0.30 kB[22m [2m│ gzip:  0.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtelemetry/utils/get-filesize-sum.js[22m                                                                                                                                            [2m  0.29 kB[22m [2m│ gzip:  0.22 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/installation/index.js[22m                                                                                                                                           [2m  0.29 kB[22m [2m│ gzip:  0.17 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-graphql-query-and-variables.js[22m                                                                                                                                       [2m  0.29 kB[22m [2m│ gzip:  0.22 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/utils/create-default-accountability.js[22m                                                                                                                             [2m  0.28 kB[22m [2m│ gzip:  0.19 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/mcp/transport.js[22m                                                                                                                                                            [2m  0.28 kB[22m [2m│ gzip:  0.18 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/number/utils/maybe-stringify-big-int.js[22m                                                                                                                       [2m  0.28 kB[22m [2m│ gzip:  0.20 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/migrations/20210422A-remove-files-interface.js[22m                                                                                                                        [2m  0.26 kB[22m [2m│ gzip:  0.20 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/types/hash.js[22m                                                                                                                                                 [2m  0.26 kB[22m [2m│ gzip:  0.19 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/types/date.js[22m                                                                                                                                                 [2m  0.26 kB[22m [2m│ gzip:  0.19 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/process-ast/utils/has-item-permissions.js[22m                                                                                                                  [2m  0.26 kB[22m [2m│ gzip:  0.17 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/require-yaml.js[22m                                                                                                                                                          [2m  0.25 kB[22m [2m│ gzip:  0.18 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/sequence/types.js[22m                                                                                                                                             [2m  0.25 kB[22m [2m│ gzip:  0.18 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/providers/index.js[22m                                                                                                                                                          [2m  0.25 kB[22m [2m│ gzip:  0.14 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/errors/validation.js[22m                                                                                                                                          [2m  0.25 kB[22m [2m│ gzip:  0.18 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/dashboards.js[22m                                                                                                                                                         [2m  0.25 kB[22m [2m│ gzip:  0.17 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdeployment/index.js[22m                                                                                                                                                            [2m  0.24 kB[22m [2m│ gzip:  0.12 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/errors/execution.js[22m                                                                                                                                           [2m  0.24 kB[22m [2m│ gzip:  0.18 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/md.js[22m                                                                                                                                                                    [2m  0.24 kB[22m [2m│ gzip:  0.18 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/process-ast/utils/context-has-dynamic-variables.js[22m                                                                                                         [2m  0.24 kB[22m [2m│ gzip:  0.18 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/presets.js[22m                                                                                                                                                            [2m  0.24 kB[22m [2m│ gzip:  0.17 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/capabilities/dialects/default.js[22m                                                                                                                              [2m  0.23 kB[22m [2m│ gzip:  0.15 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/async-handler.js[22m                                                                                                                                                         [2m  0.23 kB[22m [2m│ gzip:  0.17 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-versioned-hash.js[22m                                                                                                                                                    [2m  0.23 kB[22m [2m│ gzip:  0.17 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/sequence/dialects/default.js[22m                                                                                                                                  [2m  0.23 kB[22m [2m│ gzip:  0.16 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/fetch-user-count/fetch-active-users.js[22m                                                                                                                                   [2m  0.23 kB[22m [2m│ gzip:  0.18 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/panels.js[22m                                                                                                                                                             [2m  0.23 kB[22m [2m│ gzip:  0.17 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcli/commands/security/secret.js[22m                                                                                                                                                [2m  0.23 kB[22m [2m│ gzip:  0.18 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mredis/index.js[22m                                                                                                                                                                 [2m  0.23 kB[22m [2m│ gzip:  0.13 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcli/commands/security/key.js[22m                                                                                                                                                   [2m  0.22 kB[22m [2m│ gzip:  0.18 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/number/dialects/default.js[22m                                                                                                                                    [2m  0.22 kB[22m [2m│ gzip:  0.15 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-string-byte-size.js[22m                                                                                                                                                  [2m  0.22 kB[22m [2m│ gzip:  0.17 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mcli/run.js[22m                                                                                                                                                                     [2m  0.22 kB[22m [2m│ gzip:  0.17 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/utils/default-permission.js[22m                                                                                                                                        [2m  0.22 kB[22m [2m│ gzip:  0.16 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/is-admin.js[22m                                                                                                                                                              [2m  0.21 kB[22m [2m│ gzip:  0.15 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtypes/meta.js[22m                                                                                                                                                                  [2m  0.21 kB[22m [2m│ gzip:  0.18 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/files/adapters/index.js[22m                                                                                                                                                     [2m  0.21 kB[22m [2m│ gzip:  0.11 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/date/dialects/default.js[22m                                                                                                                                      [2m  0.20 kB[22m [2m│ gzip:  0.15 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/sandbox/sdk/generators/index.js[22m                                                                                                                                 [2m  0.19 kB[22m [2m│ gzip:  0.10 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/process-ast/utils/format-a2o-key.js[22m                                                                                                                        [2m  0.19 kB[22m [2m│ gzip:  0.16 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/process-ast/utils/stringify-query-path.js[22m                                                                                                                  [2m  0.19 kB[22m [2m│ gzip:  0.15 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/get-module-default.js[22m                                                                                                                                                    [2m  0.19 kB[22m [2m│ gzip:  0.14 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtelemetry/index.js[22m                                                                                                                                                             [2m  0.18 kB[22m [2m│ gzip:  0.10 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mutils/require-text.js[22m                                                                                                                                                          [2m  0.18 kB[22m [2m│ gzip:  0.15 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/graphql/errors/index.js[22m                                                                                                                                               [2m  0.17 kB[22m [2m│ gzip:  0.10 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mservices/tus/index.js[22m                                                                                                                                                          [2m  0.17 kB[22m [2m│ gzip:  0.10 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mlicense/index.js[22m                                                                                                                                                               [2m  0.17 kB[22m [2m│ gzip:  0.10 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/helpers/types.js[22m                                                                                                                                                      [2m  0.16 kB[22m [2m│ gzip:  0.14 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/sandbox/sdk/index.js[22m                                                                                                                                            [2m  0.14 kB[22m [2m│ gzip:  0.09 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdeployment/drivers/index.js[22m                                                                                                                                                    [2m  0.13 kB[22m [2m│ gzip:  0.09 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/tools/define-tool.js[22m                                                                                                                                                        [2m  0.12 kB[22m [2m│ gzip:  0.11 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mstart.js[22m                                                                                                                                                                       [2m  0.11 kB[22m [2m│ gzip:  0.10 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mmetrics/index.js[22m                                                                                                                                                               [2m  0.09 kB[22m [2m│ gzip:  0.08 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mlock/index.js[22m                                                                                                                                                                  [2m  0.08 kB[22m [2m│ gzip:  0.08 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/mcp/index.js[22m                                                                                                                                                                [2m  0.07 kB[22m [2m│ gzip:  0.07 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mbus/index.js[22m                                                                                                                                                                   [2m  0.06 kB[22m [2m│ gzip:  0.07 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mindex.js[22m                                                                                                                                                                       [2m  0.06 kB[22m [2m│ gzip:  0.06 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mextensions/lib/sandbox/sdk/utils/index.js[22m                                                                                                                                      [2m  0.05 kB[22m [2m│ gzip:  0.06 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtypes/index.js[22m                                                                                                                                                                 [2m  0.05 kB[22m [2m│ gzip:  0.06 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/files/types.js[22m                                                                                                                                                              [2m  0.01 kB[22m [2m│ gzip:  0.03 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/mcp/types.js[22m                                                                                                                                                                [2m  0.01 kB[22m [2m│ gzip:  0.03 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/providers/types.js[22m                                                                                                                                                          [2m  0.01 kB[22m [2m│ gzip:  0.03 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mai/tools/types.js[22m                                                                                                                                                              [2m  0.01 kB[22m [2m│ gzip:  0.03 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/errors/dialects/types.js[22m                                                                                                                                              [2m  0.01 kB[22m [2m│ gzip:  0.03 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mdatabase/run-ast/types.js[22m                                                                                                                                                      [2m  0.01 kB[22m [2m│ gzip:  0.03 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mmetrics/types/metric.js[22m                                                                                                                                                        [2m  0.01 kB[22m [2m│ gzip:  0.03 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/modules/process-ast/types.js[22m                                                                                                                                       [2m  0.01 kB[22m [2m│ gzip:  0.03 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mpermissions/types.js[22m                                                                                                                                                           [2m  0.01 kB[22m [2m│ gzip:  0.03 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtelemetry/types/report.js[22m                                                                                                                                                      [2m  0.01 kB[22m [2m│ gzip:  0.03 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtypes/ast.js[22m                                                                                                                                                                   [2m  0.01 kB[22m [2m│ gzip:  0.03 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtypes/auth.js[22m                                                                                                                                                                  [2m  0.01 kB[22m [2m│ gzip:  0.03 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtypes/collection.js[22m                                                                                                                                                            [2m  0.01 kB[22m [2m│ gzip:  0.03 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtypes/events.js[22m                                                                                                                                                                [2m  0.01 kB[22m [2m│ gzip:  0.03 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtypes/migration.js[22m                                                                                                                                                             [2m  0.01 kB[22m [2m│ gzip:  0.03 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtypes/revision.js[22m                                                                                                                                                              [2m  0.01 kB[22m [2m│ gzip:  0.03 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mtypes/rolemap.js[22m                                                                                                                                                               [2m  0.01 kB[22m [2m│ gzip:  0.03 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/collab/types.js[22m                                                                                                                                                      [2m  0.01 kB[22m [2m│ gzip:  0.03 kB[22m
+api build: [34mℹ[39m [2mdist/[22m[1mwebsocket/types.js[22m                                                                                                                                                             [2m  0.01 kB[22m [2m│ gzip:  0.03 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/chai@5.3.3/node_modules/chai/index.js                                                                                                                       [2m126.11 kB[22m [2m│ gzip: 24.55 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/@vitest_pretty-format@3.2.6/node_modules/@vitest/pretty-format/dist/index.js                                                                                [2m 40.43 kB[22m [2m│ gzip:  7.76 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/@vitest_runner@3.2.6/node_modules/@vitest/runner/dist/chunk-hooks.js                                                                                        [2m 40.35 kB[22m [2m│ gzip: 10.69 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/@vitest_utils@3.2.6/node_modules/@vitest/utils/dist/index.js                                                                                                [2m 14.66 kB[22m [2m│ gzip:  3.53 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/js-tokens@9.0.1/node_modules/js-tokens/index.js                                                                                                             [2m 13.04 kB[22m [2m│ gzip:  2.91 kB[22m
+api build: [34mℹ[39m [2mdist/[22mpackages/types/dist/index.js                                                                                                                                                   [2m 10.84 kB[22m [2m│ gzip:  2.39 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/@vitest_utils@3.2.6/node_modules/@vitest/utils/dist/source-map.js                                                                                           [2m  6.32 kB[22m [2m│ gzip:  2.22 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/loupe@3.2.1/node_modules/loupe/lib/helpers.js                                                                                                               [2m  4.23 kB[22m [2m│ gzip:  1.51 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/loupe@3.2.1/node_modules/loupe/lib/index.js                                                                                                                 [2m  4.20 kB[22m [2m│ gzip:  1.24 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/expect-type@1.2.2/node_modules/expect-type/dist/index.js                                                                                                    [2m  3.46 kB[22m [2m│ gzip:  1.34 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/@vitest_utils@3.2.6/node_modules/@vitest/utils/dist/chunk-_commonjsHelpers.js                                                                               [2m  3.41 kB[22m [2m│ gzip:  1.31 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/strip-literal@3.1.0/node_modules/strip-literal/dist/index.js                                                                                                [2m  2.13 kB[22m [2m│ gzip:  0.75 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/tinyrainbow@2.0.0/node_modules/tinyrainbow/dist/chunk-BVHSVHOK.js                                                                                           [2m  2.07 kB[22m [2m│ gzip:  0.96 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/loupe@3.2.1/node_modules/loupe/lib/html.js                                                                                                                  [2m  1.65 kB[22m [2m│ gzip:  0.63 kB[22m
+api build: [34mℹ[39m [2mdist/[22m_virtual/rolldown_runtime.js                                                                                                                                                   [2m  1.36 kB[22m [2m│ gzip:  0.65 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/loupe@3.2.1/node_modules/loupe/lib/typedarray.js                                                                                                            [2m  1.32 kB[22m [2m│ gzip:  0.61 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/@vitest_utils@3.2.6/node_modules/@vitest/utils/dist/helpers.js                                                                                              [2m  1.30 kB[22m [2m│ gzip:  0.64 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/loupe@3.2.1/node_modules/loupe/lib/error.js                                                                                                                 [2m  1.10 kB[22m [2m│ gzip:  0.54 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/loupe@3.2.1/node_modules/loupe/lib/object.js                                                                                                                [2m  0.95 kB[22m [2m│ gzip:  0.42 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/loupe@3.2.1/node_modules/loupe/lib/string.js                                                                                                                [2m  0.87 kB[22m [2m│ gzip:  0.48 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/vitest@3.2.6_@types_node@22.13.14_@vitest_ui@3.2.6_happy-dom@20.8.9_jiti@2.6.1_jsdom@20_adb1f9f62293ec4388afdb2696b45de7/node_modules/vitest/dist/index.js  [2m  0.83 kB[22m [2m│ gzip:  0.36 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/loupe@3.2.1/node_modules/loupe/lib/array.js                                                                                                                 [2m  0.73 kB[22m [2m│ gzip:  0.36 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/loupe@3.2.1/node_modules/loupe/lib/map.js                                                                                                                   [2m  0.70 kB[22m [2m│ gzip:  0.36 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/loupe@3.2.1/node_modules/loupe/lib/number.js                                                                                                                [2m  0.64 kB[22m [2m│ gzip:  0.30 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/loupe@3.2.1/node_modules/loupe/lib/class.js                                                                                                                 [2m  0.58 kB[22m [2m│ gzip:  0.34 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/loupe@3.2.1/node_modules/loupe/lib/date.js                                                                                                                  [2m  0.49 kB[22m [2m│ gzip:  0.31 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/expect-type@1.2.2/node_modules/expect-type/dist/overloads.js                                                                                                [2m  0.48 kB[22m [2m│ gzip:  0.27 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/expect-type@1.2.2/node_modules/expect-type/dist/branding.js                                                                                                 [2m  0.47 kB[22m [2m│ gzip:  0.27 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/expect-type@1.2.2/node_modules/expect-type/dist/messages.js                                                                                                 [2m  0.47 kB[22m [2m│ gzip:  0.27 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/loupe@3.2.1/node_modules/loupe/lib/function.js                                                                                                              [2m  0.47 kB[22m [2m│ gzip:  0.28 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/expect-type@1.2.2/node_modules/expect-type/dist/utils.js                                                                                                    [2m  0.46 kB[22m [2m│ gzip:  0.27 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/loupe@3.2.1/node_modules/loupe/lib/set.js                                                                                                                   [2m  0.45 kB[22m [2m│ gzip:  0.29 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/loupe@3.2.1/node_modules/loupe/lib/regexp.js                                                                                                                [2m  0.43 kB[22m [2m│ gzip:  0.28 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/loupe@3.2.1/node_modules/loupe/lib/bigint.js                                                                                                                [2m  0.37 kB[22m [2m│ gzip:  0.25 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/loupe@3.2.1/node_modules/loupe/lib/arguments.js                                                                                                             [2m  0.35 kB[22m [2m│ gzip:  0.23 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/loupe@3.2.1/node_modules/loupe/lib/symbol.js                                                                                                                [2m  0.30 kB[22m [2m│ gzip:  0.20 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/tinyrainbow@2.0.0/node_modules/tinyrainbow/dist/node.js                                                                                                     [2m  0.26 kB[22m [2m│ gzip:  0.20 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/loupe@3.2.1/node_modules/loupe/lib/promise.js                                                                                                               [2m  0.21 kB[22m [2m│ gzip:  0.16 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/@vitest_runner@3.2.6/node_modules/@vitest/runner/dist/index.js                                                                                              [2m  0.14 kB[22m [2m│ gzip:  0.13 kB[22m
+api build: [34mℹ[39m [2mdist/[22mnode_modules/.pnpm/@vitest_runner@3.2.6/node_modules/@vitest/runner/dist/utils.js                                                                                              [2m  0.07 kB[22m [2m│ gzip:  0.08 kB[22m
+api build: [34mℹ[39m 818 files, total: 2257.27 kB
+api build: [32m✔[39m Build complete in [32m4264ms[39m
+api build: Done

--- a/tmp/v11-5feat.log
+++ b/tmp/v11-5feat.log
@@ -1,0 +1,1714 @@
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82101696270)
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  ✓ Test api
+  ✓ Publish hhh-v11
+  - Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+✓ pr-controle compose-hhh-v11 · 27751156618
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+✓ compose in 4m57s (ID 82101696270)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  ✓ Test api
+  ✓ Publish hhh-v11
+  - Report skipped features or failed tests
+  ✓ Post Install + build
+  ✓ Post Run actions/checkout@v4
+  ✓ Complete job

--- a/tmp/v11-batch.log
+++ b/tmp/v11-batch.log
@@ -1,0 +1,1211 @@
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  ✓ Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+✓ compose in 3m39s (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  ✓ Test api
+  ✓ Publish hhh-v11
+  - Report skipped features or failed tests
+  ✓ Post Install + build
+  ✓ Post Run actions/checkout@v4
+  ✓ Complete job
+
+ANNOTATIONS
+! Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4, pnpm/action-setup@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+compose: .github#2
+
+✓ pr-controle compose-hhh-v11 · 27751630002
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+✓ compose in 3m39s (ID 82103274098)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  ✓ Test api
+  ✓ Publish hhh-v11
+  - Report skipped features or failed tests
+  ✓ Post Install + build
+  ✓ Post Run actions/checkout@v4
+  ✓ Complete job
+
+ANNOTATIONS
+! Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4, pnpm/action-setup@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+compose: .github#2
+

--- a/tmp/v11-compose-watch.log
+++ b/tmp/v11-compose-watch.log
@@ -1,0 +1,1606 @@
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  ✓ Test api
+  ✓ Publish hhh-v11
+  - Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  ✓ Test api
+  ✓ Publish hhh-v11
+  - Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+✓ pr-controle compose-hhh-v11 · 27749982151
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+✓ compose in 5m8s (ID 82097733610)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  ✓ Test api
+  ✓ Publish hhh-v11
+  - Report skipped features or failed tests
+  ✓ Post Install + build
+  ✓ Post Run actions/checkout@v4
+  ✓ Complete job
+
+ANNOTATIONS
+! Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4, pnpm/action-setup@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+compose: .github#2
+

--- a/tmp/v11-roots-compose.log
+++ b/tmp/v11-roots-compose.log
@@ -1,0 +1,1625 @@
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  ✓ Test api
+  ✓ Publish hhh-v11
+  - Report skipped features or failed tests
+  ✓ Post Install + build
+  * Post Run actions/checkout@v4
+✓ pr-controle compose-hhh-v11 · 27750463715
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+✓ compose in 5m0s (ID 82099369832)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  ✓ Test api
+  ✓ Publish hhh-v11
+  - Report skipped features or failed tests
+  ✓ Post Install + build
+  ✓ Post Run actions/checkout@v4
+  ✓ Complete job
+
+ANNOTATIONS
+! Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4, pnpm/action-setup@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+compose: .github#2
+

--- a/tmp/v11-skipnoop.log
+++ b/tmp/v11-skipnoop.log
@@ -1,0 +1,1758 @@
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82104285699)
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  X Test api
+  - Publish hhh-v11
+  ✓ Report skipped features or failed tests
+  ✓ Post Install + build
+  * Post Run actions/checkout@v4
+X pr-controle compose-hhh-v11 · 27751934786
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+X compose in 5m11s (ID 82104285699)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  X Test api
+  - Publish hhh-v11
+  ✓ Report skipped features or failed tests
+  ✓ Post Install + build
+  ✓ Post Run actions/checkout@v4
+  ✓ Complete job

--- a/tmp/v11-skipnoop2.log
+++ b/tmp/v11-skipnoop2.log
@@ -1,0 +1,1828 @@
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82105898846)
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82105898846)
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82105898846)
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82105898846)
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82105898846)
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  * Run actions/checkout@v4
+  * Configure git identity
+  * Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch less than a minute ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  * Fetch base tag + refuse MSCL
+  * Materialize hhh-v11-base
+  * Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  * Compose hhh-v11
+  * Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 1 minute ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 2 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  * Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 3 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 4 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  * Test api
+  * Publish hhh-v11
+  * Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+Refreshing run status every 3 seconds. Press Ctrl+C to quit.
+
+* pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+* compose (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  ✓ Test api
+  ✓ Publish hhh-v11
+  - Report skipped features or failed tests
+  * Post Install + build
+  * Post Run actions/checkout@v4
+✓ pr-controle compose-hhh-v11 · 27752416345
+Triggered via workflow_dispatch about 5 minutes ago
+
+JOBS
+✓ compose in 5m13s (ID 82105898846)
+  ✓ Set up job
+  ✓ Run actions/checkout@v4
+  ✓ Configure git identity
+  ✓ Resolve base ref
+  ✓ Fetch base tag + refuse MSCL
+  ✓ Materialize hhh-v11-base
+  ✓ Discover open fork-feat PRs
+  ✓ Compose hhh-v11
+  ✓ Allowlist compose bot for CLA
+  ✓ Install + build
+  ✓ Test api
+  ✓ Publish hhh-v11
+  - Report skipped features or failed tests
+  ✓ Post Install + build
+  ✓ Post Run actions/checkout@v4
+  ✓ Complete job


### PR DESCRIPTION
Fork-permanent, stacked on `fork-feat/db-read-events`. Cherry-picked from `v11.9.2-hhh-dev` (`ee343a26` filterable errors via throwDatabaseError, `e6f2a9f` error stack before hook). The `024cae6` add-field error variant is deferred to the fields cluster (entangled with drop-index).

---
_Recreated from #90 after the branch rename to the version-namespaced scheme (`v11.10.1-feat/*` on `upstream-v11.10.1`)._