### PR TITLE
feat(cache): REDIS_KEEP_ALIVE env to unblock Railway App-Sleeping

### DIFF
--- a/api/src/cache.test.ts
+++ b/api/src/cache.test.ts
@@ -101,6 +101,26 @@ describe('getRedisConnection', () => {
 			database: 3,
 		});
 	});
+
+	test(oneLine`
+		REDIS_KEEP_ALIVE overrides the URL form into an object carrying socket.keepAlive
+		(disables the 5s probe so an idle preview can App-Sleep)
+	`, () => {
+		setEnv({ REDIS: 'redis://localhost:6379/2', REDIS_KEEP_ALIVE: false });
+
+		expect(getRedisConnection()).toEqual({
+			url: 'redis://localhost:6379/2',
+			socket: { keepAlive: false },
+		});
+	});
+
+	test('REDIS_KEEP_ALIVE threads into the host/port socket options', () => {
+		setEnv({ REDIS_HOST: 'h', REDIS_PORT: '6379', REDIS_KEEP_ALIVE: 600_000 });
+
+		expect(getRedisConnection()).toEqual({
+			socket: { host: 'h', port: 6379, keepAlive: 600_000 },
+		});
+	});
 });
 
 describe('scoped cache purging', () => {

--- a/api/src/cache.ts
+++ b/api/src/cache.ts
@@ -196,8 +196,18 @@ function getConfig(store: Store = 'memory', ttl: number | undefined, namespaceSu
 export function getRedisConnection(): string | Record<string, unknown> {
 	const url = env['REDIS'];
 
+	// node-redis defaults its socket `keepAlive` to 5000ms → a TCP keepalive probe every 5s on the
+	// persistent cache connection. That outbound traffic blocks Railway App-Sleeping on an otherwise-idle
+	// preview. `REDIS_KEEP_ALIVE=false` disables the probe; a large ms value spaces it past the sleep
+	// window. Unset → node-redis's 5000ms default is preserved untouched (prod is unaffected).
+	const keepAlive = env['REDIS_KEEP_ALIVE'] as number | boolean | undefined;
+
 	if (url) {
-		return url as string;
+		if (keepAlive === undefined) {
+			return url as string;
+		}
+
+		return { url, socket: { keepAlive } };
 	}
 
 	const { host, port, username, password, db, tls } = getConfigFromEnv('REDIS') as Record<string, any>;
@@ -207,6 +217,7 @@ export function getRedisConnection(): string | Record<string, unknown> {
 			host,
 			...(port !== undefined && { port: Number(port) }),
 			...(tls && { tls: true }),
+			...(keepAlive !== undefined && { keepAlive }),
 		},
 		...(username !== undefined && { username }),
 		...(password !== undefined && { password }),


### PR DESCRIPTION
### Why

On Railway, an idle preview API should App-Sleep to save cost — but ours never does while Redis is on. The Network Flow Logs show a steady **86 B TCP round-trip API↔Redis every 5 s** (Status OK, not reconnects). That's node-redis's default socket `keepAlive: 5000` (`@redis/client` `socket.js`) firing a keepalive probe on the persistent **cache** connection — constant outbound that resets the 10-min sleep clock. (The ioredis bus defaults keepAlive `0`, so it isn't involved; confirmed by: Redis off → the API sleeps.)

Prod runs App-Sleeping off by design, so this is a preview-only cost problem — but there's no way to reach the cache client's socket options through directus env today.

### What

Thread a `REDIS_KEEP_ALIVE` env into `getRedisConnection()`:
- **unset** → returns the bare URL exactly as before → node-redis keeps its 5000 ms default → **prod unchanged**.
- **`REDIS_KEEP_ALIVE=false`** → `{ url, socket: { keepAlive: false } }` → no 5 s probe → an idle preview can sleep.
- **`REDIS_KEEP_ALIVE=600000`** → spaces the probe past the sleep window instead of disabling it.

Also threads into the `REDIS_HOST`/`REDIS_PORT` object form. Low risk: keepAlive only speeds dead-socket detection; a preview survives without it (node-redis reconnects lazily on the next op).

### Retrocompat

Fully backward-compatible — the URL passthrough is byte-identical when `REDIS_KEEP_ALIVE` is unset. No defaults/variables entry added (mirrors the `REDIS_RETRY_*` knobs from #208, read straight off `env`).

### Out of scope

Only the cache client's keepalive. If Railway drops the *idle* connection during a sleep attempt, node-redis reconnects (outbound) — whether disabling keepAlive is *sufficient* to sleep depends on Railway's idle-drop timing; it's *necessary* regardless. The bus SUBSCRIBE (ioredis, keepAlive 0) is idle-passive and untouched.

### Open question

Should the default reproduce node-redis's 5000 explicitly (so it shows up in config dumps), or stay unset as here to guarantee an identical prod path? I went with unset to keep prod byte-identical.