### PR TITLE
ci(release-fork): add dist-branch workflow (filtered to *-hhh-dev)

### DIFF
--- a/.github/workflows/release-fork.yml
+++ b/.github/workflows/release-fork.yml
@@ -1,0 +1,47 @@
+name: Release Fork
+
+on:
+  push:
+    branches:
+      # release branches only — build a committed `<branch>-dist` for each *-hhh-dev line
+      - '*-hhh-dev'
+
+jobs:
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Configure Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Create new branch if it doesn't exist
+        id: create_branch
+        run: |
+          CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+          DIST_BRANCH="${CURRENT_BRANCH}-dist"
+          git push origin --delete ${DIST_BRANCH} || true
+          git checkout -b ${DIST_BRANCH}
+        shell: bash
+
+      - name: Prepare
+        uses: ./.github/actions/prepare
+        with:
+          registry: https://registry.npmjs.org
+
+      - name: Add and commit dist folder
+        run: |
+          # remove dist/ from gitignore
+          mv .gitignore .gitignore.bak
+          grep -v 'dist/' .gitignore.bak > .gitignore
+          # cat .gitignore
+
+          git add '**/dist/**'
+
+          git commit -m "Add dist folders content"
+          git push origin HEAD
+        shell: bash


### PR DESCRIPTION
The v11.10.1 line lost \`release-fork.yml\` when \`v11.10.1-prepare\` was branched off upstream — so merging into \`v11.10.1-hhh-dev\` (e.g. #199) never built the \`-dist\` branch.

Restores it, **filtered to \`*-hhh-dev\`** so it:
- stays **dormant** on prepare + feature branches (no spurious dist builds),
- **fires** on the hhh-dev release lines (\`v11.10.1-hhh-dev\`, etc.) → builds + commits \`<branch>-dist\`.

Lands on prepare so future resets keep it; a sibling PR adds it directly to \`v11.10.1-hhh-dev\` (already generated, needs it now). Uses the existing \`./.github/actions/prepare\` (builds via tsdown).

Assisted-by: Claude:claude-opus-4-8