### PR TITLE
ci(blackbox): pg+sqlite smoke default, full matrix via Blackbox-Full label

### DIFF
--- a/.github/workflows/blackbox-pr.yml
+++ b/.github/workflows/blackbox-pr.yml
@@ -13,8 +13,14 @@ permissions:
 jobs:
   blackbox-tests:
     name: Blackbox Tests
-    if: contains(github.event.pull_request.labels.*.name, 'Run Blackbox')
+    # `Run Blackbox` runs the pg+sqlite smoke set; `Blackbox-Full` runs the whole vendor
+    # matrix (and triggers on its own, no need to also add `Run Blackbox`).
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'Run Blackbox') ||
+      contains(github.event.pull_request.labels.*.name, 'Blackbox-Full')
     uses: ./.github/workflows/blackbox.yml
+    with:
+      full: ${{ contains(github.event.pull_request.labels.*.name, 'Blackbox-Full') }}
     # Reusable workflows don't inherit caller secrets implicitly; blackbox.yml needs
     # CODECOV_TOKEN to upload the `blackbox` coverage flag (protected repo rejects tokenless).
     secrets: inherit

--- a/.github/workflows/blackbox.yml
+++ b/.github/workflows/blackbox.yml
@@ -13,6 +13,11 @@ on:
       - pnpm-lock.yaml
       - .github/workflows/blackbox.yml
   workflow_call:
+    inputs:
+      full:
+        description: 'Run the full DB matrix (all vendors) instead of the pg+sqlite smoke set'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -25,6 +30,24 @@ env:
   NODE_OPTIONS: --max_old_space_size=6144
 
 jobs:
+  setup:
+    name: setup
+    runs-on: ubuntu-latest
+    outputs:
+      vendors: ${{ steps.matrix.outputs.vendors }}
+    steps:
+      # Default DB matrix is the pg+sqlite smoke set. The full vendor matrix runs on a
+      # push to a trunk branch, or on a PR carrying the `Blackbox-Full` label (passed in
+      # as `inputs.full` by blackbox-pr.yml).
+      - name: Select vendor matrix
+        id: matrix
+        run: |
+          if [ "${{ github.event_name }}" = "push" ] || [ "${{ inputs.full }}" = "true" ]; then
+            echo 'vendors=["sqlite3","postgres","mysql","maria","mssql","oracle"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'vendors=["sqlite3","postgres"]' >> "$GITHUB_OUTPUT"
+          fi
+
   common:
     name: common
     runs-on: ubuntu-latest
@@ -45,19 +68,15 @@ jobs:
 
   db:
     name: ${{ matrix.vendor }}
+    needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        vendor:
-          - sqlite3
-          - postgres
-          - mysql
-          - maria
-          - mssql
-          - oracle
-          # - cockroachdb
+        # Smoke set (sqlite3 + postgres) by default; full vendor set when setup selects it.
+        # cockroachdb stays excluded everywhere for now.
+        vendor: ${{ fromJSON(needs.setup.outputs.vendors) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7


### PR DESCRIPTION
The 6-vendor blackbox matrix (mssql/oracle especially) is slow and flaky-prone to run on every labelled PR. This narrows the routine cost and makes the full matrix opt-in.

- **`Run Blackbox`** → sqlite3 + postgres smoke set (the two we care about most, fast).
- **`Blackbox-Full`** (new label) → the whole vendor matrix (sqlite3, postgres, mysql, maria, mssql, oracle). Triggers a run on its own — no need to also add `Run Blackbox`.
- **push to trunk** (main / v11.10.1-prepare) → full matrix, unchanged.

Mechanics: a `setup` job emits the vendor list (`inputs.full` OR `event==push` → full, else smoke), the `db` job consumes it via `fromJSON`. `blackbox-pr.yml` passes `full` from the `Blackbox-Full` label.

**Open questions:**
- Trunk pushes run full — fine? Or narrow prepare-pushes to smoke too (frequent) and keep full only for main?
- `common` job (sqlite3 saml/redis/minio) still always runs — left as-is.

Out of scope: cockroachdb stays excluded everywhere.