### PR TITLE
ci(codeql): scan pull_request diffs, not just nightly schedule

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,7 @@ name: CodeQL Analysis
 
 on:
   workflow_call:
+  pull_request:
   schedule:
     - cron: '0 0 * * *'
 


### PR DESCRIPTION
## Why

CodeQL is wired and green on the fork, but it only runs nightly on the default branch (`schedule` cron). That means our feat PRs — the whole `v11.10.1-feat/*` line, renovate majors, everything — merge **without any SAST gate**. A vulnerability introduced in a PR diff isn't caught until the nightly run on the already-merged code, on the wrong branch.

This adds the `pull_request` trigger so each PR's diff is analyzed and alerts surface on the PR itself, before merge.

```yaml
on:
  workflow_call:
  pull_request:   # ← added
  schedule:
    - cron: '0 0 * * *'
```

Kept `workflow_call` and `schedule` untouched.

## Notes / open questions

- For the `pull_request` event GitHub loads the workflow definition from the **base** branch, so this needs to live on `v11.10.1-prepare` (and eventually the default branch) to actually gate the feats stacked on it. Targeting `prepare` here.
- This is **report-only** — it does not block merges yet. To make it blocking we'd add the CodeQL check as a required status in branch protection. Want that, or keep it advisory for now?
- Cost: one extra CodeQL analyze (~JS only, `build: false`) per PR push. Acceptable? Could scope with `paths:` to skip docs-only PRs if it gets noisy.
- Out of scope: instrumenting the app/E2E, the blackbox-coverage plan, and any change to the CodeQL config/query set — pure trigger change.