### PR TITLE
v11.10.1-feat: drop rolldown-superseded catalog entries

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,8 +58,6 @@ catalog:
   '@pnpm/workspace.pkgs-graph': 1000.0.39
   '@popperjs/core': 2.11.8
   '@rollup/plugin-alias': 6.0.0
-  '@rollup/plugin-commonjs': 28.0.9
-  '@rollup/plugin-json': 6.1.0
   '@rollup/plugin-node-resolve': 16.0.3
   '@rollup/plugin-replace': 6.0.3
   '@rollup/plugin-terser': 0.4.4
@@ -259,7 +257,6 @@ catalog:
   rolldown: 1.1.3
   rolldown-plugin-istanbul: git+https://github.com/jclaveau/rolldown-plugin-istanbul.git
   rollup: 4.62.2
-  rollup-plugin-esbuild: 6.2.1
   rollup-plugin-node-externals: 8.1.2
   rollup-plugin-styler: 2.0.0
   samlify: 2.10.1


### PR DESCRIPTION
Stacked on batch-insert (top of the v11.10.1 chain), where the rollup→rolldown migration is fully in effect.

**Removed** 3 dead catalog entries (0 imports, rolldown provides them natively): `@rollup/plugin-commonjs`, `@rollup/plugin-json`, `rollup-plugin-esbuild`. Lockfile unchanged (they had no resolution).

**Kept**: `rollup` + terser/virtual/replace/styler/alias/node-resolve/yaml plugins — rolldown reuses rollup-compatible plugins, still consumed.

**Hoist:** nothing to do — the catalog already captures every shared external dep (0 deps appear concretely in ≥2 packages; the 23 remaining concrete deps are single-package).

Assisted-by: Claude:claude-opus-4-8