### PR TITLE
feat(redis): configurable reconnect policy via REDIS_RETRY_* env

### DIFF
--- a/api/src/redis/lib/create-redis.test.ts
+++ b/api/src/redis/lib/create-redis.test.ts
@@ -8,6 +8,8 @@ vi.mock('ioredis');
 vi.mock('../../utils/get-config-from-env.js');
 vi.mock('@directus/env');
 
+type RetryStrategy = (attempt: number) => number | null;
+
 let mockRedis: Redis;
 
 beforeEach(() => {
@@ -19,31 +21,94 @@ afterEach(() => {
 	vi.clearAllMocks();
 });
 
+// Grab the retryStrategy the constructor was built with for a given env. URL mode passes
+// it as the second argument; discrete-config mode folds it into the single options object.
+function retryStrategyFor(env: Record<string, unknown>): RetryStrategy {
+	vi.mocked(useEnv).mockReturnValue(env);
+	createRedis();
+
+	const [first, second] = vi.mocked(Redis).mock.calls.at(-1)!;
+
+	const options = env['REDIS']
+		? second
+		: first;
+
+	return (options as { retryStrategy: RetryStrategy }).retryStrategy;
+}
+
 describe('createRedis', () => {
 	test('Creates and returns new Redis instance from connection string', () => {
 		const connectionString = 'test-connection-string';
-		const mockEnv = { REDIS: connectionString };
-		vi.mocked(useEnv).mockReturnValue(mockEnv);
+		vi.mocked(useEnv).mockReturnValue({ REDIS: connectionString });
 
 		const redis = createRedis();
 
-		expect(Redis).toHaveBeenCalledWith(connectionString);
+		// The URL still drives the connection; the retry policy now rides alongside it
+		// (the URL form used to drop every ioredis option).
+		expect(Redis).toHaveBeenCalledWith(connectionString, {
+			retryStrategy: expect.any(Function),
+		});
+
 		expect(redis).toBe(mockRedis);
 	});
 
 	test('Uses Redis connection object if Redis connection string is missing', () => {
 		const redisHost = 'test-host';
-		const mockEnv = { REDIS_HOST: redisHost };
-		vi.mocked(useEnv).mockReturnValue(mockEnv);
+		vi.mocked(useEnv).mockReturnValue({ REDIS_HOST: redisHost });
 
 		const mockConfig = { host: redisHost };
-
 		vi.mocked(getConfigFromEnv).mockReturnValue(mockConfig);
 
 		const redis = createRedis();
 
 		expect(getConfigFromEnv).toHaveBeenCalledWith('REDIS');
-		expect(Redis).toHaveBeenCalledWith(mockConfig);
+
+		expect(Redis).toHaveBeenCalledWith({
+			host: redisHost,
+			retryStrategy: expect.any(Function),
+		});
+
 		expect(redis).toBe(mockRedis);
+	});
+
+	describe('retryStrategy', () => {
+		test('Defaults to ioredis backoff, capped, never null', () => {
+			const retry = retryStrategyFor({ REDIS: 'x' });
+
+			expect(retry(1)).toBe(50);
+			expect(retry(10)).toBe(500);
+			expect(retry(1000)).toBe(2000); // capped
+			expect(retry(1e9)).toBe(2000); // still a number => keeps retrying
+		});
+
+		test('Honours base + max delay knobs', () => {
+			const retry = retryStrategyFor({
+				REDIS: 'x',
+				REDIS_RETRY_BASE_DELAY: 100,
+				REDIS_RETRY_MAX_DELAY: 900_000,
+			});
+
+			expect(retry(1)).toBe(100);
+			expect(retry(50)).toBe(5000);
+			expect(retry(1e6)).toBe(900_000); // capped at the widened window
+		});
+
+		test('Gives up (null) past max attempts', () => {
+			const retry = retryStrategyFor({ REDIS: 'x', REDIS_RETRY_MAX_ATTEMPTS: 3 });
+
+			expect(retry(3)).toBe(150); // last allowed attempt still backs off
+			expect(retry(4)).toBeNull();
+		});
+
+		test('Falls back to defaults on malformed knobs', () => {
+			const retry = retryStrategyFor({
+				REDIS: 'x',
+				REDIS_RETRY_BASE_DELAY: 'nope',
+				REDIS_RETRY_MAX_ATTEMPTS: -1,
+			});
+
+			expect(retry(1)).toBe(50); // unparseable base => default 50
+			expect(retry(1e9)).toBe(2000); // negative attempts rejected => never null
+		});
 	});
 });

--- a/api/src/redis/lib/create-redis.ts
+++ b/api/src/redis/lib/create-redis.ts
@@ -1,6 +1,60 @@
 import { useEnv } from '@directus/env';
-import { Redis } from 'ioredis';
+import { Redis, type RedisOptions } from 'ioredis';
 import { getConfigFromEnv } from '../../utils/get-config-from-env.js';
+
+/**
+ * ioredis' reconnect policy is a function, so it can't be set through the env like the other
+ * `REDIS_*` scalar options. Build one from exposed scalar knobs instead, so a serverless host
+ * (e.g. Railway app-sleeping, which only sleeps a service after 10 min with no outbound packets)
+ * can widen the reconnect gap — or stop reconnecting — once Redis is unreachable, and be allowed
+ * to idle out instead of being held awake by an endless reconnect loop.
+ *
+ * Defaults reproduce ioredis' built-in strategy (unlimited retries, 50ms..2000ms backoff), so an
+ * unconfigured deployment behaves exactly as before.
+ *
+ * - REDIS_RETRY_BASE_DELAY   backoff step in ms per attempt        (default 50)
+ * - REDIS_RETRY_MAX_DELAY    backoff cap in ms                     (default 2000)
+ * - REDIS_RETRY_MAX_ATTEMPTS stop reconnecting after N attempts    (default unset = unlimited)
+ *
+ * Serverless recipe: a large REDIS_RETRY_MAX_DELAY (e.g. `number:900000`) keeps the client
+ * self-healing but spaces attempts far enough apart to clear the sleep window. REDIS_RETRY_MAX_
+ * ATTEMPTS hard-stops reconnection — use with care: ioredis will not reconnect on its own after
+ * giving up, so it only suits short-lived processes, not the long-running API.
+ */
+function retryStrategyFromEnv(): RedisOptions['retryStrategy'] {
+	const env = useEnv();
+	const baseDelay = toMs(env['REDIS_RETRY_BASE_DELAY'], 50);
+	const maxDelay = toMs(env['REDIS_RETRY_MAX_DELAY'], 2000);
+	const maxAttempts = toCount(env['REDIS_RETRY_MAX_ATTEMPTS']);
+
+	return (attempt) => {
+		if (maxAttempts !== undefined && attempt > maxAttempts) {
+			return null;
+		}
+
+		return Math.min(attempt * baseDelay, maxDelay);
+	};
+}
+
+function toMs(value: unknown, fallback: number): number {
+	const parsed = Number(value);
+
+	return Number.isFinite(parsed) && parsed >= 0
+		? parsed
+		: fallback;
+}
+
+function toCount(value: unknown): number | undefined {
+	if (value === undefined || value === null || value === '') {
+		return undefined;
+	}
+
+	const parsed = Number(value);
+
+	return Number.isInteger(parsed) && parsed >= 0
+		? parsed
+		: undefined;
+}
 
 /**
  * Create a new Redis instance based on the global env configuration
@@ -9,5 +63,9 @@ import { getConfigFromEnv } from '../../utils/get-config-from-env.js';
  */
 export const createRedis = () => {
 	const env = useEnv();
-	return new Redis(env['REDIS'] ?? getConfigFromEnv('REDIS'));
+	const options: RedisOptions = { retryStrategy: retryStrategyFromEnv() };
+
+	return env['REDIS']
+		? new Redis(env['REDIS'] as string, options)
+		: new Redis({ ...getConfigFromEnv('REDIS'), ...options });
 };


### PR DESCRIPTION
### Why

Our PR/preview services on Railway use app-sleeping (serverless) to save cost, and today that forces `REDIS_ENABLED=false` there. The reason: Railway only sleeps a service after 10 min with **no outbound packets**, but a persistent Redis client whose peer sleeps reconnects on an endless loop (`retryStrategy` default = reconnect forever) → the service never goes idle → never sleeps. So on previews we lose Redis entirely — no shared cache, and no way to exercise the scoped-cache work.

`retryStrategy` is the one knob that would fix this, and it's a **function**, so unlike every other `REDIS_*` option it can't be set from the env (`getConfigFromEnv` only maps scalars; a `REDIS` URL string bypasses options entirely).

### What

Build the strategy inside `createRedis` from scalar env knobs, so ops can widen the reconnect gap past the sleep window (or stop reconnecting) without a code change:

- `REDIS_RETRY_BASE_DELAY` — backoff step ms/attempt (default `50`)
- `REDIS_RETRY_MAX_DELAY` — backoff cap ms (default `2000`)
- `REDIS_RETRY_MAX_ATTEMPTS` — give up after N attempts (default unset = unlimited)

Preview recipe: `REDIS_RETRY_MAX_DELAY="number:900000"` spaces attempts past the 10-min window while still self-healing.

### Retrocompat

Defaults reproduce ioredis' built-in strategy (unlimited retries, `50ms..2000ms` backoff) exactly, so an unconfigured deployment is unchanged. As a side effect, ioredis options are now passed in **both** the URL and discrete-config modes — the URL form previously dropped them silently.

### Known limitation

`REDIS_RETRY_MAX_ATTEMPTS` hard-stops reconnection, and ioredis will **not** reconnect on its own afterwards — so it only suits short-lived / preview services, not a long-running prod API. Full serverless-correctness (reconnect strictly on-demand, disconnect while idle) is a larger change and out of scope here; this just exposes the knob.

### Questions

- Naming OK, or prefer a single `REDIS_RETRY_STRATEGY=exponential|none` enum over three vars?
- Worth dropping `REDIS_RETRY_MAX_ATTEMPTS` given the caveat, to avoid a foot-gun on prod?
- Should discrete-mode options also merge into URL mode more broadly, or keep that minimal?