### PR TITLE
feat(cache): scoped value-tag invalidation (per-collection scope fields)

### DIFF
--- a/api/src/cache.test.ts
+++ b/api/src/cache.test.ts
@@ -1,9 +1,11 @@
+import type { CacheTag } from '@directus/types';
 import type Keyv from 'keyv';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 // cache.ts captures `const env = useEnv()` at module load, so mutate one shared object
 // (never reassign) to keep that reference and getConfigFromEnv's useEnv() in sync.
-const mockEnv = vi.hoisted(() => ({ current: {} as Record<string, unknown> }));
+const mockEnv = vi.hoisted(() => ({ current: {} as Record<string, any> }));
+const env = mockEnv.current;
 
 const redis = vi.hoisted(() => {
 	const pipeline = { sadd: vi.fn(), expire: vi.fn(), exec: vi.fn() };
@@ -19,17 +21,29 @@ const redis = vi.hoisted(() => {
 	};
 });
 
-vi.mock('@directus/env', () => ({ useEnv: () => mockEnv.current }));
-vi.mock('./logger/index.js', () => ({ useLogger: () => ({ warn() {}, error() {}, info() {} }) }));
-vi.mock('./bus/index.js', () => ({ useBus: () => ({ subscribe: vi.fn(), publish: vi.fn() }) }));
-vi.mock('./redis/index.js', () => ({ redisConfigAvailable: () => true, useRedis: () => redis }));
+// Passthrough filter by default; individual tests override to assert extension augmentation.
+const emitFilter = vi.hoisted(() => vi.fn(async (_event: string, payload: unknown) => payload));
 
-const { getRedisConnection, purgeCache, scopedCachePurgeEnabled, tagCacheKeyCollections } = await import('./cache.js');
+vi.mock('@directus/env', () => ({ useEnv: () => mockEnv.current }));
+vi.mock('./bus/index.js', () => ({ useBus: () => ({ subscribe: vi.fn(), publish: vi.fn() }) }));
+vi.mock('./logger/index.js', () => ({ useLogger: () => ({ warn() {}, error() {}, info() {} }) }));
+vi.mock('./emitter.js', () => ({ default: { emitFilter } }));
+
+vi.mock('./redis/index.js', () => ({
+	redisConfigAvailable: () => true,
+	useRedis: () => redis,
+}));
+
+const { getRedisConnection, purgeCache, scopedCachePurgeEnabled, tagCacheKeys } = await import('./cache.js');
 
 function setEnv(values: Record<string, unknown>) {
 	for (const key of Object.keys(mockEnv.current)) delete mockEnv.current[key];
 	Object.assign(mockEnv.current, values);
 }
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
 
 describe('getRedisConnection', () => {
 	beforeEach(() => setEnv({}));
@@ -65,14 +79,14 @@ describe('getRedisConnection', () => {
 
 describe('scoped cache purging', () => {
 	beforeEach(() => {
-		vi.clearAllMocks();
-
 		setEnv({
 			CACHE_NAMESPACE: 'system-cache',
 			CACHE_TTL: '5m',
 			CACHE_STORE: 'redis',
 			CACHE_AUTO_PURGE_MODE: 'scoped',
 		});
+
+		emitFilter.mockImplementation(async (_event: string, payload: unknown) => payload);
 	});
 
 	describe('scopedCachePurgeEnabled', () => {
@@ -81,64 +95,21 @@ describe('scoped cache purging', () => {
 		});
 
 		test('false when mode is full', () => {
-			mockEnv.current['CACHE_AUTO_PURGE_MODE'] = 'full';
+			env['CACHE_AUTO_PURGE_MODE'] = 'full';
 			expect(scopedCachePurgeEnabled()).toBe(false);
 		});
 
 		test('false when store is memory even if mode=scoped', () => {
-			mockEnv.current['CACHE_STORE'] = 'memory';
+			env['CACHE_STORE'] = 'memory';
 			expect(scopedCachePurgeEnabled()).toBe(false);
 		});
 	});
 
-	describe('purgeCache', () => {
-		test('scoped mode deletes only tagged members + the tag set, never clears', async () => {
-			redis.smembers.mockResolvedValue(['key-a', 'key-a__expires_at', 'key-b']);
-			const cache = { clear: vi.fn(), delete: vi.fn() } as unknown as Keyv;
+	describe('tagCacheKeys', () => {
+		test('indexes the key + expires sibling under every bare collection tag, with a TTL', async () => {
+			await tagCacheKeys('resp-key', [{ collection: 'articles' }, { collection: 'directus_users' }]);
 
-			await purgeCache(cache, 'articles');
-
-			expect(redis.smembers).toHaveBeenCalledWith('system-cache:tag:articles');
-			expect(cache.delete).toHaveBeenCalledWith('key-a');
-			expect(cache.delete).toHaveBeenCalledWith('key-a__expires_at');
-			expect(cache.delete).toHaveBeenCalledWith('key-b');
-			expect(cache.delete).toHaveBeenCalledTimes(3);
-			expect(redis.del).toHaveBeenCalledWith('system-cache:tag:articles');
-			expect(cache.clear).not.toHaveBeenCalled();
-		});
-
-		test('scoped mode with empty tag set deletes nothing but still drops the set', async () => {
-			redis.smembers.mockResolvedValue([]);
-			const cache = { clear: vi.fn(), delete: vi.fn() } as unknown as Keyv;
-
-			await purgeCache(cache, 'articles');
-
-			expect(cache.delete).not.toHaveBeenCalled();
-			expect(redis.del).toHaveBeenCalledWith('system-cache:tag:articles');
-			expect(cache.clear).not.toHaveBeenCalled();
-		});
-
-		test('full mode flushes the whole cache and never touches redis', async () => {
-			mockEnv.current['CACHE_AUTO_PURGE_MODE'] = 'full';
-			const cache = { clear: vi.fn(), delete: vi.fn() } as unknown as Keyv;
-
-			await purgeCache(cache, 'articles');
-
-			expect(cache.clear).toHaveBeenCalledTimes(1);
-			expect(cache.delete).not.toHaveBeenCalled();
-			expect(redis.smembers).not.toHaveBeenCalled();
-		});
-	});
-
-	describe('tagCacheKeyCollections', () => {
-		test('indexes the key + expires sibling under every collection, with a TTL', async () => {
-			await tagCacheKeyCollections('resp-key', ['articles', 'directus_users']);
-
-			expect(redis._pipeline.sadd).toHaveBeenCalledWith(
-				'system-cache:tag:articles',
-				'resp-key',
-				'resp-key__expires_at',
-			);
+			expect(redis._pipeline.sadd).toHaveBeenCalledWith('system-cache:tag:articles', 'resp-key', 'resp-key__expires_at');
 
 			expect(redis._pipeline.sadd).toHaveBeenCalledWith(
 				'system-cache:tag:directus_users',
@@ -151,15 +122,133 @@ describe('scoped cache purging', () => {
 			expect(redis._pipeline.exec).toHaveBeenCalledOnce();
 		});
 
-		test('no-op when no collections', async () => {
-			await tagCacheKeyCollections('resp-key', []);
+		test('value tags encode field=value into the tag key', async () => {
+			await tagCacheKeys('resp-key', [
+				{ collection: 'slots', field: 'student', value: 'A' },
+				{ collection: 'slots', field: 'student', value: 7 },
+			]);
+
+			expect(redis._pipeline.sadd).toHaveBeenCalledWith(
+				'system-cache:tag:slots:student=A',
+				'resp-key',
+				'resp-key__expires_at',
+			);
+
+			expect(redis._pipeline.sadd).toHaveBeenCalledWith(
+				'system-cache:tag:slots:student=7',
+				'resp-key',
+				'resp-key__expires_at',
+			);
+		});
+
+		test('a null scope value serializes to a stable sentinel', async () => {
+			await tagCacheKeys('resp-key', [{ collection: 'slots', field: 'student', value: null }]);
+
+			expect(redis._pipeline.sadd).toHaveBeenCalledWith(
+				'system-cache:tag:slots:student=null',
+				'resp-key',
+				'resp-key__expires_at',
+			);
+		});
+
+		test('duplicate tags collapse to a single SADD', async () => {
+			await tagCacheKeys('resp-key', [
+				{ collection: 'slots', field: 'student', value: 'A' },
+				{ collection: 'slots', field: 'student', value: 'A' },
+			]);
+
+			expect(redis._pipeline.sadd).toHaveBeenCalledOnce();
+		});
+
+		test('no-op when no tags', async () => {
+			await tagCacheKeys('resp-key', []);
 			expect(redis.pipeline).not.toHaveBeenCalled();
 		});
 
 		test('no-op in full mode', async () => {
-			mockEnv.current['CACHE_AUTO_PURGE_MODE'] = 'full';
-			await tagCacheKeyCollections('resp-key', ['articles']);
+			env['CACHE_AUTO_PURGE_MODE'] = 'full';
+			await tagCacheKeys('resp-key', [{ collection: 'articles' }]);
 			expect(redis.pipeline).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('purgeCache', () => {
+		test('always purges the bare collection tag (global readers) alongside value slices', async () => {
+			redis.smembers.mockImplementation(async (tagKey: string) =>
+				tagKey === 'system-cache:tag:slots' ? ['global-key'] : ['key-a', 'key-a__expires_at'],
+			);
+
+			const cache = { clear: vi.fn(), delete: vi.fn() } as unknown as Keyv;
+
+			await purgeCache(cache, 'slots', [{ collection: 'slots', field: 'student', value: 'A' }]);
+
+			expect(redis.smembers).toHaveBeenCalledWith('system-cache:tag:slots');
+			expect(redis.smembers).toHaveBeenCalledWith('system-cache:tag:slots:student=A');
+			expect(cache.delete).toHaveBeenCalledWith('global-key');
+			expect(cache.delete).toHaveBeenCalledWith('key-a');
+			expect(cache.delete).toHaveBeenCalledWith('key-a__expires_at');
+			expect(redis.del).toHaveBeenCalledWith('system-cache:tag:slots', 'system-cache:tag:slots:student=A');
+			expect(cache.clear).not.toHaveBeenCalled();
+		});
+
+		test('spares other value slices — student=B is never touched when purging student=A', async () => {
+			redis.smembers.mockResolvedValue([]);
+			const cache = { clear: vi.fn(), delete: vi.fn() } as unknown as Keyv;
+
+			await purgeCache(cache, 'slots', [{ collection: 'slots', field: 'student', value: 'A' }]);
+
+			expect(redis.smembers).not.toHaveBeenCalledWith('system-cache:tag:slots:student=B');
+			expect(redis.del).not.toHaveBeenCalledWith(expect.stringContaining('student=B'));
+		});
+
+		test('no value tags purges only the bare collection tag', async () => {
+			redis.smembers.mockResolvedValue(['key-a', 'key-a__expires_at', 'key-b']);
+			const cache = { clear: vi.fn(), delete: vi.fn() } as unknown as Keyv;
+
+			await purgeCache(cache, 'articles');
+
+			expect(redis.smembers).toHaveBeenCalledWith('system-cache:tag:articles');
+			expect(redis.smembers).toHaveBeenCalledOnce();
+			expect(cache.delete).toHaveBeenCalledTimes(3);
+			expect(redis.del).toHaveBeenCalledWith('system-cache:tag:articles');
+			expect(cache.clear).not.toHaveBeenCalled();
+		});
+
+		test('null valueTags falls back to a full flush (unresolvable mutation)', async () => {
+			const cache = { clear: vi.fn(), delete: vi.fn() } as unknown as Keyv;
+
+			await purgeCache(cache, 'articles', null);
+
+			expect(cache.clear).toHaveBeenCalledTimes(1);
+			expect(cache.delete).not.toHaveBeenCalled();
+			expect(redis.smembers).not.toHaveBeenCalled();
+		});
+
+		test('full mode flushes the whole cache and never touches redis', async () => {
+			env['CACHE_AUTO_PURGE_MODE'] = 'full';
+			const cache = { clear: vi.fn(), delete: vi.fn() } as unknown as Keyv;
+
+			await purgeCache(cache, 'articles', [{ collection: 'articles', field: 'student', value: 'A' }]);
+
+			expect(cache.clear).toHaveBeenCalledTimes(1);
+			expect(cache.delete).not.toHaveBeenCalled();
+			expect(redis.smembers).not.toHaveBeenCalled();
+		});
+
+		test('cache.purge filter augments the purge set (extension-resolved tags get dropped)', async () => {
+			emitFilter.mockImplementation(async (_event: string, tags: CacheTag[]) => [
+				...tags,
+				{ collection: 'slots', field: 'owner', value: 'B' },
+			]);
+
+			redis.smembers.mockResolvedValue(['owned-key']);
+			const cache = { clear: vi.fn(), delete: vi.fn() } as unknown as Keyv;
+
+			await purgeCache(cache, 'slots', []);
+
+			expect(emitFilter).toHaveBeenCalledWith('cache.purge', [{ collection: 'slots' }], { collection: 'slots' }, null);
+			expect(redis.smembers).toHaveBeenCalledWith('system-cache:tag:slots:owner=B');
+			expect(redis.del).toHaveBeenCalledWith('system-cache:tag:slots', 'system-cache:tag:slots:owner=B');
 		});
 	});
 });

--- a/api/src/cache.ts
+++ b/api/src/cache.ts
@@ -1,7 +1,8 @@
 import { useEnv } from '@directus/env';
-import type { SchemaOverview } from '@directus/types';
+import type { CacheTag, EventContext, SchemaOverview } from '@directus/types';
 import Keyv, { type KeyvOptions } from 'keyv';
 import { useBus } from './bus/index.js';
+import emitter from './emitter.js';
 import { useLogger } from './logger/index.js';
 import { clearCache as clearPermissionCache } from './permissions/cache.js';
 import { redisConfigAvailable, useRedis } from './redis/index.js';
@@ -166,28 +167,32 @@ export function scopedCachePurgeEnabled(): boolean {
 	return env['CACHE_AUTO_PURGE_MODE'] === 'scoped' && env['CACHE_STORE'] === 'redis' && redisConfigAvailable();
 }
 
-function cacheTagKey(collection: string): string {
-	return `${env['CACHE_NAMESPACE']}:tag:${collection}`;
+function serializeTagValue(value: unknown): string {
+	return value === null || value === undefined ? 'null' : String(value);
+}
+
+function cacheTagKey(tag: CacheTag): string {
+	const base = `${env['CACHE_NAMESPACE']}:tag:${tag.collection}`;
+	return tag.field === undefined ? base : `${base}:${tag.field}=${serializeTagValue(tag.value)}`;
 }
 
 /**
- * Index a freshly-cached response key under every collection its data came from, so a later mutation
- * on any of those collections can drop just this entry instead of the whole namespace. Both the
- * payload key and its `__expires_at` sibling are tagged. The tag set self-expires at twice the cache
- * TTL as a safety net against members orphaned by a crash between write and purge.
+ * Index a freshly-cached response key under every tag its data came from, so a later mutation can
+ * drop just the matching entries instead of the whole namespace. Both the payload key and its
+ * `__expires_at` sibling are tagged. Each tag set self-expires at twice the cache TTL as a safety net
+ * against members orphaned by a crash between write and purge.
  */
-export async function tagCacheKeyCollections(key: string, collections: Iterable<string>): Promise<void> {
+export async function tagCacheKeys(key: string, tags: Iterable<CacheTag>): Promise<void> {
 	if (!scopedCachePurgeEnabled()) return;
 
-	const tags = [...collections];
-	if (tags.length === 0) return;
+	const tagKeys = [...new Set([...tags].map(cacheTagKey))];
+	if (tagKeys.length === 0) return;
 
 	const redis = useRedis();
 	const ttlSeconds = Math.ceil(getMilliseconds(env['CACHE_TTL'], 0) / 1000) * 2;
 	const pipeline = redis.pipeline();
 
-	for (const collection of tags) {
-		const tagKey = cacheTagKey(collection);
+	for (const tagKey of tagKeys) {
 		pipeline.sadd(tagKey, key, `${key}__expires_at`);
 		if (ttlSeconds > 0) pipeline.expire(tagKey, ttlSeconds);
 	}
@@ -196,25 +201,44 @@ export async function tagCacheKeyCollections(key: string, collections: Iterable<
 }
 
 /**
- * Purge cached responses affected by a mutation on `collection`. In scoped mode only entries tagged
- * with that collection (plus their `__expires_at` siblings) are deleted; otherwise the whole data
- * cache is flushed (legacy `cache.clear()` behavior).
+ * Purge cached responses affected by a mutation on `collection`. Outside scoped mode the whole data
+ * cache is flushed (legacy `cache.clear()` behavior). In scoped mode the bare collection tag (global
+ * reads) is always purged alongside the resolved `valueTags` (the owner/partition slices the mutation
+ * touched), leaving every other slice untouched. A `null` `valueTags` means "values couldn't be
+ * resolved" → fall back to a full flush rather than risk leaving a stale value slice behind.
  */
-export async function purgeCache(cache: Keyv, collection: string): Promise<void> {
+export async function purgeCache(
+	cache: Keyv,
+	collection: string,
+	valueTags: CacheTag[] | null = [],
+	context: EventContext | null = null,
+): Promise<void> {
 	if (!scopedCachePurgeEnabled()) {
 		await cache.clear();
 		return;
 	}
 
+	if (valueTags === null) {
+		await cache.clear();
+		return;
+	}
+
+	const tags = (await emitter.emitFilter(
+		'cache.purge',
+		[{ collection }, ...valueTags],
+		{ collection },
+		context,
+	)) as CacheTag[];
+
 	const redis = useRedis();
-	const tagKey = cacheTagKey(collection);
-	const members = await redis.smembers(tagKey);
+	const tagKeys = [...new Set(tags.map(cacheTagKey))];
+	const members = [...new Set((await Promise.all(tagKeys.map((tagKey) => redis.smembers(tagKey)))).flat())];
 
 	if (members.length > 0) {
 		await Promise.all(members.map((member) => cache.delete(member)));
 	}
 
-	await redis.del(tagKey);
+	await redis.del(...tagKeys);
 }
 
 function getKeyvInstance(store: Store, ttl: number | undefined, namespaceSuffix?: string): Keyv {

--- a/api/src/database/migrations/20260626A-add-cache-scope-fields.ts
+++ b/api/src/database/migrations/20260626A-add-cache-scope-fields.ts
@@ -1,0 +1,13 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_collections', (table) => {
+		table.json('cache_scope_fields').nullable();
+	});
+}
+
+export async function down(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_collections', (table) => {
+		table.dropColumn('cache_scope_fields');
+	});
+}

--- a/api/src/middleware/respond.ts
+++ b/api/src/middleware/respond.ts
@@ -1,7 +1,7 @@
 import { useEnv } from '@directus/env';
 import { parse as parseBytesConfiguration } from 'bytes';
 import type { RequestHandler } from 'express';
-import { getCache, setCacheValue, tagCacheKeyCollections } from '../cache.js';
+import { getCache, setCacheValue, tagCacheKeys } from '../cache.js';
 import getDatabase from '../database/index.js';
 import { useLogger } from '../logger/index.js';
 import { ExportService } from '../services/import-export.js';
@@ -49,7 +49,7 @@ export const respond: RequestHandler = asyncHandler(async (req, res) => {
 		try {
 			await setCacheValue(cache, key, res.locals['payload'], getMilliseconds(env['CACHE_TTL']));
 			await setCacheValue(cache, `${key}__expires_at`, { exp: Date.now() + getMilliseconds(env['CACHE_TTL'], 0) });
-			await tagCacheKeyCollections(key, res.locals['cacheTags'] ?? []);
+			await tagCacheKeys(key, res.locals['cacheTags'] ?? []);
 		} catch (err: any) {
 			logger.warn(err, `[cache] Couldn't set key ${key}. ${err}`);
 		}

--- a/api/src/services/graphql/cache-tags.test.ts
+++ b/api/src/services/graphql/cache-tags.test.ts
@@ -34,27 +34,27 @@ describe('GraphQLService cache tags', () => {
 		const gql = makeService(schema);
 
 		vi.mocked(getService).mockReturnValueOnce({
-			readByQuery: async () => withMeta([{ id: 1 }], { cacheTags: new Set(['articles', 'users']) }),
+			readByQuery: async () =>
+				withMeta([{ id: 1 }], { cacheTags: [{ collection: 'articles' }, { collection: 'users' }] }),
 		} as any);
 
 		await gql.read('articles', {});
-		expect([...gql.cacheTags].sort()).toEqual(['articles', 'users']);
+		expect(gql.cacheTags.map((tag) => tag.collection).sort()).toEqual(['articles', 'users']);
 
 		// a second read on another collection adds to the same per-request union
 		vi.mocked(getService).mockReturnValueOnce({
-			readByQuery: async () => withMeta([{ id: 2 }], { cacheTags: new Set(['directus_files']) }),
+			readByQuery: async () => withMeta([{ id: 2 }], { cacheTags: [{ collection: 'directus_files' }] }),
 		} as any);
 
 		await gql.read('files', {});
-		expect([...gql.cacheTags].sort()).toEqual(['articles', 'directus_files', 'users']);
+		expect(gql.cacheTags.map((tag) => tag.collection).sort()).toEqual(['articles', 'directus_files', 'users']);
 	});
 
 	test('execute() stamps the unioned tags onto its result via getMeta()', async () => {
 		const gql = makeService({});
 		vi.spyOn(gql, 'getSchema').mockResolvedValue({} as any);
 
-		gql.cacheTags.add('articles');
-		gql.cacheTags.add('users');
+		gql.cacheTags.push({ collection: 'articles' }, { collection: 'users' });
 
 		const result = await gql.execute({
 			document: {} as any,
@@ -64,6 +64,6 @@ describe('GraphQLService cache tags', () => {
 		});
 
 		expect(result.data).toEqual({ ok: true });
-		expect([...(readMeta(result)?.cacheTags ?? [])].sort()).toEqual(['articles', 'users']);
+		expect((readMeta(result)?.cacheTags ?? []).map((tag) => tag.collection).sort()).toEqual(['articles', 'users']);
 	});
 });

--- a/api/src/services/graphql/index.ts
+++ b/api/src/services/graphql/index.ts
@@ -2,6 +2,7 @@ import { useEnv } from '@directus/env';
 import type {
 	AbstractServiceOptions,
 	Accountability,
+	CacheTag,
 	GraphQLParams,
 	GQLScope,
 	Item,
@@ -38,14 +39,14 @@ export class GraphQLService {
 	 * cached entry assembled from many reads, so this aggregate is by design (unlike a per-query read,
 	 * whose tags ride its result via `getMeta()`). Stamped onto the execute() result.
 	 */
-	cacheTags: Set<string>;
+	cacheTags: CacheTag[];
 
 	constructor(options: AbstractServiceOptions & { scope: GQLScope }) {
 		this.accountability = options?.accountability || null;
 		this.knex = options?.knex || getDatabase();
 		this.schema = options.schema;
 		this.scope = options.scope;
-		this.cacheTags = new Set();
+		this.cacheTags = [];
 	}
 
 	/**
@@ -118,9 +119,7 @@ export class GraphQLService {
 			? await service.readSingleton(query, { stripNonRequested: false })
 			: await service.readByQuery(query, { stripNonRequested: false });
 
-		for (const tag of readMeta(result)?.cacheTags ?? []) {
-			this.cacheTags.add(tag);
-		}
+		this.cacheTags.push(...(readMeta(result)?.cacheTags ?? []));
 
 		return result;
 	}

--- a/api/src/services/items-scope-tags.test.ts
+++ b/api/src/services/items-scope-tags.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'vitest';
+import { collectScopeValueTags } from './items.js';
+
+// Pure value-derivation behind read tagging (requireAll) and update-payload tagging (!requireAll).
+describe('collectScopeValueTags', () => {
+	test('one tag per distinct value per field', () => {
+		const rows = [
+			{ student: 'A', course: 'math' },
+			{ student: 'B', course: 'math' },
+			{ student: 'A', course: 'art' },
+		];
+
+		expect(collectScopeValueTags('slots', ['student', 'course'], rows, true)).toEqual([
+			{ collection: 'slots', field: 'student', value: 'A' },
+			{ collection: 'slots', field: 'student', value: 'B' },
+			{ collection: 'slots', field: 'course', value: 'math' },
+			{ collection: 'slots', field: 'course', value: 'art' },
+		]);
+	});
+
+	test('null and numeric values are kept distinct', () => {
+		const rows = [{ student: null }, { student: 0 }, { student: null }];
+
+		expect(collectScopeValueTags('slots', ['student'], rows, true)).toEqual([
+			{ collection: 'slots', field: 'student', value: null },
+			{ collection: 'slots', field: 'student', value: 0 },
+		]);
+	});
+
+	test('requireAll returns null when a field is not present on a row (unprojected read / omitted create)', () => {
+		const rows = [{ student: 'A' }, { course: 'math' }];
+
+		expect(collectScopeValueTags('slots', ['student'], rows, true)).toBeNull();
+	});
+
+	test('without requireAll a missing field is skipped, not fatal (update payload that leaves it unchanged)', () => {
+		const rows = [{ student: 'A' }, { course: 'math' }];
+
+		expect(collectScopeValueTags('slots', ['student'], rows, false)).toEqual([
+			{ collection: 'slots', field: 'student', value: 'A' },
+		]);
+	});
+
+	test('a field present but holding null is resolvable (distinct from being absent)', () => {
+		expect(collectScopeValueTags('slots', ['student'], [{ student: null }], true)).toEqual([
+			{ collection: 'slots', field: 'student', value: null },
+		]);
+	});
+
+	test('empty rows resolve to an empty tag list, not null (caller falls back to a bare tag)', () => {
+		expect(collectScopeValueTags('slots', ['student'], [], true)).toEqual([]);
+	});
+
+	test('no configured fields yields no value tags', () => {
+		expect(collectScopeValueTags('slots', [], [{ student: 'A' }], true)).toEqual([]);
+	});
+});

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -9,6 +9,8 @@ import type {
 	ActionEventParams,
 	Alterations,
 	Item as AnyItem,
+	CacheTag,
+	EventContext,
 	MutationTracker,
 	MutationOptions,
 	PrimaryKey,
@@ -66,6 +68,41 @@ async function emitActionEvents(actionEvents: ActionEventParams[], opts: Mutatio
 	}
 }
 
+/**
+ * Build value tags from the distinct scope-field values present across `rows`. With `requireAll` a
+ * row missing any scope field makes the values unresolvable (returns `null`), so the caller falls
+ * back to a coarse purge rather than leaving a slice stale — used on reads (a field that wasn't
+ * projected) and creates (a field the payload omitted). Without it, missing fields are skipped, used
+ * for update payloads where an absent field just means "unchanged" and the pre-update capture covers
+ * the old value.
+ */
+export function collectScopeValueTags(
+	collection: string,
+	fields: string[],
+	rows: Record<string, any>[],
+	requireAll: boolean,
+): CacheTag[] | null {
+	const tags: CacheTag[] = [];
+
+	for (const field of fields) {
+		const seen = new Set<unknown>();
+
+		for (const row of rows) {
+			if (!(field in row)) {
+				if (requireAll) return null;
+				continue;
+			}
+
+			const value = row[field];
+			if (seen.has(value)) continue;
+			seen.add(value);
+			tags.push({ collection, field, value });
+		}
+	}
+
+	return tags;
+}
+
 export class ItemsService<Item extends AnyItem = AnyItem, Collection extends string = string>
 	implements AbstractService<Item>
 {
@@ -87,6 +124,30 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		this.nested = options.nested ?? [];
 
 		return this;
+	}
+
+	/**
+	 * Read the current scope-field values for the given keys as value tags, before a mutation runs.
+	 * Captures the *old* values an update/delete is about to change so their cache slices get purged
+	 * (an update that moves a row from `student=A` to `student=B` must drop both). Returns an empty
+	 * list when the collection has no scope fields or there are no keys (a bare purge then suffices).
+	 */
+	private async captureScopeValueTags(keys: PrimaryKey[]): Promise<CacheTag[] | null> {
+		if (!scopedCachePurgeEnabled()) return [];
+
+		const scopeFields = this.schema.collections[this.collection]?.cacheScopeFields ?? [];
+		if (scopeFields.length === 0 || keys.length === 0) return [];
+
+		const primaryKeyField = this.schema.collections[this.collection]!.primary;
+
+		const rows = await this.knex.select(primaryKeyField, ...scopeFields).from(this.collection).whereIn(primaryKeyField, keys);
+
+		return collectScopeValueTags(this.collection, scopeFields, rows, true);
+	}
+
+	/** Event context handed to the `cache.purge` filter so extensions can resolve their own tags. */
+	private cachePurgeContext(): EventContext {
+		return { database: this.knex, schema: this.schema, accountability: this.accountability };
 	}
 
 	/**
@@ -569,7 +630,11 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		}
 
 		if (shouldClearCache(this.cache, opts, this.collection)) {
-			await purgeCache(this.cache, this.collection);
+			const scopeFields = this.schema.collections[this.collection]?.cacheScopeFields ?? [];
+			// New rows: a payload that omits a scope field has an unknown (default) value, so it can't
+			// be scoped — `collectScopeValueTags` returns null and purgeCache falls back to a full flush.
+			const valueTags = collectScopeValueTags(this.collection, scopeFields, data, true);
+			await purgeCache(this.cache, this.collection, valueTags, this.cachePurgeContext());
 		}
 
 		return results;
@@ -614,17 +679,6 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			{ knex: this.knex, schema: this.schema },
 		);
 
-		// Collect every collection this read touches (root + relations in fields/filter/sort) so a
-		// later mutation can drop just these cache entries instead of flushing the whole namespace.
-		// Bounded to this read — it rides the result via `getMeta()`, not a service-level field.
-		const cacheTags = new Set<string>();
-
-		if (scopedCachePurgeEnabled()) {
-			for (const collection of collectionsInFieldMap(fieldMapFromAst(ast, this.schema))) {
-				cacheTags.add(collection);
-			}
-		}
-
 		const records = await runAst(ast, this.schema, this.accountability, {
 			knex: this.knex,
 			// GraphQL requires relational keys to be returned regardless
@@ -652,6 +706,40 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 						},
 					)
 				: records;
+
+		// Scope this read for tag-based cache purging. The root collection gets value tags built from the
+		// scope-field values present in the returned rows, so one owner's/partition's later write drops
+		// only their entries. Every other touched collection — and a root whose scope values can't be
+		// resolved (field not projected, empty result, none configured) — falls back to a bare collection
+		// tag. The `cache.scope` filter lets extensions augment these (e.g. resolve M2M owners); whatever
+		// they add here must be reproducible on the `cache.purge` side or it leaks. Bounded to this read —
+		// it rides the result via `getMeta()`, not a service-level field.
+		const cacheTags: CacheTag[] = [];
+
+		if (scopedCachePurgeEnabled()) {
+			const scopeFields = this.schema.collections[this.collection]?.cacheScopeFields ?? [];
+
+			const rootValueTags =
+				scopeFields.length > 0 ? collectScopeValueTags(this.collection, scopeFields, filteredRecords, true) : null;
+
+			for (const collection of collectionsInFieldMap(fieldMapFromAst(ast, this.schema))) {
+				if (collection === this.collection && rootValueTags && rootValueTags.length > 0) {
+					cacheTags.push(...rootValueTags);
+				} else {
+					cacheTags.push({ collection });
+				}
+			}
+
+			const scopedTags = (await emitter.emitFilter(
+				'cache.scope',
+				cacheTags,
+				{ collection: this.collection, query: updatedQuery },
+				{ database: this.knex, schema: this.schema, accountability: this.accountability },
+			)) as CacheTag[];
+
+			cacheTags.length = 0;
+			cacheTags.push(...scopedTags);
+		}
 
 		if (opts?.emitEvents !== false) {
 			// Read action hooks stay fire-and-forget; the await opt-in (`awaitActionHooks`) is for mutations.
@@ -695,7 +783,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		}
 
 		// Carry the read's metadata onto the single returned item.
-		return withMeta(results[0]!, readMeta(results) ?? { cacheTags: new Set() });
+		return withMeta(results[0]!, readMeta(results) ?? { cacheTags: [] });
 	}
 
 	/**
@@ -757,6 +845,13 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 		const keys: PrimaryKey[] = [];
 
+		// Pre-update scope values for every row this batch touches (old ∪ new on purge, like updateMany).
+		const batchKeys = data
+			.map((item) => item[primaryKeyField])
+			.filter((key): key is PrimaryKey => key !== undefined && key !== null);
+
+		const oldScopeValueTags = await this.captureScopeValueTags(batchKeys);
+
 		try {
 			await transaction(this.knex, async (knex) => {
 				const service = this.fork({ knex });
@@ -786,7 +881,10 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			});
 		} finally {
 			if (shouldClearCache(this.cache, opts, this.collection)) {
-				await purgeCache(this.cache, this.collection);
+				const scopeFields = this.schema.collections[this.collection]?.cacheScopeFields ?? [];
+				const newScopeValueTags = collectScopeValueTags(this.collection, scopeFields, data, false) ?? [];
+				const valueTags = oldScopeValueTags === null ? null : [...oldScopeValueTags, ...newScopeValueTags];
+				await purgeCache(this.cache, this.collection, valueTags, this.cachePurgeContext());
 			}
 		}
 
@@ -819,6 +917,10 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 		const primaryKeyField = this.schema.collections[this.collection]!.primary;
 		validateKeys(this.schema, this.collection, primaryKeyField, keys);
+
+		// Capture the scope values these rows hold before the update so an update that moves a row to a
+		// new scope value purges both slices (old ∪ new). Empty when the collection isn't scoped.
+		const oldScopeValueTags = await this.captureScopeValueTags(keys);
 
 		const fields = Object.keys(this.schema.collections[this.collection]!.fields);
 
@@ -1071,7 +1173,12 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		});
 
 		if (shouldClearCache(this.cache, opts, this.collection)) {
-			await purgeCache(this.cache, this.collection);
+			const scopeFields = this.schema.collections[this.collection]?.cacheScopeFields ?? [];
+			// Old slices from the pre-update capture, plus the new value the update sets (if it touches a
+			// scope field). An absent scope field means "unchanged", already covered by the old capture.
+			const newScopeValueTags = collectScopeValueTags(this.collection, scopeFields, [data], false) ?? [];
+			const valueTags = oldScopeValueTags === null ? null : [...oldScopeValueTags, ...newScopeValueTags];
+			await purgeCache(this.cache, this.collection, valueTags, this.cachePurgeContext());
 		}
 
 		if (opts.emitEvents !== false) {
@@ -1149,7 +1256,10 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		});
 
 		if (shouldClearCache(this.cache, opts, this.collection)) {
-			await purgeCache(this.cache, this.collection);
+			// Upserts mix inserts and updates per row, so old (pre-update) scope values can't be captured
+			// cheaply for the update subset. Fall back to a full flush (`null`) rather than risk leaving a
+			// moved-value slice stale. TODO(scoped-cache): resolve per-row once upsert churn is measured.
+			await purgeCache(this.cache, this.collection, null, this.cachePurgeContext());
 		}
 
 		return primaryKeys;
@@ -1233,6 +1343,10 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 			return keys.map(() => null);
 		}
 
+		// Capture the scope values of the rows about to be deleted; after the delete they're gone and
+		// can't be read, so a later purge couldn't tell which slices to drop.
+		const oldScopeValueTags = await this.captureScopeValueTags(keysAfterHooks);
+
 		if (this.accountability) {
 			await validateAccess(
 				{
@@ -1300,7 +1414,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		});
 
 		if (shouldClearCache(this.cache, opts, this.collection)) {
-			await purgeCache(this.cache, this.collection);
+			await purgeCache(this.cache, this.collection, oldScopeValueTags, this.cachePurgeContext());
 		}
 
 		if (opts.emitEvents !== false) {
@@ -1336,7 +1450,7 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 		query.limit = 1;
 
 		const records = await this.readByQuery(query, opts);
-		const meta = readMeta(records) ?? { cacheTags: new Set<string>() };
+		const meta = readMeta(records) ?? { cacheTags: [] };
 		const record = records[0];
 
 		if (!record) {

--- a/api/src/services/permissions-cache-tags.test.ts
+++ b/api/src/services/permissions-cache-tags.test.ts
@@ -29,7 +29,7 @@ describe('PermissionsService.readByQuery override', () => {
 	test('carries the cache-tag rider across the withAppMinimalPermissions rebuild', async () => {
 		// super.readByQuery returns a tagged array; the override rebuilds it (new array) and must
 		// re-attach the rider so permissions reads stay scoped-invalidatable (not TTL-only).
-		const tagged = withMeta([{ id: 1 }], { cacheTags: new Set(['directus_permissions']) });
+		const tagged = withMeta([{ id: 1 }], { cacheTags: [{ collection: 'directus_permissions' }] });
 		vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue(tagged);
 
 		const service = new PermissionsService({ knex: db, schema: {} as any, accountability: null });
@@ -37,6 +37,6 @@ describe('PermissionsService.readByQuery override', () => {
 
 		// rebuilt (app-minimal appended) AND the rider survived
 		expect(result).toHaveLength(2);
-		expect([...(readMeta(result)?.cacheTags ?? [])]).toEqual(['directus_permissions']);
+		expect(readMeta(result)?.cacheTags ?? []).toEqual([{ collection: 'directus_permissions' }]);
 	});
 });

--- a/api/src/services/permissions.ts
+++ b/api/src/services/permissions.ts
@@ -39,7 +39,7 @@ export class PermissionsService extends ItemsService {
 		// withAppMinimalPermissions returns a fresh array, so carry the read's cache-tag rider across.
 		return withMeta(
 			withAppMinimalPermissions(this.accountability, result, query.filter) as Partial<Item>[],
-			readMeta(result) ?? { cacheTags: new Set() },
+			readMeta(result) ?? { cacheTags: [] },
 		);
 	}
 

--- a/api/src/utils/get-schema.ts
+++ b/api/src/utils/get-schema.ts
@@ -127,7 +127,7 @@ async function getDatabaseSchema(database: Knex, schemaInspector: SchemaInspecto
 
 	const collections = [
 		...(await database
-			.select('collection', 'singleton', 'note', 'sort_field', 'accountability')
+			.select('collection', 'singleton', 'note', 'sort_field', 'accountability', 'cache_scope_fields')
 			.from('directus_collections')),
 		...systemCollectionRows,
 	];
@@ -158,6 +158,7 @@ async function getDatabaseSchema(database: Knex, schemaInspector: SchemaInspecto
 			note: collectionMeta?.note || null,
 			sortField: collectionMeta?.sort_field || null,
 			accountability: collectionMeta ? collectionMeta.accountability : 'all',
+			cacheScopeFields: parseJsonFieldList(collectionMeta?.cache_scope_fields),
 			fields: mapValues(schemaOverview[collection]?.columns, (column) => {
 				return {
 					field: column.column_name,
@@ -227,4 +228,24 @@ async function getDatabaseSchema(database: Knex, schemaInspector: SchemaInspecto
 	result.relations = await relationsService.readAll(undefined, undefined, true);
 
 	return result;
+}
+
+/**
+ * Read a JSON-column field list off a raw `directus_collections` row. The column comes back parsed
+ * on Postgres but as a JSON string on MySQL/SQLite, so accept both and degrade to an empty list on
+ * anything unexpected.
+ */
+function parseJsonFieldList(raw: unknown): string[] {
+	if (Array.isArray(raw)) return raw.filter((entry): entry is string => typeof entry === 'string');
+
+	if (typeof raw === 'string' && raw.length > 0) {
+		try {
+			const parsed = JSON.parse(raw);
+			return Array.isArray(parsed) ? parsed.filter((entry): entry is string => typeof entry === 'string') : [];
+		} catch {
+			return [];
+		}
+	}
+
+	return [];
 }

--- a/api/src/utils/read-meta.test.ts
+++ b/api/src/utils/read-meta.test.ts
@@ -3,15 +3,15 @@ import { readMeta, withMeta } from './read-meta.js';
 
 describe('withMeta / readMeta', () => {
 	test('round-trips the metadata via getMeta()', () => {
-		const meta = { cacheTags: new Set(['articles', 'users']) };
+		const meta = { cacheTags: [{ collection: 'articles' }, { collection: 'users' }] };
 		const result = withMeta([{ id: 1 }], meta);
 
 		expect(readMeta(result)).toBe(meta);
-		expect([...readMeta(result)!.cacheTags]).toEqual(['articles', 'users']);
+		expect(readMeta(result)!.cacheTags).toEqual([{ collection: 'articles' }, { collection: 'users' }]);
 	});
 
 	test('getMeta is non-enumerable — invisible to JSON and spread', () => {
-		const rows = withMeta([{ id: 1 }], { cacheTags: new Set(['articles']) });
+		const rows = withMeta([{ id: 1 }], { cacheTags: [{ collection: 'articles' }] });
 
 		expect(JSON.stringify(rows)).toBe('[{"id":1}]');
 		expect(Object.keys(rows)).toEqual(['0']);
@@ -20,8 +20,8 @@ describe('withMeta / readMeta', () => {
 	});
 
 	test('works on a single object as well as an array', () => {
-		const item = withMeta({ id: 1 }, { cacheTags: new Set(['articles']) });
-		expect([...readMeta(item)!.cacheTags]).toEqual(['articles']);
+		const item = withMeta({ id: 1 }, { cacheTags: [{ collection: 'articles' }] });
+		expect(readMeta(item)!.cacheTags).toEqual([{ collection: 'articles' }]);
 	});
 
 	test('readMeta is safe on values without metadata', () => {

--- a/packages/system-data/src/fields/collections.yaml
+++ b/packages/system-data/src/fields/collections.yaml
@@ -239,6 +239,13 @@ fields:
     options:
       collectionField: collection
 
+  - field: cache_scope_fields
+    special:
+      - cast-json
+    interface: system-field-tree
+    options:
+      collectionField: collection
+
   - field: sort
     hidden: true
 

--- a/packages/system-data/src/types.ts
+++ b/packages/system-data/src/types.ts
@@ -37,6 +37,7 @@ export type CollectionMeta = {
 	unarchive_value: string | null;
 	archive_app_filter: boolean;
 	item_duplication_fields: string[] | null;
+	cache_scope_fields: string[] | null;
 	accountability: 'all' | 'activity' | null;
 	system: boolean | null;
 	sort: number | null;
@@ -54,6 +55,7 @@ export type BaseCollectionMeta = Pick<
 	| 'translations'
 	| 'versioning'
 	| 'item_duplication_fields'
+	| 'cache_scope_fields'
 	| 'accountability'
 	| 'group'
 	| 'system'

--- a/packages/types/src/read-meta.ts
+++ b/packages/types/src/read-meta.ts
@@ -1,10 +1,21 @@
 /**
+ * A unit of cache scope. A bare tag (no `field`) covers every entry that read the collection — the
+ * coarse bucket holding "global" reads that couldn't be narrowed. A value tag pins a single
+ * `field=value` slice so one owner's/partition's writes drop only their own entries.
+ */
+export interface CacheTag {
+	collection: string;
+	field?: string;
+	value?: unknown;
+}
+
+/**
  * Metadata about a read operation, carried alongside its result (see `WithMeta`). Bounded to the
  * single read that produced it — never an accumulating service-level field.
  */
 export interface ReadMeta {
-	/** Collections whose data fed this read (root + relations via fields/filter/sort); scopes cache-tag invalidation. */
-	cacheTags: Set<string>;
+	/** Scope tags whose data fed this read (root value slices + relations); scopes cache-tag invalidation. */
+	cacheTags: CacheTag[];
 }
 
 /**

--- a/packages/types/src/schema.ts
+++ b/packages/types/src/schema.ts
@@ -24,6 +24,8 @@ export type CollectionOverview = {
 	sortField: string | null;
 	note: string | null;
 	accountability: 'all' | 'activity' | null;
+	/** Field names whose values scope tag-based cache invalidation for this collection. */
+	cacheScopeFields?: string[];
 	fields: {
 		[name: string]: FieldOverview;
 	};


### PR DESCRIPTION
Scoped purging today is collection-level: any write to a collection drops *every* cached read of it. For the planner that's still a sledgehammer — one student adding a time-slot wipes every student's cached planning. This makes the purge **value**-scoped: a per-collection `cache_scope_fields` (admin-configurable on the data-model page) names the owner/partition columns, and a mutation only drops the cache slices whose data actually changed.

### Why this shape
- **Config lives in `directus_collections` meta** (JSON column) → rides the schema snapshot, so **directus-schema-sync carries it with zero extra config**. Single source of truth, travels with the schema. Admin UI is the existing `system-field-tree` multi-select (no new component), forward-compatible with picking relational paths later.
- **The invariant that keeps it correct:** a scoped read tags ONLY its value slices (`tag:slots:student=A`); the bare collection tag holds only "global" reads that couldn't be scoped. A write purges bare (global readers) **+** the resolved value slices, sparing every other slice. So student A's write drops A's + global entries, never B's.
- **Writes resolve values precisely:** create from payload, update/delete from a pre-mutation capture **unioned** with the new payload value (a row moved A→B drops both old and new).
- **`cache.scope` / `cache.purge` filter pair:** extensions can augment the tag set (e.g. resolve M2M owners in userland) without core relation support. Contract — whatever you add on `cache.scope` must be reproducible on `cache.purge`, or the entry leaks.

### Retrocompat
Fully opt-in. `cache_scope_fields` empty (the default for every collection) = today's bare-collection behavior, byte-for-byte. Requires `CACHE_AUTO_PURGE_MODE=scoped` + `CACHE_STORE=redis`; anything else keeps the existing full-flush fallback. The new column is nullable + additive.

### Questions for you
- `upsertMany` falls back to a full flush (mixed insert/update → old values aren't cheaply capturable). Acceptable for now, or resolve per-row? (`TODO` marked in code.)
- Read-side fan-out: an admin "all students" read tags N value slices. No cap yet — fine until it's measured as a problem?
- Relations/M2M deliberately stay bare-tagged in core (resolved via the filter pair in userland). Keep core scalar-only for now?

### Out of scope (named, considered + not done)
- The runAst SQL-result cache (separate layer below the response cache — weak win now that prod PG is ~100% RAM-resident, cold reads already cheap).
- `cache.key` filter (custom cache-key dimensions), read-side fan-out cap, relations/M2M owner-tagging in core.
- Blackbox scoped env (real redis+DB end-to-end) — adding next; current coverage is unit-level (cache + value-derivation).