### PR TITLE
ci(codecov): make aggregate patch blocking + ignore controllers

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -16,8 +16,12 @@ coverage:
 # the blackbox suite, which does not feed the codecov unit flag — so they can't lift patch
 # coverage and would otherwise red every PR that touches them. Service-layer logic is the
 # unit-tested surface.
+# Build configs (tsdown/vite/rollup/vitest) are consumed by the bundler, never imported by a
+# test, so they are always 0% covered — exclude them rather than red every build-tooling PR.
 ignore:
   - 'api/src/controllers'
+  - '**/*.config.ts'
+  - '**/*.config.js'
 
 flag_management:
   default_rules:

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,3 +1,24 @@
+coverage:
+  status:
+    # Aggregate (non-flag) diff coverage is now BLOCKING — the dialect/unit tests the ramp
+    # waited for have landed (mariadb-json, drop-index, pino censor, rolldown build, …).
+    patch:
+      default:
+        target: auto
+        informational: false
+    # Overall coverage stays report-only: on a stacked feature line it mostly reflects
+    # base drift, not the PR's own diff (see the per-PR coverage diagnoses).
+    project:
+      default:
+        informational: true
+
+# Controllers are thin HTTP guards (e.g. isSystemCollection → ForbiddenError) exercised by
+# the blackbox suite, which does not feed the codecov unit flag — so they can't lift patch
+# coverage and would otherwise red every PR that touches them. Service-layer logic is the
+# unit-tested surface.
+ignore:
+  - 'api/src/controllers'
+
 flag_management:
   default_rules:
     carryforward: true


### PR DESCRIPTION
Flips the aggregate `codecov/patch` status to **blocking** (target auto) now that the ramp's prerequisite dialect/unit tests have landed (mariadb-json #99, drop-index #98, pino censor #163, rolldown build #114). `codecov/project` stays report-only — on a stacked feature line it mostly reflects base drift, not the PR's own diff.

Also `ignore: api/src/controllers` — those are thin HTTP guards (`isSystemCollection → ForbiddenError`) exercised by the blackbox suite, which doesn't feed the codecov unit flag, so they can't lift patch coverage and would otherwise red every PR touching them (this is the #104 blocker).

After this merges I'll add `codecov/patch` to the `v11.10.1-prepare` required checks so coverage is actually enforced.

Config validated against `codecov.io/validate`.