### PR TITLE
feat(cache): permission-aware scoped cache read scoping (stacked on #205)

### DIFF
--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -116,15 +116,21 @@ export function pinnedScopeTagsFromFilter(
 	collection: string,
 	fields: string[],
 	filter: Filter | null | undefined,
+	resolveValue: (raw: unknown) => { resolved: boolean; value: unknown } = (raw) => ({ resolved: true, value: raw }),
 ): ScopedCacheTag[] {
 	if (!filter || fields.length === 0) return [];
 
 	const fieldSet = new Set(fields);
 	const pinned = new Map<string, Set<unknown>>();
 
-	function pin(field: string, values: unknown[]): void {
+	function pin(field: string, rawValues: unknown[]): void {
+		const resolved = rawValues.map(resolveValue);
+		// A bound we can't fully resolve (e.g. an `_in` mixing a concrete value with an unresolved dynamic
+		// variable) can't be soundly pinned — skip the field so the read keeps the bare collection tag.
+		if (resolved.some((entry) => !entry.resolved)) return;
+
 		const seen = pinned.get(field) ?? new Set<unknown>();
-		for (const value of values) seen.add(value);
+		for (const entry of resolved) seen.add(entry.value);
 		pinned.set(field, seen);
 	}
 
@@ -153,6 +159,45 @@ export function pinnedScopeTagsFromFilter(
 	}
 
 	return tags;
+}
+
+/**
+ * Resolve the trivial dynamic variables a permission case may use on a scope field, matching what the
+ * query layer's `parseDynamicVariable` does for the bare forms ($CURRENT_USER → `accountability.user`,
+ * $CURRENT_ROLE → `accountability.role`). Anything richer ($CURRENT_USER.field, $CURRENT_ROLES,
+ * $CURRENT_POLICIES, $NOW) needs the fetched dynamic-variable context, so it's reported unresolved and
+ * the read falls back to the bare collection tag rather than risk pinning a wrong value.
+ */
+function resolveScopeCaseValue(
+	raw: unknown,
+	accountability: Accountability | null,
+): { resolved: boolean; value: unknown } {
+	if (typeof raw !== 'string' || !raw.startsWith('$')) return { resolved: true, value: raw };
+	if (raw === '$CURRENT_USER') return { resolved: true, value: accountability?.user ?? null };
+	if (raw === '$CURRENT_ROLE') return { resolved: true, value: accountability?.role ?? null };
+	return { resolved: false, value: undefined };
+}
+
+/**
+ * Pin root scope tags off the permission cases injected into the AST — the read side, permission-aware.
+ * Item-read permissions bound the result by `{ _or: cases }` (`joinFilterWithCases`): a SINGLE case is a
+ * plain AND predicate that excludes every non-matching row, so it bounds the read exactly like an
+ * explicit `_eq`/`_in` filter. Multiple cases are OR'd (a row need match only one) and so don't bound; no
+ * case means unrestricted item access. We therefore pin only the single-case form, resolving its trivial
+ * dynamic variables the same way the query layer does. This is what scopes a permission-isolated read
+ * (e.g. the planner's "a student sees only their own rows") to a value slice instead of the bare
+ * collection tag — the partition lives in permissions, not in the API filter `pinnedScopeTagsFromFilter`
+ * sees.
+ */
+export function pinnedScopeTagsFromCases(
+	collection: string,
+	fields: string[],
+	cases: Filter[] | undefined,
+	accountability: Accountability | null,
+): ScopedCacheTag[] {
+	if (!cases || cases.length !== 1) return [];
+
+	return pinnedScopeTagsFromFilter(collection, fields, cases[0], (raw) => resolveScopeCaseValue(raw, accountability));
 }
 
 export class ItemsService<Item extends AnyItem = AnyItem, Collection extends string = string>
@@ -795,7 +840,13 @@ export class ItemsService<Item extends AnyItem = AnyItem, Collection extends str
 
 		if (scopedCachePurgeEnabled()) {
 			const scopedCacheFields = this.schema.collections[this.collection]?.scopedCacheFields ?? [];
-			const rootScopedCacheTags = pinnedScopeTagsFromFilter(this.collection, scopedCacheFields, updatedQuery.filter);
+
+			// Bound the root either by the API filter or by the permission cases injected into the AST — the
+			// latter is what scopes a permission-isolated read whose partition never appears in the query.
+			const rootScopedCacheTags = [
+				...pinnedScopeTagsFromFilter(this.collection, scopedCacheFields, updatedQuery.filter),
+				...pinnedScopeTagsFromCases(this.collection, scopedCacheFields, ast.cases, this.accountability),
+			];
 
 			for (const collection of collectionsInFieldMap(fieldMapFromAst(ast, this.schema))) {
 				if (collection === this.collection && rootScopedCacheTags.length > 0) {

--- a/api/src/services/scoped-cache-tags.test.ts
+++ b/api/src/services/scoped-cache-tags.test.ts
@@ -1,5 +1,8 @@
+import type { Accountability } from '@directus/types';
 import { describe, expect, test } from 'vitest';
-import { pinnedScopeTagsFromFilter, scopedCacheTagsFromRows } from './items.js';
+import { pinnedScopeTagsFromCases, pinnedScopeTagsFromFilter, scopedCacheTagsFromRows } from './items.js';
+
+const alice = { user: 'alice-id', role: 'student-role' } as Accountability;
 
 // Pure scope-tag derivation behind update-payload / create tagging
 // (requireAll toggles fatal-on-missing).
@@ -99,5 +102,59 @@ describe('pinnedScopeTagsFromFilter', () => {
 	test('empty / null filter yields no pin', () => {
 		expect(pinnedScopeTagsFromFilter('slots', ['student'], null)).toEqual([]);
 		expect(pinnedScopeTagsFromFilter('slots', ['student'], {})).toEqual([]);
+	});
+});
+
+// Permission-aware read scoping: a single permission case bounds the result (rows
+// that don't match are excluded), so it pins like an explicit filter — after resolving
+// the trivial dynamic variables. This is what value-scopes a permission-isolated read
+// whose partition lives in permissions, not the API query.
+describe('pinnedScopeTagsFromCases', () => {
+	test('a single case with $CURRENT_USER on a scope field pins the resolved user id', () => {
+		expect(pinnedScopeTagsFromCases('slots', ['student'], [{ student: { _eq: '$CURRENT_USER' } }], alice)).toEqual([
+			{ collection: 'slots', field: 'student', value: 'alice-id' },
+		]);
+	});
+
+	test('$CURRENT_ROLE resolves to the accountability role', () => {
+		expect(pinnedScopeTagsFromCases('slots', ['student'], [{ student: { _eq: '$CURRENT_ROLE' } }], alice)).toEqual([
+			{ collection: 'slots', field: 'student', value: 'student-role' },
+		]);
+	});
+
+	test('a literal value in a single case pins directly', () => {
+		expect(pinnedScopeTagsFromCases('slots', ['student'], [{ student: { _eq: 'A' } }], alice)).toEqual([
+			{ collection: 'slots', field: 'student', value: 'A' },
+		]);
+	});
+
+	test('a case reached through _and pins', () => {
+		const cases = [{ _and: [{ student: { _eq: '$CURRENT_USER' } }, { course: { _eq: 'math' } }] }];
+
+		expect(pinnedScopeTagsFromCases('slots', ['student', 'course'], cases, alice)).toEqual([
+			{ collection: 'slots', field: 'student', value: 'alice-id' },
+			{ collection: 'slots', field: 'course', value: 'math' },
+		]);
+	});
+
+	test('multiple cases are OR-combined — none bounds, so nothing pins', () => {
+		const cases = [{ student: { _eq: '$CURRENT_USER' } }, { student: { _eq: 'shared' } }];
+		expect(pinnedScopeTagsFromCases('slots', ['student'], cases, alice)).toEqual([]);
+	});
+
+	test('no cases (unrestricted item access) pins nothing', () => {
+		expect(pinnedScopeTagsFromCases('slots', ['student'], [], alice)).toEqual([]);
+		expect(pinnedScopeTagsFromCases('slots', ['student'], undefined, alice)).toEqual([]);
+	});
+
+	test('an unresolvable dynamic ($CURRENT_USER.team) does not pin — read stays bare-tagged', () => {
+		expect(pinnedScopeTagsFromCases('slots', ['student'], [{ student: { _eq: '$CURRENT_USER.team' } }], alice)).toEqual(
+			[],
+		);
+	});
+
+	test('an _in mixing a concrete value and an unresolvable dynamic skips the field (no partial bound)', () => {
+		const cases = [{ student: { _in: ['A', '$CURRENT_POLICIES'] } }];
+		expect(pinnedScopeTagsFromCases('slots', ['student'], cases, alice)).toEqual([]);
 	});
 });


### PR DESCRIPTION
Stacked on #205 (`v11.10.1-feat/scoped-cache-value-tags`) — review/merge that first.

#205 value-scopes a read off its **API filter**. But our isolation lives in **permissions**, not the query: a student lists `/items/slots` with no filter, and a policy restricts them to `student = $CURRENT_USER`. The API filter is empty, so #205 falls back to the bare collection tag — and one student's write purges every student's cached read. The sledgehammer #205 set out to kill still lands on exactly the planner case.

This scopes the root off the **permission cases** injected into the AST. `joinFilterWithCases` applies them as a row `WHERE {_or: cases}`, so a **single** case excludes every non-matching row — it bounds the read exactly like an explicit `_eq`/`_in`. Multiple cases are OR'd (a row need only match one) and so don't bound; I pin only the single-case form. Dynamic variables resolve the same way the query layer's `parseDynamicVariable` does (`$CURRENT_USER` → `accountability.user`, `$CURRENT_ROLE` → `role`); anything richer bails to the bare tag.

`pinnedScopeTagsFromFilter` gains an optional value-resolver so the API-filter and permission-case paths share one walk.

### Why it's sound
- A single case is an AND predicate → non-matching rows are **excluded**, not field-nulled (verified in `joinFilterWithCases` + `applyFilter`). Tagging the read with the case's value slice can't under-invalidate.
- Permission *changes* already purge the response cache: the `policies`/`roles`/`access`/`permissions` services' `clearCaches` call `cache.clear()`, so a re-scoped read can't outlive a permission edit.

### Retrocompat
Additive. No permission case, multiple cases, or an unresolvable dynamic → identical to #205's behavior (bare collection tag). Inert when `scopedCachePurgeEnabled()` is false.

### Not ready to compose yet
Deliberately kept off the `v11.10.1-feat:` composed-title prefix until two things land:
- **e2e/blackbox with real permissions** — only the `pinnedScopeTagsFromCases` derivation is unit-tested; no full-stack proof that a permission-isolated read MISSes after a same-partition write and HITs after an other-partition write.
- **richer dynamic-variable resolution** — `$CURRENT_USER.field` and `$CURRENT_ROLES`/`$CURRENT_POLICIES` arrays need the fetched variable context; today they bail to bare (safe, just coarse).

### Questions for you
- Resolve the full dynamic-variable set (reuse the run-ast variable context) or keep the conservative bail-to-bare subset and accept coarser scoping for dotted/array vars?
- Pin only single-case: a two-policy student (own rows + a shared bucket) is two cases → OR → bare. Worth handling "all cases pin the same field" as a union-of-values pin, or leave it coarse?
- Out of scope here (named): relations/M2M owner scoping via cases — core stays scalar-root like #205; the `cache.scope` filter remains the userland seam.
