### PR TITLE
ci(blackbox): rename label `Blackbox-Full` -> `Run Blackbox Full`

### DIFF
--- a/.github/workflows/blackbox-pr.yml
+++ b/.github/workflows/blackbox-pr.yml
@@ -13,14 +13,14 @@ permissions:
 jobs:
   blackbox-tests:
     name: Blackbox Tests
-    # `Run Blackbox` runs the pg+sqlite smoke set; `Blackbox-Full` runs the whole vendor
+    # `Run Blackbox` runs the pg+sqlite smoke set; `Run Blackbox Full` runs the whole vendor
     # matrix (and triggers on its own, no need to also add `Run Blackbox`).
     if: >-
       contains(github.event.pull_request.labels.*.name, 'Run Blackbox') ||
-      contains(github.event.pull_request.labels.*.name, 'Blackbox-Full')
+      contains(github.event.pull_request.labels.*.name, 'Run Blackbox Full')
     uses: ./.github/workflows/blackbox.yml
     with:
-      full: ${{ contains(github.event.pull_request.labels.*.name, 'Blackbox-Full') }}
+      full: ${{ contains(github.event.pull_request.labels.*.name, 'Run Blackbox Full') }}
     # Reusable workflows don't inherit caller secrets implicitly; blackbox.yml needs
     # CODECOV_TOKEN to upload the `blackbox` coverage flag (protected repo rejects tokenless).
     secrets: inherit

--- a/.github/workflows/blackbox.yml
+++ b/.github/workflows/blackbox.yml
@@ -37,7 +37,7 @@ jobs:
       vendors: ${{ steps.matrix.outputs.vendors }}
     steps:
       # Default DB matrix is the pg+sqlite smoke set. The full vendor matrix runs on a
-      # push to a trunk branch, or on a PR carrying the `Blackbox-Full` label (passed in
+      # push to a trunk branch, or on a PR carrying the `Run Blackbox Full` label (passed in
       # as `inputs.full` by blackbox-pr.yml).
       - name: Select vendor matrix
         id: matrix


### PR DESCRIPTION
Rename the full-matrix label for naming consistency with `Run Blackbox` (smoke). Touches `blackbox-pr.yml` + `blackbox.yml` (4 refs). The GitHub label object is renamed in repo settings alongside.

Must land on prepare first: the whole v11.10.1 compose chain has been rebased onto this commit (`2935a1c6fb`), so a **rebase-merge** (sha-preserving) keeps the chain aligned with no further rebasing.

Assisted-by: Claude:claude-opus-4-8