### PR TITLE
ci(blackbox): pass secrets to reusable blackbox.yml (CODECOV_TOKEN)

### DIFF
--- a/.github/workflows/blackbox-pr.yml
+++ b/.github/workflows/blackbox-pr.yml
@@ -15,3 +15,6 @@ jobs:
     name: Blackbox Tests
     if: contains(github.event.pull_request.labels.*.name, 'Run Blackbox')
     uses: ./.github/workflows/blackbox.yml
+    # Reusable workflows don't inherit caller secrets implicitly; blackbox.yml needs
+    # CODECOV_TOKEN to upload the `blackbox` coverage flag (protected repo rejects tokenless).
+    secrets: inherit


### PR DESCRIPTION
blackbox.yml runs as a `workflow_call` reusable from blackbox-pr.yml. Reusable workflows don't inherit caller secrets implicitly, so `CODECOV_TOKEN` was empty and the blackbox coverage upload failed with `Token required because branch is protected`. Pass `secrets: inherit` so the `blackbox` flag uploads.

Same fix already pushed to v11.10.1-feat/build-tsdown (the base of #190) so the flag uploads there immediately; this is the durable home on the prepare line.