### PR TITLE
feat(cache): pin scoped-cache read tags off permission cases

### DIFF
--- a/.agents/auto-memory/MEMORY.md
+++ b/.agents/auto-memory/MEMORY.md
@@ -32,3 +32,5 @@
 - [api vitest typecheck blocked by pre-existing debt](reference_api_typecheck_blocked.md) — \*.test-d.ts never run;
   enabling typecheck surfaces ~203 src type errors (and emitter graph pulls in untyped pino-http-print) → needs a
   dedicated cleanup PR
+- [Service-level read-through cache + CACHE_TYPES](project_directus_service_cache.md) — readByQuery caches via service-cache.ts (dual-write, own key namespace, HTTP fast-path intact); CACHE_TYPES array selects api/service consumers; settled decisions (system-collection excluded for security, TTL shared, gql out-of-scope) so review doesn't re-litigate; PR #207
+- [Permission-case scoped cache (PR #212)](project_directus_permission_case_cache.md) — pin scoped-cache read tags off ast.cases (permission policy), not just the API filter; generalized `_or` in the filter pinner (union iff all branches bind); reuse joinFilterWithCases; settled: cases pre-resolved so no resolver, DNF rejected, no `_not`, root-cases-only

--- a/.agents/auto-memory/project_directus_permission_case_cache.md
+++ b/.agents/auto-memory/project_directus_permission_case_cache.md
@@ -1,0 +1,27 @@
+---
+name: project_directus_permission_case_cache
+description: PR #212 — scoped-cache read tags pinned off permission cases (ast.cases) + covered-gated multi-field _or union in the filter pinner; settled design decisions so a fresh review doesn't re-litigate
+metadata:
+  type: project
+---
+
+PR **#212** `feat(cache): pin scoped-cache read tags off permission cases`. Branch `v11.10.1-feat/scoped-cache-permission-cases`, base `v11.10.1-hhh-dev` (carries #205 scoped-cache + #210 relational pin). Supersedes #206. Green pg+sqlite.
+
+**Problem:** planner reads get the BARE collection tag (one user's write purges everyone's slice) because the partition predicate (`owner_field = $CURRENT_USER`) lives in a **permission policy** → injected as `ast.cases`, not in the query filter. `pinnedScopedCacheTagsFromFilter` only read the filter.
+
+**Mechanism (final):**
+- Recursive evaluator (`evalNode`/`evalOr`/`evalLeaf` + `unionTags`) returns `{tags, covered}` per node — `covered` = "every row this node matches carries ≥1 pinned tag". `_and`/root **union** tags and are covered if **ANY** conjunct is (row meets all); `_or` is pinnable **iff EVERY branch is covered** (else a row matching an uncovered branch is stale), then **unions all branches' tags across fields**.
+- `items.ts` pins off `joinFilterWithCases(updatedQuery.filter, ast.cases)` — ONE call, the **same combiner run-ast uses for the SQL WHERE** (`{_and:[filter,{_or:cases}]}`), so the pin can't diverge from what the query returns. `pinnedScopedCacheTagsFromCases` was deleted (folded in). See [[feedback_reuse_source_of_truth_combiner]].
+- Bonus: query `?filter[_or][…]` now pins the union too (was bare).
+- **Multi-field `_or` union (lift, commit 309b6de95e):** a case set / query `_or` whose branches bind DIFFERENT scope fields (`{_or:[{owner:A},{dept:X}]}`) now pins BOTH `(owner,A)+(dept,X)` instead of bare — sound because the purge model ORs at the tag level (a read under >1 tag drops if a write hits any). Was the old "different-field → bare" floor; the `covered` gate replaced it.
+
+**SETTLED — do NOT re-raise in a fresh review:**
+- **No dynamic-var resolver in the pinner.** `ast.cases` arrive already `parseFilter`-resolved (`fetchPermissions`→`processPermissions`→`parseFilter`), incl. the SHARE path (`getPermissionsForShare`: policy perms via same fetch, generated perms are concrete PKs). `$CURRENT_USER`/`$NOW`/`$CURRENT_ROLES` are concrete values here — never literal `$…`. Do not re-add `resolveScopeCaseValue`.
+- **DNF rejected.** Distributing `_and` over `_or` is worst-case exponential on user/policy-controlled filters; the linear over-approximating walk is the bounded form. Don't propose normalization.
+- **No `_not` in directus filters** (only `_and`/`_or`; negation is per-operator `_neq`/`_nin`/`_nnull`). Pinner only pins `_eq`/`_in`, so negations degrade to bare — no inversion edge.
+- **Multi-field `_or` union IS supported** (lifted — see Mechanism). The retained sound floor is narrower: a branch binding **NO pinnable field** (e.g. the `{string_field:_nnull}` 2nd case in the multi-case bb test, or a non-scope `_contains`) fails the every-branch-covered gate → the whole `_or` is bare. Do NOT re-propose the floor as "different-field→bare" — that's stale; different pinnable fields now union.
+- **`_and` uses value-UNION over-approx** (not intersection) — intentional, over-purges/never-stale.
+- **Root `ast.cases` only** — nested `child.cases` are per-relation, out of scope (scope fields live on the root collection).
+- **`covered` gate is the whole soundness argument** — union-all-branches would be UNSOUND without it (an uncovered branch's rows carry no tag → stale). Unit-tested in isolation.
+
+Proof: `scoped-cache-tags.test.ts` (`_or` union / unbounding-branch / relational-in-`_or` / `_and`-over-`_or` / empty-`_or` / `_or` dedup / `_and` same-field union / empty-`_in`→bare / **multi-field `_or` pins both** / multi-field-with-unbounding-branch→bare) + blackbox in `cache.test.ts` (per-user isolation, resolved-token guard, multi-case→bare, multilevel `_and`, two-policy same-field union, query-`_or` union, **relational permission-case** `{owner_ref:{id:{_eq}}}`, **two-scope-field multi-field union** via dedicated `test_app_cache_scoped_multi` collection — spare-on-neither witness). Commits: 309b6de95e (lift) + 87be9b35de (bb witness) + 39b3ee89ab (90-col style). Related: [[project_directus_service_cache]].

--- a/.agents/auto-memory/project_directus_service_cache.md
+++ b/.agents/auto-memory/project_directus_service_cache.md
@@ -1,0 +1,30 @@
+---
+name: project_directus_service_cache
+description:
+  Service-level read-through cache in ItemsService.readByQuery (PR #207 on v11.10.1-feat/read-through-cache) +
+  CACHE_TYPES env; architecture, guards, and settled design decisions so a fresh review doesn't re-litigate them
+metadata:
+  type: project
+---
+
+Added a **service-level read-through cache** so any `readByQuery` caller (custom endpoint, hook, another service) caches — not only requests through the HTTP cache middleware. PR #207, branch `v11.10.1-feat/read-through-cache`, based on `fix/api-tsdown-externals` (which carries the scoped-cache feature; not in `main`).
+
+**Architecture:**
+- Mechanics live in `api/src/services/service-cache.ts` — `resolveServiceCacheKey` (guard + key, or null), `readServiceCache` (HIT, swallows read errors), `writeServiceCache` (max-size + dual `setCacheValue` + `tagScopedCacheKeys`). `readByQuery` only orchestrates (~15 lines). See [[feedback_no_one_shot_helpers]] cohesive-module exception.
+- **Dual-write, NOT unified.** HTTP fast-path (`cache.ts` middleware HIT + `respond.ts` SET) is untouched. Service cache uses its OWN key namespace (`getReadThroughCacheKey` in `get-cache-key.ts` = HTTP key signals minus URL `path`, collection stands in). The two hold different shapes (raw items vs shaped response) so they must not share a key. Unifying would kill the fast-path (cached GET would re-run controller+shaping every hit).
+- Purge unchanged: service key is `tagScopedCacheKeys`-indexed, so mutations drop it via the existing scope tags.
+
+**Guards (`resolveServiceCacheKey`, all must hold):** `opts.cache !== false` (per-call opt-out, default on) + `CACHE_ENABLED` + `isCacheTypeEnabled('service')` + `cache !== null` + `!knex.isTransaction` (uncommitted) + `!isSystemCollection` (**security: permission/policy/field reads stay fresh via the system cache**) + `permissionsCachable` (no `$NOW`) + under `CACHE_VALUE_MAX_SIZE`.
+
+**CACHE_TYPES config:** `CACHE_ENABLED` = master switch + the only thing that CREATES the Keyv store (`cache.ts:60`). New `CACHE_TYPES` array (default `'api,service'`) selects consumers: `api`=HTTP cache, `service`=read-through. Registered in all 3 env files: `defaults.ts`, `directus-variables.ts` (allowlist), `type-map.ts` (`'array'`). Gate helper `isCacheTypeEnabled` in its own util `utils/is-cache-type-enabled.ts` (NOT `cache.js` — else ~10 test files that mock `cache.js` would need to stub it).
+
+**BUG fixed on this branch — hit-path tag re-propagation (`fix(api/cache): re-propagate scope tags on a service-cache hit`):** the read-through HIT originally returned `withMeta(cached, { scopedCacheTags: [] })`. But an HTTP/GraphQL response shaped ON TOP of a service HIT is tagged in `respond.ts` from that meta — so an empty list left the HTTP entry under NO scope tags → a mutation purged the service key but not the HTTP entry → stale HTTP response until TTL (desyncs when a service HIT backs an HTTP MISS: multi-URL→same service key, or REST-warmed→GraphQL read). Fix: `writeServiceCache` stores a TTL-matched `${key}__tags` sibling; `readServiceCache` returns `{records, tags}`; the hit returns the stored tags. A hit whose `__tags` sibling is evicted → treated as a MISS (self-heals). **General gotcha for dual-write caches: when layer B derives its invalidation tags from layer A's read result, A's cache-HIT path must re-propagate the same tags it set — returning `[]` silently un-tags B.**
+
+**Settled decisions — do NOT re-raise in review:**
+- Dual-write over unify (keep fast-path) — deliberate.
+- System collections excluded from service cache — security, intentional.
+- TTL shared (`CACHE_TTL`), not a separate `SERVICE_CACHE_TTL` — deferred, out of scope.
+- GraphQL still whole-response via middleware (rides `api`), not folded per-resolver — out of scope.
+- `isCacheTypeEnabled` in own util not `cache.js` — deliberate (mock-surface).
+
+**Still OPEN (jean to decide):** default `CACHE_TYPES=api,service` (service on) vs `api`-only (service opt-in). Also whether specific internal user-data callers (flows, websocket reads, item-read op) need explicit `{ cache: false }`.

--- a/api/src/scoped-cache.ts
+++ b/api/src/scoped-cache.ts
@@ -399,36 +399,3 @@ export function pinnedScopedCacheTagsFromFilter(
 
 	return tags;
 }
-
-/**
- * Pin root scope tags off the permission cases injected into the AST — the read side, made
- * permission-aware. Item-read permissions bound the result by `{ _or: cases }`
- * (`joinFilterWithCases`): a SINGLE case is a plain AND predicate that excludes every non-matching
- * row, so it bounds the read exactly like an explicit `_eq`/`_in` filter. Multiple cases are OR'd (a
- * row need match only one) and so don't bound; no case means unrestricted access. We therefore pin
- * only the single-case form. The case is already dynamic-var-resolved by the time it reaches here —
- * `fetchPermissions` runs `processPermissions` (→ `parseFilter`), so `$CURRENT_USER`/`$NOW` are
- * concrete values, exactly like the query filter `sanitizeQuery` resolved. So it feeds the filter
- * pinner directly. This scopes a permission-isolated read (the planner's "a student sees only their
- * own rows") to a value slice instead of the bare collection tag — the partition lives in
- * permissions, not in the API filter that `pinnedScopedCacheTagsFromFilter` sees.
- */
-export function pinnedScopedCacheTagsFromCases(
-	collection: string,
-	fields: string[],
-	cases: Filter[] | undefined,
-	fieldTypes: Record<string, Type | undefined> = {},
-	relatedPrimaryKeys: Record<string, string> = {},
-): ScopedCacheTag[] {
-	if (!cases || cases.length !== 1) {
-		return [];
-	}
-
-	return pinnedScopedCacheTagsFromFilter(
-		collection,
-		fields,
-		cases[0],
-		fieldTypes,
-		relatedPrimaryKeys,
-	);
-}

--- a/api/src/scoped-cache.ts
+++ b/api/src/scoped-cache.ts
@@ -1,11 +1,5 @@
 import { useEnv } from '@directus/env';
-import type {
-	Accountability,
-	EventContext,
-	Filter,
-	ScopedCacheTag,
-	Type,
-} from '@directus/types';
+import type { EventContext, Filter, ScopedCacheTag, Type } from '@directus/types';
 import type Keyv from 'keyv';
 import emitter from './emitter.js';
 import { redisConfigAvailable, useRedis } from './redis/index.js';
@@ -316,11 +310,6 @@ export function pinnedScopedCacheTagsFromFilter(
 	filter: Filter | null | undefined,
 	fieldTypes: Record<string, Type | undefined> = {},
 	relatedPrimaryKeys: Record<string, string> = {},
-	resolveValue: (raw: unknown) => { resolved: boolean; value: unknown } = (
-		raw,
-	) => {
-		return { resolved: true, value: raw };
-	},
 ): ScopedCacheTag[] {
 	if (!filter || fields.length === 0) {
 		return [];
@@ -333,15 +322,7 @@ export function pinnedScopedCacheTagsFromFilter(
 		const seen = pinned.get(field) ?? new Set<unknown>();
 
 		for (const value of values) {
-			const resolved = resolveValue(value);
-
-			// An unresolvable bound (e.g. a permission case's `$CURRENT_USER.field`) can't be
-			// soundly pinned — skip the whole field so the read keeps the bare collection tag.
-			if (!resolved.resolved) {
-				return;
-			}
-
-			seen.add(resolved.value);
+			seen.add(value);
 		}
 
 		pinned.set(field, seen);
@@ -420,48 +401,22 @@ export function pinnedScopedCacheTagsFromFilter(
 }
 
 /**
- * Resolve the trivial dynamic variables a permission case pins on a scope field, matching the query
- * layer's `parseDynamicVariable` for the bare forms (`$CURRENT_USER` → `accountability.user`,
- * `$CURRENT_ROLE` → `accountability.role`). Anything richer (`$CURRENT_USER.field`, the
- * `$CURRENT_ROLES`/`$CURRENT_POLICIES` arrays, `$NOW`) needs the fetched dynamic-variable context, so
- * it's reported unresolved and the field falls back to the bare collection tag rather than pin a
- * wrong value.
- */
-function resolveScopeCaseValue(
-	raw: unknown,
-	accountability: Accountability | null,
-): { resolved: boolean; value: unknown } {
-	if (typeof raw !== 'string' || !raw.startsWith('$')) {
-		return { resolved: true, value: raw };
-	}
-
-	if (raw === '$CURRENT_USER') {
-		return { resolved: true, value: accountability?.user ?? null };
-	}
-
-	if (raw === '$CURRENT_ROLE') {
-		return { resolved: true, value: accountability?.role ?? null };
-	}
-
-	return { resolved: false, value: undefined };
-}
-
-/**
  * Pin root scope tags off the permission cases injected into the AST — the read side, made
  * permission-aware. Item-read permissions bound the result by `{ _or: cases }`
  * (`joinFilterWithCases`): a SINGLE case is a plain AND predicate that excludes every non-matching
  * row, so it bounds the read exactly like an explicit `_eq`/`_in` filter. Multiple cases are OR'd (a
  * row need match only one) and so don't bound; no case means unrestricted access. We therefore pin
- * only the single-case form, resolving its trivial dynamic variables the way the query layer does.
- * This scopes a permission-isolated read (e.g. the planner's "a student sees only their own rows") to
- * a value slice instead of the bare collection tag — the partition lives in permissions, not in the
- * API filter that `pinnedScopedCacheTagsFromFilter` sees.
+ * only the single-case form. The case is already dynamic-var-resolved by the time it reaches here —
+ * `fetchPermissions` runs `processPermissions` (→ `parseFilter`), so `$CURRENT_USER`/`$NOW` are
+ * concrete values, exactly like the query filter `sanitizeQuery` resolved. So it feeds the filter
+ * pinner directly. This scopes a permission-isolated read (the planner's "a student sees only their
+ * own rows") to a value slice instead of the bare collection tag — the partition lives in
+ * permissions, not in the API filter that `pinnedScopedCacheTagsFromFilter` sees.
  */
 export function pinnedScopedCacheTagsFromCases(
 	collection: string,
 	fields: string[],
 	cases: Filter[] | undefined,
-	accountability: Accountability | null,
 	fieldTypes: Record<string, Type | undefined> = {},
 	relatedPrimaryKeys: Record<string, string> = {},
 ): ScopedCacheTag[] {
@@ -475,6 +430,5 @@ export function pinnedScopedCacheTagsFromCases(
 		cases[0],
 		fieldTypes,
 		relatedPrimaryKeys,
-		(raw) => resolveScopeCaseValue(raw, accountability),
 	);
 }

--- a/api/src/scoped-cache.ts
+++ b/api/src/scoped-cache.ts
@@ -1,5 +1,11 @@
 import { useEnv } from '@directus/env';
-import type { Accountability, EventContext, Filter, ScopedCacheTag, Type } from '@directus/types';
+import type {
+	Accountability,
+	EventContext,
+	Filter,
+	ScopedCacheTag,
+	Type,
+} from '@directus/types';
 import type Keyv from 'keyv';
 import emitter from './emitter.js';
 import { redisConfigAvailable, useRedis } from './redis/index.js';
@@ -310,10 +316,11 @@ export function pinnedScopedCacheTagsFromFilter(
 	filter: Filter | null | undefined,
 	fieldTypes: Record<string, Type | undefined> = {},
 	relatedPrimaryKeys: Record<string, string> = {},
-	resolveValue: (raw: unknown) => { resolved: boolean; value: unknown } = (raw) => ({
-		resolved: true,
-		value: raw,
-	}),
+	resolveValue: (raw: unknown) => { resolved: boolean; value: unknown } = (
+		raw,
+	) => {
+		return { resolved: true, value: raw };
+	},
 ): ScopedCacheTag[] {
 	if (!filter || fields.length === 0) {
 		return [];

--- a/api/src/scoped-cache.ts
+++ b/api/src/scoped-cache.ts
@@ -1,5 +1,5 @@
 import { useEnv } from '@directus/env';
-import type { EventContext, Filter, ScopedCacheTag, Type } from '@directus/types';
+import type { Accountability, EventContext, Filter, ScopedCacheTag, Type } from '@directus/types';
 import type Keyv from 'keyv';
 import emitter from './emitter.js';
 import { redisConfigAvailable, useRedis } from './redis/index.js';
@@ -310,6 +310,10 @@ export function pinnedScopedCacheTagsFromFilter(
 	filter: Filter | null | undefined,
 	fieldTypes: Record<string, Type | undefined> = {},
 	relatedPrimaryKeys: Record<string, string> = {},
+	resolveValue: (raw: unknown) => { resolved: boolean; value: unknown } = (raw) => ({
+		resolved: true,
+		value: raw,
+	}),
 ): ScopedCacheTag[] {
 	if (!filter || fields.length === 0) {
 		return [];
@@ -322,7 +326,15 @@ export function pinnedScopedCacheTagsFromFilter(
 		const seen = pinned.get(field) ?? new Set<unknown>();
 
 		for (const value of values) {
-			seen.add(value);
+			const resolved = resolveValue(value);
+
+			// An unresolvable bound (e.g. a permission case's `$CURRENT_USER.field`) can't be
+			// soundly pinned — skip the whole field so the read keeps the bare collection tag.
+			if (!resolved.resolved) {
+				return;
+			}
+
+			seen.add(resolved.value);
 		}
 
 		pinned.set(field, seen);
@@ -398,4 +410,64 @@ export function pinnedScopedCacheTagsFromFilter(
 	}
 
 	return tags;
+}
+
+/**
+ * Resolve the trivial dynamic variables a permission case pins on a scope field, matching the query
+ * layer's `parseDynamicVariable` for the bare forms (`$CURRENT_USER` → `accountability.user`,
+ * `$CURRENT_ROLE` → `accountability.role`). Anything richer (`$CURRENT_USER.field`, the
+ * `$CURRENT_ROLES`/`$CURRENT_POLICIES` arrays, `$NOW`) needs the fetched dynamic-variable context, so
+ * it's reported unresolved and the field falls back to the bare collection tag rather than pin a
+ * wrong value.
+ */
+function resolveScopeCaseValue(
+	raw: unknown,
+	accountability: Accountability | null,
+): { resolved: boolean; value: unknown } {
+	if (typeof raw !== 'string' || !raw.startsWith('$')) {
+		return { resolved: true, value: raw };
+	}
+
+	if (raw === '$CURRENT_USER') {
+		return { resolved: true, value: accountability?.user ?? null };
+	}
+
+	if (raw === '$CURRENT_ROLE') {
+		return { resolved: true, value: accountability?.role ?? null };
+	}
+
+	return { resolved: false, value: undefined };
+}
+
+/**
+ * Pin root scope tags off the permission cases injected into the AST — the read side, made
+ * permission-aware. Item-read permissions bound the result by `{ _or: cases }`
+ * (`joinFilterWithCases`): a SINGLE case is a plain AND predicate that excludes every non-matching
+ * row, so it bounds the read exactly like an explicit `_eq`/`_in` filter. Multiple cases are OR'd (a
+ * row need match only one) and so don't bound; no case means unrestricted access. We therefore pin
+ * only the single-case form, resolving its trivial dynamic variables the way the query layer does.
+ * This scopes a permission-isolated read (e.g. the planner's "a student sees only their own rows") to
+ * a value slice instead of the bare collection tag — the partition lives in permissions, not in the
+ * API filter that `pinnedScopedCacheTagsFromFilter` sees.
+ */
+export function pinnedScopedCacheTagsFromCases(
+	collection: string,
+	fields: string[],
+	cases: Filter[] | undefined,
+	accountability: Accountability | null,
+	fieldTypes: Record<string, Type | undefined> = {},
+	relatedPrimaryKeys: Record<string, string> = {},
+): ScopedCacheTag[] {
+	if (!cases || cases.length !== 1) {
+		return [];
+	}
+
+	return pinnedScopedCacheTagsFromFilter(
+		collection,
+		fields,
+		cases[0],
+		fieldTypes,
+		relatedPrimaryKeys,
+		(raw) => resolveScopeCaseValue(raw, accountability),
+	);
 }

--- a/api/src/scoped-cache.ts
+++ b/api/src/scoped-cache.ts
@@ -295,16 +295,19 @@ export function scopedCacheTagsFromRows(
  * Scope a read's root cache tags off a filter — the read side. A read is soundly scoped to a value
  * slice only when the filter *bounds* it to that value: a future insert with a new scope value must
  * be excluded by the same filter, or the read would silently miss it. Tags come from `_eq`/`_in` on
- * a scoped field (flat or relational `{ fk: { <pk>: … } }`), combined by operator:
- *   - `_and`/root union a field's values (an over-approximation of the intersection — over-purges,
- *     never stale).
- *   - `_or` keeps a field only when EVERY branch bounds it, unioning their values (a matching row
- *     satisfies at least one branch, so its value lies in the union).
+ * a scoped field (flat or relational `{ fk: { <pk>: … } }`). Each node reports its tags plus whether
+ * it *covers* every row it matches (i.e. binds a pinnable field on that row), combined by operator:
+ *   - `_and`/root union a field's values and are covered if ANY conjunct is (a row satisfies every
+ *     conjunct); the value union over-approximates the intersection — over-purges, never stale.
+ *   - `_or` is sound only when EVERY branch is covered (else a row matching an uncovered branch
+ *     carries no pinned tag → stale); then its tags are the union across branches — a matching row
+ *     satisfies one branch, whose covering tag lies in that union. This holds across *different*
+ *     fields too: `{ _or: [{ owner }, { dept }] }` pins both, purged if a write touches either.
  * This is what scopes a permission-isolated read: the caller passes
  * `joinFilterWithCases(query.filter, ast.cases)`, whose `{ _or: cases }` is unioned by that rule
- * (one case = its own values; a case that leaves a field unbound → bare for that field). No pinned
- * field → `[]`, and the caller falls back to the bare collection tag. `fieldTypes` canonicalizes a
- * value the way the purge side does and skips date-ish types (not pin-safe, `PIN_UNSAFE_SCOPE_TYPES`).
+ * (one case = its own values; a case that leaves ALL fields unbound → bare). No pinned field → `[]`,
+ * and the caller falls back to the bare collection tag. `fieldTypes` canonicalizes a value the way
+ * the purge side does and skips date-ish types (not pin-safe, `PIN_UNSAFE_SCOPE_TYPES`).
  */
 export function pinnedScopedCacheTagsFromFilter(
 	collection: string,
@@ -319,54 +322,12 @@ export function pinnedScopedCacheTagsFromFilter(
 
 	const fieldSet = new Set(fields);
 
-	// A single `_eq`/`_in` (or relational `{ fk: { <pk>: { _eq | _in } } }`) leaf → its value set,
-	// or an empty map when the key isn't a pinnable scope field.
-	function evalLeaf(field: string, value: unknown): Map<string, Set<unknown>> {
-		const map = new Map<string, Set<unknown>>();
+	// A node's pinned tags plus whether it *covers* every row it matches — a leaf that bound a
+	// pinnable field covers its rows; an uncovered node's rows carry no pinned tag (would be stale).
+	type Eval = { tags: Map<string, Set<unknown>>; covered: boolean };
 
-		if (
-			!fieldSet.has(field) ||
-			!isPinnableScopeType(fieldTypes[field]) ||
-			value === null ||
-			typeof value !== 'object'
-		) {
-			return map;
-		}
-
-		const ops = value as Record<string, unknown>;
-
-		if ('_eq' in ops) {
-			map.set(field, new Set([ops['_eq']]));
-		}
-		else if ('_in' in ops && Array.isArray(ops['_in'])) {
-			map.set(field, new Set(ops['_in']));
-		}
-		else {
-			// Relational: a filter on the related PK bounds the fk to the value the write side
-			// stores. Only the related PK is sound — a non-PK attribute wouldn't determine it.
-			const relatedPrimaryKey = relatedPrimaryKeys[field];
-
-			const inner = relatedPrimaryKey === undefined
-				? undefined
-				: ops[relatedPrimaryKey];
-
-			if (inner !== null && typeof inner === 'object') {
-				const innerOps = inner as Record<string, unknown>;
-
-				if ('_eq' in innerOps) {
-					map.set(field, new Set([innerOps['_eq']]));
-				}
-				else if ('_in' in innerOps && Array.isArray(innerOps['_in'])) {
-					map.set(field, new Set(innerOps['_in']));
-				}
-			}
-		}
-
-		return map;
-	}
-
-	// AND: a row satisfies every conjunct, so a field bound by any conjunct is bound; values union.
-	function mergeAnd(
+	// Union `source`'s values into `target` in place (shared by AND and OR).
+	function unionTags(
 		target: Map<string, Set<unknown>>,
 		source: Map<string, Set<unknown>>,
 	): void {
@@ -381,49 +342,90 @@ export function pinnedScopedCacheTagsFromFilter(
 		}
 	}
 
-	// OR: a row matches at least one branch, so a field is bound only when EVERY branch bounds it;
-	// its values are the union across branches.
-	function mergeOr(branches: Map<string, Set<unknown>>[]): Map<string, Set<unknown>> {
-		const result = new Map<string, Set<unknown>>();
+	// A single `_eq`/`_in` (or relational `{ fk: { <pk>: { _eq | _in } } }`) leaf → its value set.
+	// Covered iff it bound a pinnable scope field; a non-scope/date/non-`_eq`/`_in` key covers nothing.
+	function evalLeaf(field: string, value: unknown): Eval {
+		const tags = new Map<string, Set<unknown>>();
 
-		if (branches.length === 0) {
-			return result;
+		if (
+			!fieldSet.has(field) ||
+			!isPinnableScopeType(fieldTypes[field]) ||
+			value === null ||
+			typeof value !== 'object'
+		) {
+			return { tags, covered: false };
 		}
 
-		for (const field of branches[0]!.keys()) {
-			if (!branches.every((branch) => branch.has(field))) {
-				continue;
-			}
+		const ops = value as Record<string, unknown>;
 
-			const union = new Set<unknown>();
+		if ('_eq' in ops) {
+			tags.set(field, new Set([ops['_eq']]));
+		}
+		else if ('_in' in ops && Array.isArray(ops['_in'])) {
+			tags.set(field, new Set(ops['_in']));
+		}
+		else {
+			// Relational: a filter on the related PK bounds the fk to the value the write side
+			// stores. Only the related PK is sound — a non-PK attribute wouldn't determine it.
+			const relatedPrimaryKey = relatedPrimaryKeys[field];
 
-			for (const branch of branches) {
-				for (const value of branch.get(field)!) {
-					union.add(value);
+			const inner = relatedPrimaryKey === undefined
+				? undefined
+				: ops[relatedPrimaryKey];
+
+			if (inner !== null && typeof inner === 'object') {
+				const innerOps = inner as Record<string, unknown>;
+
+				if ('_eq' in innerOps) {
+					tags.set(field, new Set([innerOps['_eq']]));
+				}
+				else if ('_in' in innerOps && Array.isArray(innerOps['_in'])) {
+					tags.set(field, new Set(innerOps['_in']));
 				}
 			}
-
-			result.set(field, union);
 		}
 
-		return result;
+		return { tags, covered: tags.size > 0 };
 	}
 
-	// Every key at an object level is AND-combined (the root and `_and` share this).
-	function evalNode(node: Filter): Map<string, Set<unknown>> {
-		const result = new Map<string, Set<unknown>>();
+	// OR: a row matches at least one branch. Sound to pin only when EVERY branch covers its own rows
+	// (else a row matching an uncovered branch carries no pinned tag → stale); then the tags are the
+	// union across branches — a matching row's covering tag lies in it, across different fields too.
+	function evalOr(branches: Eval[]): Eval {
+		if (branches.length === 0 || !branches.every((branch) => branch.covered)) {
+			return { tags: new Map<string, Set<unknown>>(), covered: false };
+		}
+
+		const tags = new Map<string, Set<unknown>>();
+
+		for (const branch of branches) {
+			unionTags(tags, branch.tags);
+		}
+
+		return { tags, covered: true };
+	}
+
+	// Every key at an object level is AND-combined (the root and `_and` share this): a row satisfies
+	// every conjunct, so tags union and the node is covered if ANY conjunct covers the row.
+	function evalNode(node: Filter): Eval {
+		const result: Eval = { tags: new Map<string, Set<unknown>>(), covered: false };
+
+		function andIn(part: Eval): void {
+			unionTags(result.tags, part.tags);
+			result.covered = result.covered || part.covered;
+		}
 
 		for (const [key, value] of Object.entries(node)) {
 			if (key === '_and' && Array.isArray(value)) {
 				for (const sub of value) {
-					mergeAnd(result, evalNode(sub as Filter));
+					andIn(evalNode(sub as Filter));
 				}
 			}
 			else if (key === '_or' && Array.isArray(value)) {
-				mergeAnd(result, mergeOr(value.map((sub) => evalNode(sub as Filter))));
+				andIn(evalOr(value.map((sub) => evalNode(sub as Filter))));
 			}
 			else {
-				mergeAnd(result, evalLeaf(key, value));
+				andIn(evalLeaf(key, value));
 			}
 		}
 
@@ -433,7 +435,7 @@ export function pinnedScopedCacheTagsFromFilter(
 	const pinned = evalNode(filter);
 	const tags: ScopedCacheTag[] = [];
 
-	for (const [field, values] of pinned) {
+	for (const [field, values] of pinned.tags) {
 		for (const value of values) {
 			tags.push({ collection, field, value, type: fieldTypes[field] });
 		}

--- a/api/src/scoped-cache.ts
+++ b/api/src/scoped-cache.ts
@@ -292,17 +292,19 @@ export function scopedCacheTagsFromRows(
 }
 
 /**
- * Scope a read's root cache tags off the query filter — the read side. A read is
- * soundly scoped to a value slice only when the filter *bounds* it to that value: a
- * future insert with a new scope value must be excluded by the same filter, or the
- * read would silently miss it (a write to the new value purges only its own slice,
- * never this read). So scope tags come from `_eq`/`_in` constraints on a scoped cache
- * field, reached through the root or an `_and` (an `_or` branch doesn't bound — a row
- * matching the other branch still belongs). No pinned field → returns `[]`, and the
- * caller falls back to the bare collection tag so every write to the collection
- * invalidates the read. `fieldTypes` carries each field's schema type so the pinned
- * filter value canonicalizes the same way the purge side's stored row value does — and
- * so date-ish types (not pin-safe, see `PIN_UNSAFE_SCOPE_TYPES`) are skipped.
+ * Scope a read's root cache tags off a filter — the read side. A read is soundly scoped to a value
+ * slice only when the filter *bounds* it to that value: a future insert with a new scope value must
+ * be excluded by the same filter, or the read would silently miss it. Tags come from `_eq`/`_in` on
+ * a scoped field (flat or relational `{ fk: { <pk>: … } }`), combined by operator:
+ *   - `_and`/root union a field's values (an over-approximation of the intersection — over-purges,
+ *     never stale).
+ *   - `_or` keeps a field only when EVERY branch bounds it, unioning their values (a matching row
+ *     satisfies at least one branch, so its value lies in the union).
+ * This is what scopes a permission-isolated read: the caller passes
+ * `joinFilterWithCases(query.filter, ast.cases)`, whose `{ _or: cases }` is unioned by that rule
+ * (one case = its own values; a case that leaves a field unbound → bare for that field). No pinned
+ * field → `[]`, and the caller falls back to the bare collection tag. `fieldTypes` canonicalizes a
+ * value the way the purge side does and skips date-ish types (not pin-safe, `PIN_UNSAFE_SCOPE_TYPES`).
  */
 export function pinnedScopedCacheTagsFromFilter(
 	collection: string,
@@ -316,152 +318,124 @@ export function pinnedScopedCacheTagsFromFilter(
 	}
 
 	const fieldSet = new Set(fields);
-	const pinned = new Map<string, Set<unknown>>();
 
-	function pin(field: string, values: unknown[]): void {
-		const seen = pinned.get(field) ?? new Set<unknown>();
+	// A single `_eq`/`_in` (or relational `{ fk: { <pk>: { _eq | _in } } }`) leaf → its value set,
+	// or an empty map when the key isn't a pinnable scope field.
+	function evalLeaf(field: string, value: unknown): Map<string, Set<unknown>> {
+		const map = new Map<string, Set<unknown>>();
 
-		for (const value of values) {
-			seen.add(value);
+		if (
+			!fieldSet.has(field) ||
+			!isPinnableScopeType(fieldTypes[field]) ||
+			value === null ||
+			typeof value !== 'object'
+		) {
+			return map;
 		}
 
-		pinned.set(field, seen);
+		const ops = value as Record<string, unknown>;
+
+		if ('_eq' in ops) {
+			map.set(field, new Set([ops['_eq']]));
+		}
+		else if ('_in' in ops && Array.isArray(ops['_in'])) {
+			map.set(field, new Set(ops['_in']));
+		}
+		else {
+			// Relational: a filter on the related PK bounds the fk to the value the write side
+			// stores. Only the related PK is sound — a non-PK attribute wouldn't determine it.
+			const relatedPrimaryKey = relatedPrimaryKeys[field];
+
+			const inner = relatedPrimaryKey === undefined
+				? undefined
+				: ops[relatedPrimaryKey];
+
+			if (inner !== null && typeof inner === 'object') {
+				const innerOps = inner as Record<string, unknown>;
+
+				if ('_eq' in innerOps) {
+					map.set(field, new Set([innerOps['_eq']]));
+				}
+				else if ('_in' in innerOps && Array.isArray(innerOps['_in'])) {
+					map.set(field, new Set(innerOps['_in']));
+				}
+			}
+		}
+
+		return map;
 	}
 
-	function walk(node: Filter): void {
+	// AND: a row satisfies every conjunct, so a field bound by any conjunct is bound; values union.
+	function mergeAnd(
+		target: Map<string, Set<unknown>>,
+		source: Map<string, Set<unknown>>,
+	): void {
+		for (const [field, values] of source) {
+			const seen = target.get(field) ?? new Set<unknown>();
+
+			for (const value of values) {
+				seen.add(value);
+			}
+
+			target.set(field, seen);
+		}
+	}
+
+	// OR: a row matches at least one branch, so a field is bound only when EVERY branch bounds it;
+	// its values are the union across branches.
+	function mergeOr(branches: Map<string, Set<unknown>>[]): Map<string, Set<unknown>> {
+		const result = new Map<string, Set<unknown>>();
+
+		if (branches.length === 0) {
+			return result;
+		}
+
+		for (const field of branches[0]!.keys()) {
+			if (!branches.every((branch) => branch.has(field))) {
+				continue;
+			}
+
+			const union = new Set<unknown>();
+
+			for (const branch of branches) {
+				for (const value of branch.get(field)!) {
+					union.add(value);
+				}
+			}
+
+			result.set(field, union);
+		}
+
+		return result;
+	}
+
+	// Every key at an object level is AND-combined (the root and `_and` share this).
+	function evalNode(node: Filter): Map<string, Set<unknown>> {
+		const result = new Map<string, Set<unknown>>();
+
 		for (const [key, value] of Object.entries(node)) {
 			if (key === '_and' && Array.isArray(value)) {
 				for (const sub of value) {
-					walk(sub as Filter);
+					mergeAnd(result, evalNode(sub as Filter));
 				}
-
-				continue;
 			}
-
-			// `_or` doesn't bound the read; nothing under it can pin a scope. A date-ish field
-			// isn't pin-safe (filter↔row canonical can diverge), so it's skipped too — the read
-			// falls back to the bare collection tag.
-			if (
-				key === '_or' ||
-				!fieldSet.has(key) ||
-				!isPinnableScopeType(fieldTypes[key]) ||
-				value === null ||
-				typeof value !== 'object'
-			) {
-				continue;
+			else if (key === '_or' && Array.isArray(value)) {
+				mergeAnd(result, mergeOr(value.map((sub) => evalNode(sub as Filter))));
 			}
-
-			const ops = value as Record<string, unknown>;
-
-			if ('_eq' in ops) {
-				pin(key, [ops['_eq']]);
-			}
-			else if ('_in' in ops && Array.isArray(ops['_in'])) {
-				pin(key, ops['_in']);
-			}
-			// Relational form: a filter on a related scope field reaches its value through the
-			// related collection's primary key — `{ fk: { <pk>: { _eq | _in } } }`. Filtering a
-			// relation by its PK bounds the exact same value the write side stores in the fk
-			// column, so it pins identically to the flat form (covers queries and permission
-			// rules alike, e.g. `{ user_created: { id: { _eq: $CURRENT_USER } } }`). Only the
-			// related PK is sound — a non-PK attribute (`{ fk: { email: … } }`) wouldn't
-			// determine the fk value, so it's left to fall back to the bare collection tag.
 			else {
-				const relatedPrimaryKey = relatedPrimaryKeys[key];
-
-				const inner = relatedPrimaryKey === undefined
-					? undefined
-					: ops[relatedPrimaryKey];
-
-				if (inner !== null && typeof inner === 'object') {
-					const innerOps = inner as Record<string, unknown>;
-
-					if ('_eq' in innerOps) {
-						pin(key, [innerOps['_eq']]);
-					}
-					else if ('_in' in innerOps && Array.isArray(innerOps['_in'])) {
-						pin(key, innerOps['_in']);
-					}
-				}
+				mergeAnd(result, evalLeaf(key, value));
 			}
 		}
+
+		return result;
 	}
 
-	walk(filter);
-
+	const pinned = evalNode(filter);
 	const tags: ScopedCacheTag[] = [];
 
 	for (const [field, values] of pinned) {
 		for (const value of values) {
 			tags.push({ collection, field, value, type: fieldTypes[field] });
-		}
-	}
-
-	return tags;
-}
-
-/**
- * Pin root scope tags off the permission cases injected into the AST — the read side.
- * `joinFilterWithCases` applies cases as `{ _or: cases }`, so a returned row matches AT LEAST one
- * case. A scoped field can therefore be pinned only if EVERY case bounds it — otherwise a row
- * matching an unbounding case carries an unpinned value and a write to that value would leave the
- * read stale. When every case does bound it, the read is scoped to the UNION of their values (a
- * write to any one purges it). One case is the common form (its own values); zero cases, or any
- * case that leaves a field unbounded, → no pin for that field, and the caller falls back to the
- * bare collection tag. Cases arrive already dynamic-var-resolved (fetchPermissions →
- * processPermissions → parseFilter), exactly like the query filter `sanitizeQuery` resolved.
- */
-export function pinnedScopedCacheTagsFromCases(
-	collection: string,
-	fields: string[],
-	cases: Filter[] | undefined,
-	fieldTypes: Record<string, Type | undefined> = {},
-	relatedPrimaryKeys: Record<string, string> = {},
-): ScopedCacheTag[] {
-	if (!cases || cases.length === 0) {
-		return [];
-	}
-
-	const perCaseTags = cases.map((caseFilter) => {
-		return pinnedScopedCacheTagsFromFilter(
-			collection,
-			fields,
-			caseFilter,
-			fieldTypes,
-			relatedPrimaryKeys,
-		);
-	});
-
-	const tags: ScopedCacheTag[] = [];
-
-	for (const field of fields) {
-		// Sound only when every case bounds this field; else a row matching an unbounding case
-		// carries a value outside the union.
-		const boundedByEveryCase = perCaseTags.every((caseTags) => {
-			return caseTags.some((tag) => tag.field === field);
-		});
-
-		if (!boundedByEveryCase) {
-			continue;
-		}
-
-		// Union the field's values across cases, deduped on the canonical token (two cases may
-		// pin the same value).
-		const seen = new Set<string>();
-
-		for (const tag of perCaseTags.flat()) {
-			if (tag.field !== field) {
-				continue;
-			}
-
-			const token = canonicalScopedCacheValue(tag.value, tag.type);
-
-			if (seen.has(token)) {
-				continue;
-			}
-
-			seen.add(token);
-			tags.push(tag);
 		}
 	}
 

--- a/api/src/scoped-cache.ts
+++ b/api/src/scoped-cache.ts
@@ -399,3 +399,71 @@ export function pinnedScopedCacheTagsFromFilter(
 
 	return tags;
 }
+
+/**
+ * Pin root scope tags off the permission cases injected into the AST — the read side.
+ * `joinFilterWithCases` applies cases as `{ _or: cases }`, so a returned row matches AT LEAST one
+ * case. A scoped field can therefore be pinned only if EVERY case bounds it — otherwise a row
+ * matching an unbounding case carries an unpinned value and a write to that value would leave the
+ * read stale. When every case does bound it, the read is scoped to the UNION of their values (a
+ * write to any one purges it). One case is the common form (its own values); zero cases, or any
+ * case that leaves a field unbounded, → no pin for that field, and the caller falls back to the
+ * bare collection tag. Cases arrive already dynamic-var-resolved (fetchPermissions →
+ * processPermissions → parseFilter), exactly like the query filter `sanitizeQuery` resolved.
+ */
+export function pinnedScopedCacheTagsFromCases(
+	collection: string,
+	fields: string[],
+	cases: Filter[] | undefined,
+	fieldTypes: Record<string, Type | undefined> = {},
+	relatedPrimaryKeys: Record<string, string> = {},
+): ScopedCacheTag[] {
+	if (!cases || cases.length === 0) {
+		return [];
+	}
+
+	const perCaseTags = cases.map((caseFilter) => {
+		return pinnedScopedCacheTagsFromFilter(
+			collection,
+			fields,
+			caseFilter,
+			fieldTypes,
+			relatedPrimaryKeys,
+		);
+	});
+
+	const tags: ScopedCacheTag[] = [];
+
+	for (const field of fields) {
+		// Sound only when every case bounds this field; else a row matching an unbounding case
+		// carries a value outside the union.
+		const boundedByEveryCase = perCaseTags.every((caseTags) => {
+			return caseTags.some((tag) => tag.field === field);
+		});
+
+		if (!boundedByEveryCase) {
+			continue;
+		}
+
+		// Union the field's values across cases, deduped on the canonical token (two cases may
+		// pin the same value).
+		const seen = new Set<string>();
+
+		for (const tag of perCaseTags.flat()) {
+			if (tag.field !== field) {
+				continue;
+			}
+
+			const token = canonicalScopedCacheValue(tag.value, tag.type);
+
+			if (seen.has(token)) {
+				continue;
+			}
+
+			seen.add(token);
+			tags.push(tag);
+		}
+	}
+
+	return tags;
+}

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -10,6 +10,7 @@ import type {
 	Alterations,
 	Item as AnyItem,
 	EventContext,
+	Filter,
 	MutationTracker,
 	MutationOptions,
 	PrimaryKey,
@@ -26,7 +27,6 @@ import type { Knex } from 'knex';
 import { assign, clone, cloneDeep, isPlainObject, omit, pick, without } from 'lodash-es';
 import { getCache } from '../cache.js';
 import {
-	pinnedScopedCacheTagsFromCases,
 	pinnedScopedCacheTagsFromFilter,
 	purgeScopedCache,
 	scopedCacheTagsFromRows,
@@ -818,6 +818,17 @@ implements AbstractService<Item> {
 			// `$CURRENT_USER` is the concrete user id in each, matching what a write's row yields.
 			// The cases are what scope a permission-isolated read (the planner case) whose partition
 			// never appears in the query filter.
+			//
+			// `joinFilterWithCases` applies cases as `{ _or: cases }`: a SINGLE case AND-bounds the
+			// read like an `_eq`/`_in`, so it pins; 2+ cases are OR'd (a row need match only one) and
+			// don't bound, so they fall back to the bare collection tag. `null` → the pinner returns
+			// `[]`, same as an unpinnable filter.
+			let caseFilter: Filter | null = null;
+
+			if (ast.cases?.length === 1) {
+				caseFilter = ast.cases[0]!;
+			}
+
 			const rootScopedCacheTags = rootPaths.size > 1
 				? []
 				: [
@@ -828,10 +839,10 @@ implements AbstractService<Item> {
 						this.collectionScopedCacheFieldTypes,
 						this.collectionScopedCacheFieldRelatedPks,
 					),
-					...pinnedScopedCacheTagsFromCases(
+					...pinnedScopedCacheTagsFromFilter(
 						this.collection,
 						scopedCacheFields,
-						ast.cases,
+						caseFilter,
 						this.collectionScopedCacheFieldTypes,
 						this.collectionScopedCacheFieldRelatedPks,
 					),

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -813,13 +813,11 @@ implements AbstractService<Item> {
 			}
 
 			// Bound the root either by the API filter or by the permission cases injected into the
-			// AST. `updatedQuery.filter` already has dynamic vars resolved — sanitizeQuery (REST
-			// middleware + GraphQL parse-query) runs parseFilter before the service, so
-			// `$CURRENT_USER` is the concrete user id here, matching what a write's row yields.
-			// `ast.cases` instead carries the raw policy rule (`getCases` pushes it unmodified), so
-			// `pinnedScopedCacheTagsFromCases` resolves its `$CURRENT_USER` itself — this is what
-			// scopes a permission-isolated read (the planner case) whose partition never appears in
-			// the query filter.
+			// AST. Both are already dynamic-var-resolved before the service runs — the query filter
+			// by sanitizeQuery, the cases by fetchPermissions → processPermissions → parseFilter — so
+			// `$CURRENT_USER` is the concrete user id in each, matching what a write's row yields.
+			// The cases are what scope a permission-isolated read (the planner case) whose partition
+			// never appears in the query filter.
 			const rootScopedCacheTags = rootPaths.size > 1
 				? []
 				: [
@@ -834,7 +832,6 @@ implements AbstractService<Item> {
 						this.collection,
 						scopedCacheFields,
 						ast.cases,
-						this.accountability,
 						this.collectionScopedCacheFieldTypes,
 						this.collectionScopedCacheFieldRelatedPks,
 					),

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -26,6 +26,7 @@ import type { Knex } from 'knex';
 import { assign, clone, cloneDeep, isPlainObject, omit, pick, without } from 'lodash-es';
 import { getCache } from '../cache.js';
 import {
+	pinnedScopedCacheTagsFromCases,
 	pinnedScopedCacheTagsFromFilter,
 	purgeScopedCache,
 	scopedCacheTagsFromRows,
@@ -811,18 +812,33 @@ implements AbstractService<Item> {
 				}
 			}
 
-			// `updatedQuery.filter` already has dynamic vars resolved — sanitizeQuery
-			// (REST middleware + GraphQL parse-query) runs parseFilter before the service, so
+			// Bound the root either by the API filter or by the permission cases injected into the
+			// AST. `updatedQuery.filter` already has dynamic vars resolved — sanitizeQuery (REST
+			// middleware + GraphQL parse-query) runs parseFilter before the service, so
 			// `$CURRENT_USER` is the concrete user id here, matching what a write's row yields.
+			// `ast.cases` instead carries the raw policy rule (`getCases` pushes it unmodified), so
+			// `pinnedScopedCacheTagsFromCases` resolves its `$CURRENT_USER` itself — this is what
+			// scopes a permission-isolated read (the planner case) whose partition never appears in
+			// the query filter.
 			const rootScopedCacheTags = rootPaths.size > 1
 				? []
-				: pinnedScopedCacheTagsFromFilter(
-					this.collection,
-					scopedCacheFields,
-					updatedQuery.filter,
-					this.collectionScopedCacheFieldTypes,
-					this.collectionScopedCacheFieldRelatedPks,
-				);
+				: [
+					...pinnedScopedCacheTagsFromFilter(
+						this.collection,
+						scopedCacheFields,
+						updatedQuery.filter,
+						this.collectionScopedCacheFieldTypes,
+						this.collectionScopedCacheFieldRelatedPks,
+					),
+					...pinnedScopedCacheTagsFromCases(
+						this.collection,
+						scopedCacheFields,
+						ast.cases,
+						this.accountability,
+						this.collectionScopedCacheFieldTypes,
+						this.collectionScopedCacheFieldRelatedPks,
+					),
+				];
 
 			for (const collection of collectionsInFieldMap(fieldMap)) {
 				if (collection === this.collection && rootScopedCacheTags.length > 0) {

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -10,7 +10,6 @@ import type {
 	Alterations,
 	Item as AnyItem,
 	EventContext,
-	Filter,
 	MutationTracker,
 	MutationOptions,
 	PrimaryKey,
@@ -27,6 +26,7 @@ import type { Knex } from 'knex';
 import { assign, clone, cloneDeep, isPlainObject, omit, pick, without } from 'lodash-es';
 import { getCache } from '../cache.js';
 import {
+	pinnedScopedCacheTagsFromCases,
 	pinnedScopedCacheTagsFromFilter,
 	purgeScopedCache,
 	scopedCacheTagsFromRows,
@@ -817,18 +817,8 @@ implements AbstractService<Item> {
 			// by sanitizeQuery, the cases by fetchPermissions → processPermissions → parseFilter — so
 			// `$CURRENT_USER` is the concrete user id in each, matching what a write's row yields.
 			// The cases are what scope a permission-isolated read (the planner case) whose partition
-			// never appears in the query filter.
-			//
-			// `joinFilterWithCases` applies cases as `{ _or: cases }`: a SINGLE case AND-bounds the
-			// read like an `_eq`/`_in`, so it pins; 2+ cases are OR'd (a row need match only one) and
-			// don't bound, so they fall back to the bare collection tag. `null` → the pinner returns
-			// `[]`, same as an unpinnable filter.
-			let caseFilter: Filter | null = null;
-
-			if (ast.cases?.length === 1) {
-				caseFilter = ast.cases[0]!;
-			}
-
+			// never appears in the query filter (see `pinnedScopedCacheTagsFromCases` for the
+			// OR-of-cases union rule).
 			const rootScopedCacheTags = rootPaths.size > 1
 				? []
 				: [
@@ -839,10 +829,10 @@ implements AbstractService<Item> {
 						this.collectionScopedCacheFieldTypes,
 						this.collectionScopedCacheFieldRelatedPks,
 					),
-					...pinnedScopedCacheTagsFromFilter(
+					...pinnedScopedCacheTagsFromCases(
 						this.collection,
 						scopedCacheFields,
-						caseFilter,
+						ast.cases,
 						this.collectionScopedCacheFieldTypes,
 						this.collectionScopedCacheFieldRelatedPks,
 					),

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -26,7 +26,6 @@ import type { Knex } from 'knex';
 import { assign, clone, cloneDeep, isPlainObject, omit, pick, without } from 'lodash-es';
 import { getCache } from '../cache.js';
 import {
-	pinnedScopedCacheTagsFromCases,
 	pinnedScopedCacheTagsFromFilter,
 	purgeScopedCache,
 	scopedCacheTagsFromRows,
@@ -36,6 +35,9 @@ import { translateDatabaseError } from '../database/errors/translate.js';
 import { getAstFromQuery } from '../database/get-ast-from-query/get-ast-from-query.js';
 import { getHelpers } from '../database/helpers/index.js';
 import getDatabase from '../database/index.js';
+import {
+	joinFilterWithCases,
+} from '../database/run-ast/lib/apply-query/join-filter-with-cases.js';
 import { runAst } from '../database/run-ast/run-ast.js';
 import emitter from '../emitter.js';
 import { fieldMapFromAst } from '../permissions/modules/process-ast/lib/field-map-from-ast.js';
@@ -812,31 +814,22 @@ implements AbstractService<Item> {
 				}
 			}
 
-			// Bound the root either by the API filter or by the permission cases injected into the
-			// AST. Both are already dynamic-var-resolved before the service runs — the query filter
-			// by sanitizeQuery, the cases by fetchPermissions → processPermissions → parseFilter — so
-			// `$CURRENT_USER` is the concrete user id in each, matching what a write's row yields.
-			// The cases are what scope a permission-isolated read (the planner case) whose partition
-			// never appears in the query filter (see `pinnedScopedCacheTagsFromCases` for the
-			// OR-of-cases union rule).
+			// Scope off the read's EFFECTIVE bound = the API filter AND the permission cases,
+			// combined by the same `joinFilterWithCases` the SQL WHERE uses (`{ _and: [filter,
+			// { _or: cases }] }`) so the pin can't diverge from what the query actually returns. Both
+			// are already dynamic-var-resolved before the service runs — the filter by sanitizeQuery,
+			// the cases by fetchPermissions → processPermissions → parseFilter — so `$CURRENT_USER` is
+			// the concrete user id, matching what a write's row yields. The pinner unions an `_or`'s
+			// slices when every branch binds a field (the multi-policy case), else falls back to bare.
 			const rootScopedCacheTags = rootPaths.size > 1
 				? []
-				: [
-					...pinnedScopedCacheTagsFromFilter(
-						this.collection,
-						scopedCacheFields,
-						updatedQuery.filter,
-						this.collectionScopedCacheFieldTypes,
-						this.collectionScopedCacheFieldRelatedPks,
-					),
-					...pinnedScopedCacheTagsFromCases(
-						this.collection,
-						scopedCacheFields,
-						ast.cases,
-						this.collectionScopedCacheFieldTypes,
-						this.collectionScopedCacheFieldRelatedPks,
-					),
-				];
+				: pinnedScopedCacheTagsFromFilter(
+					this.collection,
+					scopedCacheFields,
+					joinFilterWithCases(updatedQuery.filter, ast.cases),
+					this.collectionScopedCacheFieldTypes,
+					this.collectionScopedCacheFieldRelatedPks,
+				);
 
 			for (const collection of collectionsInFieldMap(fieldMap)) {
 				if (collection === this.collection && rootScopedCacheTags.length > 0) {

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -820,7 +820,8 @@ implements AbstractService<Item> {
 			// are already dynamic-var-resolved before the service runs — the filter by sanitizeQuery,
 			// the cases by fetchPermissions → processPermissions → parseFilter — so `$CURRENT_USER` is
 			// the concrete user id, matching what a write's row yields. The pinner unions an `_or`'s
-			// slices when every branch binds a field (the multi-policy case), else falls back to bare.
+			// slices when every branch binds a pinnable field — same field or different ones (the
+			// multi-policy case) — else falls back to bare.
 			const rootScopedCacheTags = rootPaths.size > 1
 				? []
 				: pinnedScopedCacheTagsFromFilter(

--- a/api/src/services/scoped-cache-tags.test.ts
+++ b/api/src/services/scoped-cache-tags.test.ts
@@ -2,7 +2,6 @@ import { oneLine } from '@directus/utils';
 import { describe, expect, test } from 'vitest';
 import {
 	canonicalScopedCacheValue,
-	pinnedScopedCacheTagsFromCases,
 	pinnedScopedCacheTagsFromFilter,
 	scopedCacheTagsFromRows,
 } from '../scoped-cache.js';
@@ -234,9 +233,64 @@ describe('pinnedScopedCacheTagsFromFilter', () => {
 		]);
 	});
 
-	test('an _or branch does not bound the read, so nothing under it pins', () => {
+	test(oneLine`
+		an _or whose every branch binds the field pins the UNION of their values — a row
+		matches one branch, so its value is in the union
+	`, () => {
 		const filter = { _or: [{ student: { _eq: 'A' } }, { student: { _eq: 'B' } }] };
+
+		expect(pinnedScopedCacheTagsFromFilter('slots', ['student'], filter)).toEqual([
+			{ collection: 'slots', field: 'student', value: 'A' },
+			{ collection: 'slots', field: 'student', value: 'B' },
+		]);
+	});
+
+	test(oneLine`
+		an _or branch that leaves the field unbound drops the pin — a row matching that
+		branch carries a value outside the union
+	`, () => {
+		const filter = { _or: [{ student: { _eq: 'A' } }, { course: { _eq: 'math' } }] };
 		expect(pinnedScopedCacheTagsFromFilter('slots', ['student'], filter)).toEqual([]);
+	});
+
+	test('an _or unions the fk value for a relational branch', () => {
+		const filter = {
+			_or: [
+				{ owner: { id: { _eq: 'A' } } },
+				{ owner: { id: { _in: ['B', 'C'] } } },
+			],
+		};
+
+		expect(
+			pinnedScopedCacheTagsFromFilter('slots', ['owner'], filter, {}, { owner: 'id' }),
+		).toEqual([
+			{ collection: 'slots', field: 'owner', value: 'A' },
+			{ collection: 'slots', field: 'owner', value: 'B' },
+			{ collection: 'slots', field: 'owner', value: 'C' },
+		]);
+	});
+
+	test('a field bound by an outer _and AND every _or branch pins both sources', () => {
+		const filter = {
+			_and: [
+				{ course: { _eq: 'math' } },
+				{ _or: [{ student: { _eq: 'A' } }, { student: { _eq: 'B' } }] },
+			],
+		};
+
+		expect(
+			pinnedScopedCacheTagsFromFilter('slots', ['student', 'course'], filter),
+		).toEqual([
+			{ collection: 'slots', field: 'course', value: 'math' },
+			{ collection: 'slots', field: 'student', value: 'A' },
+			{ collection: 'slots', field: 'student', value: 'B' },
+		]);
+	});
+
+	test('an empty _or pins nothing', () => {
+		expect(
+			pinnedScopedCacheTagsFromFilter('slots', ['student'], { _or: [] }),
+		).toEqual([]);
 	});
 
 	test(oneLine`
@@ -397,105 +451,5 @@ describe('pinnedScopedCacheTagsFromFilter', () => {
 	test('empty / null filter yields no pin', () => {
 		expect(pinnedScopedCacheTagsFromFilter('slots', ['student'], null)).toEqual([]);
 		expect(pinnedScopedCacheTagsFromFilter('slots', ['student'], {})).toEqual([]);
-	});
-});
-
-describe('pinnedScopedCacheTagsFromCases', () => {
-	// Cases arrive already dynamic-var-resolved, so a policy's `$CURRENT_USER` is a concrete
-	// value here — mirrored below by plain literals.
-	test('a single case pins its values', () => {
-		expect(
-			pinnedScopedCacheTagsFromCases('slots', ['student'], [
-				{ student: { _in: ['A', 'B'] } },
-			]),
-		).toEqual([
-			{ collection: 'slots', field: 'student', value: 'A' },
-			{ collection: 'slots', field: 'student', value: 'B' },
-		]);
-	});
-
-	test(oneLine`
-		two cases both binding the same field pin the UNION of their values — a write to
-		either slice purges the read
-	`, () => {
-		expect(
-			pinnedScopedCacheTagsFromCases('slots', ['student'], [
-				{ student: { _eq: 'A' } },
-				{ student: { _eq: 'B' } },
-			]),
-		).toEqual([
-			{ collection: 'slots', field: 'student', value: 'A' },
-			{ collection: 'slots', field: 'student', value: 'B' },
-		]);
-	});
-
-	test('the union dedups a value pinned by more than one case', () => {
-		expect(
-			pinnedScopedCacheTagsFromCases('slots', ['student'], [
-				{ student: { _eq: 'A' } },
-				{ student: { _in: ['A', 'C'] } },
-			]),
-		).toEqual([
-			{ collection: 'slots', field: 'student', value: 'A' },
-			{ collection: 'slots', field: 'student', value: 'C' },
-		]);
-	});
-
-	test(oneLine`
-		a field left unbounded by ANY case is not pinned — a row matching that case carries a
-		value outside the union
-	`, () => {
-		expect(
-			pinnedScopedCacheTagsFromCases('slots', ['student'], [
-				{ student: { _eq: 'A' } },
-				{ course: { _eq: 'math' } },
-			]),
-		).toEqual([]);
-	});
-
-	test(oneLine`
-		cases binding DIFFERENT fields pin neither (each leaves the other unbound)
-	`, () => {
-		expect(
-			pinnedScopedCacheTagsFromCases('slots', ['student', 'course'], [
-				{ student: { _eq: 'A' } },
-				{ course: { _eq: 'math' } },
-			]),
-		).toEqual([]);
-	});
-
-	test('a field bounded by every case pins even when other fields differ', () => {
-		expect(
-			pinnedScopedCacheTagsFromCases('slots', ['student', 'course'], [
-				{ _and: [{ student: { _eq: 'A' } }, { course: { _eq: 'math' } }] },
-				{ student: { _eq: 'B' } },
-			]),
-		).toEqual([
-			{ collection: 'slots', field: 'student', value: 'A' },
-			{ collection: 'slots', field: 'student', value: 'B' },
-		]);
-	});
-
-	test('no cases yields no pin', () => {
-		expect(pinnedScopedCacheTagsFromCases('slots', ['student'], [])).toEqual([]);
-		expect(pinnedScopedCacheTagsFromCases('slots', ['student'], undefined)).toEqual([]);
-	});
-
-	test('relational cases union on the fk value', () => {
-		expect(
-			pinnedScopedCacheTagsFromCases(
-				'slots',
-				['user_created'],
-				[
-					{ user_created: { id: { _eq: 'A' } } },
-					{ user_created: { id: { _eq: 'B' } } },
-				],
-				{},
-				{ user_created: 'id' },
-			),
-		).toEqual([
-			{ collection: 'slots', field: 'user_created', value: 'A' },
-			{ collection: 'slots', field: 'user_created', value: 'B' },
-		]);
 	});
 });

--- a/api/src/services/scoped-cache-tags.test.ts
+++ b/api/src/services/scoped-cache-tags.test.ts
@@ -293,6 +293,38 @@ describe('pinnedScopedCacheTagsFromFilter', () => {
 		).toEqual([]);
 	});
 
+	test('an _or dedups a value bound by more than one branch', () => {
+		const filter = {
+			_or: [{ student: { _eq: 'A' } }, { student: { _in: ['A', 'B'] } }],
+		};
+
+		expect(pinnedScopedCacheTagsFromFilter('slots', ['student'], filter)).toEqual([
+			{ collection: 'slots', field: 'student', value: 'A' },
+			{ collection: 'slots', field: 'student', value: 'B' },
+		]);
+	});
+
+	test(oneLine`
+		_and binding the same field twice unions both values — the over-approximation of the
+		intersection (student=A AND student=B is empty, but a union over-purges, never stale)
+	`, () => {
+		const filter = { _and: [{ student: { _eq: 'A' } }, { student: { _eq: 'B' } }] };
+
+		expect(pinnedScopedCacheTagsFromFilter('slots', ['student'], filter)).toEqual([
+			{ collection: 'slots', field: 'student', value: 'A' },
+			{ collection: 'slots', field: 'student', value: 'B' },
+		]);
+	});
+
+	test(oneLine`
+		an empty _in bounds the field to no value, so nothing pins — the read stays bare (a
+		later insert of any value is caught by the bare collection tag)
+	`, () => {
+		expect(
+			pinnedScopedCacheTagsFromFilter('slots', ['student'], { student: { _in: [] } }),
+		).toEqual([]);
+	});
+
 	test(oneLine`
 		a date-ish scope field is not pin-safe (filter↔row canonical can diverge), so an _eq
 		on it yields no pin — the read falls back to the bare collection tag

--- a/api/src/services/scoped-cache-tags.test.ts
+++ b/api/src/services/scoped-cache-tags.test.ts
@@ -326,6 +326,37 @@ describe('pinnedScopedCacheTagsFromFilter', () => {
 	});
 
 	test(oneLine`
+		an _or whose branches bind DIFFERENT scope fields pins each — the read is purged if a
+		write touches either, since every branch covers its own rows
+	`, () => {
+		const filter = { _or: [{ student: { _eq: 'A' } }, { course: { _eq: 'math' } }] };
+
+		expect(
+			pinnedScopedCacheTagsFromFilter('slots', ['student', 'course'], filter),
+		).toEqual([
+			{ collection: 'slots', field: 'student', value: 'A' },
+			{ collection: 'slots', field: 'course', value: 'math' },
+		]);
+	});
+
+	test(oneLine`
+		an _or with one branch binding no pinnable field is bare even when the others bind
+		different scope fields — that branch's rows carry no pinned tag
+	`, () => {
+		const filter = {
+			_or: [
+				{ student: { _eq: 'A' } },
+				{ course: { _eq: 'math' } },
+				{ note: { _contains: 'x' } },
+			],
+		};
+
+		expect(
+			pinnedScopedCacheTagsFromFilter('slots', ['student', 'course'], filter),
+		).toEqual([]);
+	});
+
+	test(oneLine`
 		a date-ish scope field is not pin-safe (filter↔row canonical can diverge), so an _eq
 		on it yields no pin — the read falls back to the bare collection tag
 	`, () => {

--- a/api/src/services/scoped-cache-tags.test.ts
+++ b/api/src/services/scoped-cache-tags.test.ts
@@ -2,6 +2,7 @@ import { oneLine } from '@directus/utils';
 import { describe, expect, test } from 'vitest';
 import {
 	canonicalScopedCacheValue,
+	pinnedScopedCacheTagsFromCases,
 	pinnedScopedCacheTagsFromFilter,
 	scopedCacheTagsFromRows,
 } from '../scoped-cache.js';
@@ -396,5 +397,105 @@ describe('pinnedScopedCacheTagsFromFilter', () => {
 	test('empty / null filter yields no pin', () => {
 		expect(pinnedScopedCacheTagsFromFilter('slots', ['student'], null)).toEqual([]);
 		expect(pinnedScopedCacheTagsFromFilter('slots', ['student'], {})).toEqual([]);
+	});
+});
+
+describe('pinnedScopedCacheTagsFromCases', () => {
+	// Cases arrive already dynamic-var-resolved, so a policy's `$CURRENT_USER` is a concrete
+	// value here — mirrored below by plain literals.
+	test('a single case pins its values', () => {
+		expect(
+			pinnedScopedCacheTagsFromCases('slots', ['student'], [
+				{ student: { _in: ['A', 'B'] } },
+			]),
+		).toEqual([
+			{ collection: 'slots', field: 'student', value: 'A' },
+			{ collection: 'slots', field: 'student', value: 'B' },
+		]);
+	});
+
+	test(oneLine`
+		two cases both binding the same field pin the UNION of their values — a write to
+		either slice purges the read
+	`, () => {
+		expect(
+			pinnedScopedCacheTagsFromCases('slots', ['student'], [
+				{ student: { _eq: 'A' } },
+				{ student: { _eq: 'B' } },
+			]),
+		).toEqual([
+			{ collection: 'slots', field: 'student', value: 'A' },
+			{ collection: 'slots', field: 'student', value: 'B' },
+		]);
+	});
+
+	test('the union dedups a value pinned by more than one case', () => {
+		expect(
+			pinnedScopedCacheTagsFromCases('slots', ['student'], [
+				{ student: { _eq: 'A' } },
+				{ student: { _in: ['A', 'C'] } },
+			]),
+		).toEqual([
+			{ collection: 'slots', field: 'student', value: 'A' },
+			{ collection: 'slots', field: 'student', value: 'C' },
+		]);
+	});
+
+	test(oneLine`
+		a field left unbounded by ANY case is not pinned — a row matching that case carries a
+		value outside the union
+	`, () => {
+		expect(
+			pinnedScopedCacheTagsFromCases('slots', ['student'], [
+				{ student: { _eq: 'A' } },
+				{ course: { _eq: 'math' } },
+			]),
+		).toEqual([]);
+	});
+
+	test(oneLine`
+		cases binding DIFFERENT fields pin neither (each leaves the other unbound)
+	`, () => {
+		expect(
+			pinnedScopedCacheTagsFromCases('slots', ['student', 'course'], [
+				{ student: { _eq: 'A' } },
+				{ course: { _eq: 'math' } },
+			]),
+		).toEqual([]);
+	});
+
+	test('a field bounded by every case pins even when other fields differ', () => {
+		expect(
+			pinnedScopedCacheTagsFromCases('slots', ['student', 'course'], [
+				{ _and: [{ student: { _eq: 'A' } }, { course: { _eq: 'math' } }] },
+				{ student: { _eq: 'B' } },
+			]),
+		).toEqual([
+			{ collection: 'slots', field: 'student', value: 'A' },
+			{ collection: 'slots', field: 'student', value: 'B' },
+		]);
+	});
+
+	test('no cases yields no pin', () => {
+		expect(pinnedScopedCacheTagsFromCases('slots', ['student'], [])).toEqual([]);
+		expect(pinnedScopedCacheTagsFromCases('slots', ['student'], undefined)).toEqual([]);
+	});
+
+	test('relational cases union on the fk value', () => {
+		expect(
+			pinnedScopedCacheTagsFromCases(
+				'slots',
+				['user_created'],
+				[
+					{ user_created: { id: { _eq: 'A' } } },
+					{ user_created: { id: { _eq: 'B' } } },
+				],
+				{},
+				{ user_created: 'id' },
+			),
+		).toEqual([
+			{ collection: 'slots', field: 'user_created', value: 'A' },
+			{ collection: 'slots', field: 'user_created', value: 'B' },
+		]);
 	});
 });

--- a/api/src/services/scoped-cache-tags.test.ts
+++ b/api/src/services/scoped-cache-tags.test.ts
@@ -2,7 +2,6 @@ import { oneLine } from '@directus/utils';
 import { describe, expect, test } from 'vitest';
 import {
 	canonicalScopedCacheValue,
-	pinnedScopedCacheTagsFromCases,
 	pinnedScopedCacheTagsFromFilter,
 	scopedCacheTagsFromRows,
 } from '../scoped-cache.js';
@@ -397,84 +396,5 @@ describe('pinnedScopedCacheTagsFromFilter', () => {
 	test('empty / null filter yields no pin', () => {
 		expect(pinnedScopedCacheTagsFromFilter('slots', ['student'], null)).toEqual([]);
 		expect(pinnedScopedCacheTagsFromFilter('slots', ['student'], {})).toEqual([]);
-	});
-});
-
-describe('pinnedScopedCacheTagsFromCases', () => {
-	// Cases reach the pinner already dynamic-var-resolved (fetchPermissions →
-	// processPermissions → parseFilter), so a policy's `$CURRENT_USER` is the concrete
-	// user id here — mirrored below by a literal uuid.
-	const userId = '11111111-1111-1111-1111-111111111111';
-
-	test('a single case pins its value like a filter', () => {
-		expect(
-			pinnedScopedCacheTagsFromCases(
-				'slots',
-				['student'],
-				[{ student: { _eq: userId } }],
-			),
-		).toEqual([
-			{ collection: 'slots', field: 'student', value: userId },
-		]);
-	});
-
-	test(oneLine`
-		a relational case ({ user_created: { id: { _eq } } }) pins the fk value — the
-		planner's owner-scoping shape
-	`, () => {
-		expect(
-			pinnedScopedCacheTagsFromCases(
-				'slots',
-				['user_created'],
-				[{ user_created: { id: { _eq: userId } } }],
-				{},
-				{ user_created: 'id' },
-			),
-		).toEqual([
-			{ collection: 'slots', field: 'user_created', value: userId },
-		]);
-	});
-
-	test('multiple cases are OR-joined, so they do not bound the read (no pin)', () => {
-		expect(
-			pinnedScopedCacheTagsFromCases(
-				'slots',
-				['student'],
-				[{ student: { _eq: userId } }, { student: { _eq: 'shared' } }],
-			),
-		).toEqual([]);
-	});
-
-	test('no cases (unrestricted access) yields no pin', () => {
-		expect(
-			pinnedScopedCacheTagsFromCases('slots', ['student'], []),
-		).toEqual([]);
-
-		expect(
-			pinnedScopedCacheTagsFromCases('slots', ['student'], undefined),
-		).toEqual([]);
-	});
-
-	test('a non-equality case (_lte, e.g. a resolved $NOW) does not pin', () => {
-		expect(
-			pinnedScopedCacheTagsFromCases(
-				'slots',
-				['starts_at'],
-				[{ starts_at: { _lte: '2026-01-01T00:00:00Z' } }],
-			),
-		).toEqual([]);
-	});
-
-	test(oneLine`
-		a date-ish case field is still skipped (inherits the filter pinner guard)
-	`, () => {
-		expect(
-			pinnedScopedCacheTagsFromCases(
-				'slots',
-				['starts_at'],
-				[{ starts_at: { _eq: '2026-01-01T00:00:00Z' } }],
-				{ starts_at: 'dateTime' },
-			),
-		).toEqual([]);
 	});
 });

--- a/api/src/services/scoped-cache-tags.test.ts
+++ b/api/src/services/scoped-cache-tags.test.ts
@@ -406,7 +406,12 @@ describe('pinnedScopedCacheTagsFromCases', () => {
 
 	test('a single case with a concrete value pins it like a filter', () => {
 		expect(
-			pinnedScopedCacheTagsFromCases('slots', ['student'], [{ student: { _eq: 'A' } }], acc),
+			pinnedScopedCacheTagsFromCases(
+				'slots',
+				['student'],
+				[{ student: { _eq: 'A' } }],
+				acc,
+			),
 		).toEqual([
 			{ collection: 'slots', field: 'student', value: 'A' },
 		]);
@@ -438,7 +443,9 @@ describe('pinnedScopedCacheTagsFromCases', () => {
 		]);
 	});
 
-	test('$CURRENT_USER resolves to null under a null accountability (pins the null slice)', () => {
+	test(oneLine`
+		$CURRENT_USER resolves to null under a null accountability (pins the null slice)
+	`, () => {
 		expect(
 			pinnedScopedCacheTagsFromCases(
 				'slots',
@@ -452,8 +459,8 @@ describe('pinnedScopedCacheTagsFromCases', () => {
 	});
 
 	test(oneLine`
-		a relational case ({ user_created: { id: { _eq: $CURRENT_USER } } }) pins the resolved fk
-		value — the planner's owner-scoping shape
+		a relational case ({ user_created: { id: { _eq: $CURRENT_USER } } }) pins the
+		resolved fk value — the planner's owner-scoping shape
 	`, () => {
 		expect(
 			pinnedScopedCacheTagsFromCases(
@@ -470,8 +477,8 @@ describe('pinnedScopedCacheTagsFromCases', () => {
 	});
 
 	test(oneLine`
-		an unresolvable dynamic var ($CURRENT_USER.field, $CURRENT_ROLES, $NOW) drops the field so
-		the read falls back to the bare collection tag
+		an unresolvable dynamic var ($CURRENT_USER.field, $CURRENT_ROLES, $NOW) drops the
+		field so the read falls back to the bare collection tag
 	`, () => {
 		for (const dynamic of ['$CURRENT_USER.email', '$CURRENT_ROLES', '$NOW']) {
 			expect(
@@ -485,7 +492,9 @@ describe('pinnedScopedCacheTagsFromCases', () => {
 		}
 	});
 
-	test('an _in mixing a concrete value with an unresolvable var skips the whole field', () => {
+	test(oneLine`
+		an _in mixing a concrete value with an unresolvable var skips the whole field
+	`, () => {
 		expect(
 			pinnedScopedCacheTagsFromCases(
 				'slots',
@@ -508,11 +517,18 @@ describe('pinnedScopedCacheTagsFromCases', () => {
 	});
 
 	test('no cases (unrestricted access) yields no pin', () => {
-		expect(pinnedScopedCacheTagsFromCases('slots', ['student'], [], acc)).toEqual([]);
-		expect(pinnedScopedCacheTagsFromCases('slots', ['student'], undefined, acc)).toEqual([]);
+		expect(
+			pinnedScopedCacheTagsFromCases('slots', ['student'], [], acc),
+		).toEqual([]);
+
+		expect(
+			pinnedScopedCacheTagsFromCases('slots', ['student'], undefined, acc),
+		).toEqual([]);
 	});
 
-	test('a date-ish case field is still skipped (inherits the filter pinner guard)', () => {
+	test(oneLine`
+		a date-ish case field is still skipped (inherits the filter pinner guard)
+	`, () => {
 		expect(
 			pinnedScopedCacheTagsFromCases(
 				'slots',

--- a/api/src/services/scoped-cache-tags.test.ts
+++ b/api/src/services/scoped-cache-tags.test.ts
@@ -1,6 +1,5 @@
 import { oneLine } from '@directus/utils';
 import { describe, expect, test } from 'vitest';
-import type { Accountability } from '@directus/types';
 import {
 	canonicalScopedCacheValue,
 	pinnedScopedCacheTagsFromCases,
@@ -402,107 +401,38 @@ describe('pinnedScopedCacheTagsFromFilter', () => {
 });
 
 describe('pinnedScopedCacheTagsFromCases', () => {
-	const acc = { user: 'user-1', role: 'role-1' } as unknown as Accountability;
+	// Cases reach the pinner already dynamic-var-resolved (fetchPermissions →
+	// processPermissions → parseFilter), so a policy's `$CURRENT_USER` is the concrete
+	// user id here — mirrored below by a literal uuid.
+	const userId = '11111111-1111-1111-1111-111111111111';
 
-	test('a single case with a concrete value pins it like a filter', () => {
+	test('a single case pins its value like a filter', () => {
 		expect(
 			pinnedScopedCacheTagsFromCases(
 				'slots',
 				['student'],
-				[{ student: { _eq: 'A' } }],
-				acc,
+				[{ student: { _eq: userId } }],
 			),
 		).toEqual([
-			{ collection: 'slots', field: 'student', value: 'A' },
-		]);
-	});
-
-	test('$CURRENT_USER in a case resolves to accountability.user', () => {
-		expect(
-			pinnedScopedCacheTagsFromCases(
-				'slots',
-				['student'],
-				[{ student: { _eq: '$CURRENT_USER' } }],
-				acc,
-			),
-		).toEqual([
-			{ collection: 'slots', field: 'student', value: 'user-1' },
-		]);
-	});
-
-	test('$CURRENT_ROLE in a case resolves to accountability.role', () => {
-		expect(
-			pinnedScopedCacheTagsFromCases(
-				'slots',
-				['owner_role'],
-				[{ owner_role: { _eq: '$CURRENT_ROLE' } }],
-				acc,
-			),
-		).toEqual([
-			{ collection: 'slots', field: 'owner_role', value: 'role-1' },
+			{ collection: 'slots', field: 'student', value: userId },
 		]);
 	});
 
 	test(oneLine`
-		$CURRENT_USER resolves to null under a null accountability (pins the null slice)
-	`, () => {
-		expect(
-			pinnedScopedCacheTagsFromCases(
-				'slots',
-				['student'],
-				[{ student: { _eq: '$CURRENT_USER' } }],
-				null,
-			),
-		).toEqual([
-			{ collection: 'slots', field: 'student', value: null },
-		]);
-	});
-
-	test(oneLine`
-		a relational case ({ user_created: { id: { _eq: $CURRENT_USER } } }) pins the
-		resolved fk value — the planner's owner-scoping shape
+		a relational case ({ user_created: { id: { _eq } } }) pins the fk value — the
+		planner's owner-scoping shape
 	`, () => {
 		expect(
 			pinnedScopedCacheTagsFromCases(
 				'slots',
 				['user_created'],
-				[{ user_created: { id: { _eq: '$CURRENT_USER' } } }],
-				acc,
+				[{ user_created: { id: { _eq: userId } } }],
 				{},
 				{ user_created: 'id' },
 			),
 		).toEqual([
-			{ collection: 'slots', field: 'user_created', value: 'user-1' },
+			{ collection: 'slots', field: 'user_created', value: userId },
 		]);
-	});
-
-	test(oneLine`
-		an unresolvable dynamic var ($CURRENT_USER.field, $CURRENT_ROLES, $NOW) drops the
-		field so the read falls back to the bare collection tag
-	`, () => {
-		for (const dynamic of ['$CURRENT_USER.email', '$CURRENT_ROLES', '$NOW']) {
-			expect(
-				pinnedScopedCacheTagsFromCases(
-					'slots',
-					['student'],
-					[{ student: { _eq: dynamic } }],
-					acc,
-				),
-			).toEqual([]);
-		}
-	});
-
-	test(oneLine`
-		an _in mixing a concrete value with an unresolvable var skips the whole field
-	`, () => {
-		expect(
-			pinnedScopedCacheTagsFromCases(
-				'slots',
-				['student'],
-				[{ student: { _in: ['A', '$CURRENT_ROLES'] } }],
-				acc,
-			),
-		).toEqual([]);
 	});
 
 	test('multiple cases are OR-joined, so they do not bound the read (no pin)', () => {
@@ -510,19 +440,28 @@ describe('pinnedScopedCacheTagsFromCases', () => {
 			pinnedScopedCacheTagsFromCases(
 				'slots',
 				['student'],
-				[{ student: { _eq: '$CURRENT_USER' } }, { student: { _eq: 'shared' } }],
-				acc,
+				[{ student: { _eq: userId } }, { student: { _eq: 'shared' } }],
 			),
 		).toEqual([]);
 	});
 
 	test('no cases (unrestricted access) yields no pin', () => {
 		expect(
-			pinnedScopedCacheTagsFromCases('slots', ['student'], [], acc),
+			pinnedScopedCacheTagsFromCases('slots', ['student'], []),
 		).toEqual([]);
 
 		expect(
-			pinnedScopedCacheTagsFromCases('slots', ['student'], undefined, acc),
+			pinnedScopedCacheTagsFromCases('slots', ['student'], undefined),
+		).toEqual([]);
+	});
+
+	test('a non-equality case (_lte, e.g. a resolved $NOW) does not pin', () => {
+		expect(
+			pinnedScopedCacheTagsFromCases(
+				'slots',
+				['starts_at'],
+				[{ starts_at: { _lte: '2026-01-01T00:00:00Z' } }],
+			),
 		).toEqual([]);
 	});
 
@@ -534,7 +473,6 @@ describe('pinnedScopedCacheTagsFromCases', () => {
 				'slots',
 				['starts_at'],
 				[{ starts_at: { _eq: '2026-01-01T00:00:00Z' } }],
-				acc,
 				{ starts_at: 'dateTime' },
 			),
 		).toEqual([]);

--- a/api/src/services/scoped-cache-tags.test.ts
+++ b/api/src/services/scoped-cache-tags.test.ts
@@ -1,7 +1,9 @@
 import { oneLine } from '@directus/utils';
 import { describe, expect, test } from 'vitest';
+import type { Accountability } from '@directus/types';
 import {
 	canonicalScopedCacheValue,
+	pinnedScopedCacheTagsFromCases,
 	pinnedScopedCacheTagsFromFilter,
 	scopedCacheTagsFromRows,
 } from '../scoped-cache.js';
@@ -396,5 +398,129 @@ describe('pinnedScopedCacheTagsFromFilter', () => {
 	test('empty / null filter yields no pin', () => {
 		expect(pinnedScopedCacheTagsFromFilter('slots', ['student'], null)).toEqual([]);
 		expect(pinnedScopedCacheTagsFromFilter('slots', ['student'], {})).toEqual([]);
+	});
+});
+
+describe('pinnedScopedCacheTagsFromCases', () => {
+	const acc = { user: 'user-1', role: 'role-1' } as unknown as Accountability;
+
+	test('a single case with a concrete value pins it like a filter', () => {
+		expect(
+			pinnedScopedCacheTagsFromCases('slots', ['student'], [{ student: { _eq: 'A' } }], acc),
+		).toEqual([
+			{ collection: 'slots', field: 'student', value: 'A' },
+		]);
+	});
+
+	test('$CURRENT_USER in a case resolves to accountability.user', () => {
+		expect(
+			pinnedScopedCacheTagsFromCases(
+				'slots',
+				['student'],
+				[{ student: { _eq: '$CURRENT_USER' } }],
+				acc,
+			),
+		).toEqual([
+			{ collection: 'slots', field: 'student', value: 'user-1' },
+		]);
+	});
+
+	test('$CURRENT_ROLE in a case resolves to accountability.role', () => {
+		expect(
+			pinnedScopedCacheTagsFromCases(
+				'slots',
+				['owner_role'],
+				[{ owner_role: { _eq: '$CURRENT_ROLE' } }],
+				acc,
+			),
+		).toEqual([
+			{ collection: 'slots', field: 'owner_role', value: 'role-1' },
+		]);
+	});
+
+	test('$CURRENT_USER resolves to null under a null accountability (pins the null slice)', () => {
+		expect(
+			pinnedScopedCacheTagsFromCases(
+				'slots',
+				['student'],
+				[{ student: { _eq: '$CURRENT_USER' } }],
+				null,
+			),
+		).toEqual([
+			{ collection: 'slots', field: 'student', value: null },
+		]);
+	});
+
+	test(oneLine`
+		a relational case ({ user_created: { id: { _eq: $CURRENT_USER } } }) pins the resolved fk
+		value — the planner's owner-scoping shape
+	`, () => {
+		expect(
+			pinnedScopedCacheTagsFromCases(
+				'slots',
+				['user_created'],
+				[{ user_created: { id: { _eq: '$CURRENT_USER' } } }],
+				acc,
+				{},
+				{ user_created: 'id' },
+			),
+		).toEqual([
+			{ collection: 'slots', field: 'user_created', value: 'user-1' },
+		]);
+	});
+
+	test(oneLine`
+		an unresolvable dynamic var ($CURRENT_USER.field, $CURRENT_ROLES, $NOW) drops the field so
+		the read falls back to the bare collection tag
+	`, () => {
+		for (const dynamic of ['$CURRENT_USER.email', '$CURRENT_ROLES', '$NOW']) {
+			expect(
+				pinnedScopedCacheTagsFromCases(
+					'slots',
+					['student'],
+					[{ student: { _eq: dynamic } }],
+					acc,
+				),
+			).toEqual([]);
+		}
+	});
+
+	test('an _in mixing a concrete value with an unresolvable var skips the whole field', () => {
+		expect(
+			pinnedScopedCacheTagsFromCases(
+				'slots',
+				['student'],
+				[{ student: { _in: ['A', '$CURRENT_ROLES'] } }],
+				acc,
+			),
+		).toEqual([]);
+	});
+
+	test('multiple cases are OR-joined, so they do not bound the read (no pin)', () => {
+		expect(
+			pinnedScopedCacheTagsFromCases(
+				'slots',
+				['student'],
+				[{ student: { _eq: '$CURRENT_USER' } }, { student: { _eq: 'shared' } }],
+				acc,
+			),
+		).toEqual([]);
+	});
+
+	test('no cases (unrestricted access) yields no pin', () => {
+		expect(pinnedScopedCacheTagsFromCases('slots', ['student'], [], acc)).toEqual([]);
+		expect(pinnedScopedCacheTagsFromCases('slots', ['student'], undefined, acc)).toEqual([]);
+	});
+
+	test('a date-ish case field is still skipped (inherits the filter pinner guard)', () => {
+		expect(
+			pinnedScopedCacheTagsFromCases(
+				'slots',
+				['starts_at'],
+				[{ starts_at: { _eq: '2026-01-01T00:00:00Z' } }],
+				acc,
+				{ starts_at: 'dateTime' },
+			),
+		).toEqual([]);
 	});
 });

--- a/tests/blackbox/tests/db/app/cache.seed.ts
+++ b/tests/blackbox/tests/db/app/cache.seed.ts
@@ -41,6 +41,12 @@ export const scopedOwnerB = 'owner-b';
 // slice leaves this read cached. Owners + items are seeded per-test (ids needed).
 export const collectionScopedRel = 'test_app_cache_scoped_rel';
 
+// A collection scoped by TWO scalar fields: scoped_cache_fields = ['field_a', 'field_b'].
+// Exercises the multi-field `_or` union — a case set (or query `_or`) whose branches bind
+// DIFFERENT scope fields pins each, so a write touching either field's slice purges the read
+// while a write touching neither spares it. Rows are created per-test.
+export const collectionScopedMulti = 'test_app_cache_scoped_multi';
+
 const junctionTag = 'test_app_cache_first_tag';
 const junctionBlock = 'test_app_cache_first_block';
 
@@ -65,6 +71,7 @@ export const seedDBStructure = () => {
 				await DeleteCollection(vendor, { collection: junctionTag });
 				await DeleteCollection(vendor, { collection: junctionBlock });
 				await DeleteCollection(vendor, { collection: collectionScopedRel });
+				await DeleteCollection(vendor, { collection: collectionScopedMulti });
 				await DeleteCollection(vendor, { collection: collectionScoped });
 				await DeleteCollection(vendor, { collection: collectionIgnored });
 				await DeleteCollection(vendor, { collection: collectionGrandChild });
@@ -236,6 +243,24 @@ export const seedDBStructure = () => {
 					collection: collectionScopedRel,
 					field: 'owner_ref',
 					otherCollection: collectionGrandRelated,
+				});
+
+				// Two-scope-field collection: partition by both `field_a` and `field_b`.
+				await CreateCollection(vendor, {
+					collection: collectionScopedMulti,
+					meta: { scoped_cache_fields: ['field_a', 'field_b'] },
+				});
+
+				await CreateField(vendor, {
+					collection: collectionScopedMulti,
+					field: 'field_a',
+					type: 'string',
+				});
+
+				await CreateField(vendor, {
+					collection: collectionScopedMulti,
+					field: 'field_b',
+					type: 'string',
 				});
 
 				expect(true).toBeTruthy();

--- a/tests/blackbox/tests/db/app/cache.test.ts
+++ b/tests/blackbox/tests/db/app/cache.test.ts
@@ -1188,9 +1188,10 @@ describe('App Caching Tests', () => {
 	`, () => {
 		// The planner case: a student lists /items/slots with no filter, but a policy restricts
 		// them to `owner_field = $CURRENT_USER`. That predicate lives in the permission rule,
-		// injected as `ast.cases`, not in the query — so `pinnedScopedCacheTagsFromCases` is what
-		// scopes the read. Without it the read falls back to the bare collection tag and any other
-		// user's write purges it (the over-purge this fixes). The "spared" witness below is the
+		// injected as `ast.cases`, not in the query — so the pin off
+		// `joinFilterWithCases(filter, cases)` (its `{ _or: cases }`) scopes the read.
+		// Without it the read falls back to the bare collection tag and any other user's
+		// write purges it (the over-purge this fixes). The "spared" witness below is the
 		// proof it's value-scoped and not bare.
 		it.each(vendors)('%s', async (vendor) => {
 			const env = envs[vendor].envRedisScopedPurge;
@@ -1782,6 +1783,124 @@ describe('App Caching Tests', () => {
 			expect(afterA.headers[cacheStatusHeader]).toBe('HIT');
 			expect(afterB.statusCode).toBe(200);
 			expect(afterB.headers[cacheStatusHeader]).toBe('MISS');
+		});
+	});
+
+	describe(oneLine`
+		A permission case whose rule is RELATIONAL (owner_ref.id _eq, the partition on a related
+		pk, not a scalar) still value-scopes the read: a write to the pinned owner's slice purges
+		it, a write to another owner's slice spares it
+	`, () => {
+		// The `{ user_created: { id: { _eq: $CURRENT_USER } } }` shape — the dominant
+		// real pattern — routed through a policy, not the query. The case reaches the
+		// fk value through the related pk, so the pinner's relational unwrap has to fire
+		// on a case (an `_or` branch via joinFilterWithCases), not just on a query
+		// filter. The query-side relational pin is proven above; this proves the same
+		// unwrap through ast.cases. A concrete related pk (not $CURRENT_USER — its
+		// resolution is a separate guard) keeps this focused on the relational case path.
+		// Without the unwrap the read would pin nothing → bare → the spare witness fails.
+		it.each(vendors)('%s', async (vendor) => {
+			const env = envs[vendor].envRedisScopedPurge;
+			const url = getUrl(vendor, env);
+			const admin = `Bearer ${USER.ADMIN.TOKEN}`;
+
+			const createOwner = async () => {
+				return (
+					await request(url).post(`/items/${collectionGrandRelated}`)
+						.send({ string_field: randomUUID() })
+						.set('Authorization', admin)
+				).body.data.id;
+			};
+
+			const addItem = async (owner: number) => {
+				await request(url).post(`/items/${collectionScopedRel}`)
+					.send({ string_field: randomUUID(), owner_ref: owner })
+					.set('Authorization', admin);
+			};
+
+			// Two related owners; the policy pins the read to ownerA's slice.
+			const ownerA = await createOwner();
+			const ownerB = await createOwner();
+
+			const suffix = randomUUID();
+
+			const role = (
+				await request(url).post('/roles')
+					.send({ name: `cache-case-rel-${suffix}` })
+					.set('Authorization', admin)
+			).body.data;
+
+			const policy = (
+				await request(url).post('/policies')
+					.send({
+						name: `cache-case-rel-${suffix}`,
+						app_access: true,
+						admin_access: false,
+						roles: [{ role: role.id }],
+					})
+					.set('Authorization', admin)
+			).body.data;
+
+			await request(url).post('/permissions')
+				.send({
+					policy: policy.id,
+					collection: collectionScopedRel,
+					action: 'read',
+					fields: ['*'],
+					permissions: { owner_ref: { id: { _eq: ownerA } } },
+				})
+				.set('Authorization', admin);
+
+			const token = `cache-case-rel-${suffix}`;
+
+			await request(url).post('/users')
+				.send({
+					email: `cache-case-rel-${suffix}@example.com`,
+					password: randomUUID(),
+					role: role.id,
+					token,
+					status: 'active',
+				})
+				.set('Authorization', admin);
+
+			const auth = `Bearer ${token}`;
+
+			// A row in the pinned slice so the read has data + a scope value.
+			await addItem(ownerA);
+
+			// No filter — the owner_ref bound comes only from the relational policy case.
+			const read = `/items/${collectionScopedRel}`;
+
+			await request(url).post(`/utils/cache/clear`)
+				.set('Authorization', admin);
+
+			await request(url).get(read)
+				.set('Authorization', auth); // cold → cached, pinned to owner_ref=<ownerA>
+
+			const warm = await request(url).get(read)
+				.set('Authorization', auth);
+
+			expect(warm.statusCode).toBe(200);
+			expect(warm.headers[cacheStatusHeader]).toBe('HIT');
+
+			// A write in ANOTHER owner's slice. A bare-tagged read would MISS; the
+			// relational case pin to <ownerA> spares it.
+			await addItem(ownerB);
+
+			const afterOther = await request(url).get(read)
+				.set('Authorization', auth);
+
+			expect(afterOther.statusCode).toBe(200);
+			expect(afterOther.headers[cacheStatusHeader]).toBe('HIT');
+
+			// A write in the pinned slice (owner_ref=<ownerA>) purges the read.
+			await addItem(ownerA);
+
+			const afterMine = await request(url).get(read)
+				.set('Authorization', auth);
+
+			expect(afterMine.statusCode).toBe(200);
+			expect(afterMine.headers[cacheStatusHeader]).toBe('MISS');
 		});
 	});
 });

--- a/tests/blackbox/tests/db/app/cache.test.ts
+++ b/tests/blackbox/tests/db/app/cache.test.ts
@@ -1344,6 +1344,103 @@ describe('App Caching Tests', () => {
 	});
 
 	describe(oneLine`
+		Two permission cases (OR-joined) do NOT bound the read — it falls back to the bare
+		collection tag, so a write to ANY owner's slice purges it
+	`, () => {
+		// The single-case soundness gate: joinFilterWithCases applies cases as { _or: cases },
+		// so 2 rules mean a row need match only one — the read is not bounded to owner=me and
+		// must be bare. If the gate regressed to pinning cases[0] (owner=me), a write to
+		// another owner would wrongly spare this read. Two policies on the role = two cases.
+		it.each(vendors)('%s', async (vendor) => {
+			const env = envs[vendor].envRedisScopedPurge;
+			const url = getUrl(vendor, env);
+			const admin = `Bearer ${USER.ADMIN.TOKEN}`;
+
+			const suffix = randomUUID();
+
+			const role = (
+				await request(url).post('/roles')
+					.send({ name: `cache-multicase-${suffix}` })
+					.set('Authorization', admin)
+			).body.data;
+
+			// Two policies, each a read permission on collectionScoped with a DISTINCT rule, so
+			// getCases yields two cases (OR-joined) rather than one bounding predicate.
+			for (const rule of [
+				{ owner_field: { _eq: '$CURRENT_USER' } },
+				{ string_field: { _nnull: true } },
+			]) {
+				const policy = (
+					await request(url).post('/policies')
+						.send({
+							name: `cache-multicase-${suffix}-${randomUUID()}`,
+							app_access: true,
+							admin_access: false,
+							roles: [{ role: role.id }],
+						})
+						.set('Authorization', admin)
+				).body.data;
+
+				await request(url).post('/permissions')
+					.send({
+						policy: policy.id,
+						collection: collectionScoped,
+						action: 'read',
+						fields: ['*'],
+						permissions: rule,
+					})
+					.set('Authorization', admin);
+			}
+
+			const token = `cache-multicase-${suffix}`;
+
+			const me = (
+				await request(url).post('/users')
+					.send({
+						email: `cache-multicase-${suffix}@example.com`,
+						password: randomUUID(),
+						role: role.id,
+						token,
+						status: 'active',
+					})
+					.set('Authorization', admin)
+			).body.data;
+
+			const auth = `Bearer ${token}`;
+
+			await request(url).post(`/items/${collectionScoped}`)
+				.send({ string_field: randomUUID(), owner_field: me.id })
+				.set('Authorization', admin);
+
+			const read = `/items/${collectionScoped}`;
+
+			await request(url).post(`/utils/cache/clear`)
+				.set('Authorization', admin);
+
+			await request(url).get(read)
+				.set('Authorization', auth); // cold → cached, bare (two OR'd cases)
+
+			const warm = await request(url).get(read)
+				.set('Authorization', auth);
+
+			expect(warm.statusCode).toBe(200);
+			expect(warm.headers[cacheStatusHeader]).toBe('HIT');
+
+			// Write in ANOTHER owner's slice. A bare-tagged read MISSes here; a wrongly
+			// owner=me-pinned read would survive.
+			await request(url).post(`/items/${collectionScoped}`)
+				.send({ string_field: randomUUID(), owner_field: scopedOwnerB })
+				.set('Authorization', admin);
+
+			const after = await request(url).get(read)
+				.set('Authorization', auth);
+
+			expect(after.statusCode).toBe(200);
+			expect(after.headers[cacheStatusHeader]).toBe('MISS');
+		});
+	});
+
+	describe(oneLine`
 		Scoped purge pins a slice read filtered by a relation's primary key — a write to
 		one owner's slice leaves another owner's cached read intact (the relational pin)
 	`, () => {

--- a/tests/blackbox/tests/db/app/cache.test.ts
+++ b/tests/blackbox/tests/db/app/cache.test.ts
@@ -791,6 +791,58 @@ describe('App Caching Tests', () => {
 	});
 
 	describe(oneLine`
+		An _or query filter binding the owner in every branch pins the UNION of the slices —
+		a write to either owner purges the read, an owner outside the union spares it
+	`, () => {
+		it.each(vendors)('%s', async (vendor) => {
+			const env = envs[vendor].envRedisScopedPurge;
+			const url = getUrl(vendor, env);
+			const auth = `Bearer ${USER.ADMIN.TOKEN}`;
+
+			const read = `/items/${collectionScoped}`
+				+ `?filter[_or][0][owner_field][_eq]=${scopedOwnerA}`
+				+ `&filter[_or][1][owner_field][_eq]=${scopedOwnerB}`;
+
+			const outsideOwner = randomUUID(); // a third owner, outside { A, B }
+
+			const warmUp = async () => {
+				await request(url).post(`/utils/cache/clear`)
+					.set('Authorization', auth);
+
+				await request(url).get(read)
+					.set('Authorization', auth); // cold → cached, pinned to { A, B }
+
+				const warm = await request(url).get(read)
+					.set('Authorization', auth);
+
+				expect(warm.headers[cacheStatusHeader]).toBe('HIT');
+			};
+
+			const writeOwner = async (owner: string) => {
+				await request(url).post(`/items/${collectionScoped}`)
+					.send({ string_field: randomUUID(), owner_field: owner })
+					.set('Authorization', auth);
+
+				return request(url).get(read)
+					.set('Authorization', auth);
+			};
+
+			// An owner outside the union spares the read — the union pin, not bare.
+			await warmUp();
+			const afterOutside = await writeOwner(outsideOwner);
+			expect(afterOutside.statusCode).toBe(200);
+			expect(afterOutside.headers[cacheStatusHeader]).toBe('HIT');
+
+			// Each union member purges it.
+			await warmUp();
+			expect((await writeOwner(scopedOwnerA)).headers[cacheStatusHeader]).toBe('MISS');
+
+			await warmUp();
+			expect((await writeOwner(scopedOwnerB)).headers[cacheStatusHeader]).toBe('MISS');
+		});
+	});
+
+	describe(oneLine`
 		Value-scoped self-referential read is not owner-pinned — a write to another
 		owner still invalidates it (the nested same-collection rows are unbounded)
 	`, () => {

--- a/tests/blackbox/tests/db/app/cache.test.ts
+++ b/tests/blackbox/tests/db/app/cache.test.ts
@@ -1148,6 +1148,7 @@ describe('App Caching Tests', () => {
 			// A policy that scopes reads of collectionScoped to the caller's own rows, plus a role
 			// carrying it and a static-token user to read as. Unique names per run avoid collisions.
 			const suffix = randomUUID();
+
 			const role = (
 				await request(url).post('/roles')
 					.send({ name: `cache-case-scope-${suffix}` })

--- a/tests/blackbox/tests/db/app/cache.test.ts
+++ b/tests/blackbox/tests/db/app/cache.test.ts
@@ -1547,6 +1547,124 @@ describe('App Caching Tests', () => {
 	});
 
 	describe(oneLine`
+		Two cases that both bind the owner field pin the UNION of their slices — a write to
+		either owner purges the read, a write to an owner outside the union spares it
+	`, () => {
+		// The multi-policy planner case: a student sees their own rows AND a shared bucket, via
+		// two read policies both scoping owner_field. Each case binds owner_field, so the read
+		// is soundly pinned to { <me.id>, 'shared-bucket' } rather than falling back to bare —
+		// more precise than a collection-wide flush. An unrelated owner's write must spare it.
+		const sharedBucket = 'shared-bucket';
+
+		it.each(vendors)('%s', async (vendor) => {
+			const env = envs[vendor].envRedisScopedPurge;
+			const url = getUrl(vendor, env);
+			const admin = `Bearer ${USER.ADMIN.TOKEN}`;
+
+			const suffix = randomUUID();
+
+			const role = (
+				await request(url).post('/roles')
+					.send({ name: `cache-union-${suffix}` })
+					.set('Authorization', admin)
+			).body.data;
+
+			// Two policies, each binding owner_field: one to the caller, one to a shared bucket.
+			for (const rule of [
+				{ owner_field: { _eq: '$CURRENT_USER' } },
+				{ owner_field: { _eq: sharedBucket } },
+			]) {
+				const policy = (
+					await request(url).post('/policies')
+						.send({
+							name: `cache-union-${suffix}-${randomUUID()}`,
+							app_access: true,
+							admin_access: false,
+							roles: [{ role: role.id }],
+						})
+						.set('Authorization', admin)
+				).body.data;
+
+				await request(url).post('/permissions')
+					.send({
+						policy: policy.id,
+						collection: collectionScoped,
+						action: 'read',
+						fields: ['*'],
+						permissions: rule,
+					})
+					.set('Authorization', admin);
+			}
+
+			const token = `cache-union-${suffix}`;
+
+			const me = (
+				await request(url).post('/users')
+					.send({
+						email: `cache-union-${suffix}@example.com`,
+						password: randomUUID(),
+						role: role.id,
+						token,
+						status: 'active',
+					})
+					.set('Authorization', admin)
+			).body.data;
+
+			const auth = `Bearer ${token}`;
+
+			// A row in each union slice, so the read has data on both sides.
+			for (const owner of [me.id, sharedBucket]) {
+				await request(url).post(`/items/${collectionScoped}`)
+					.send({ string_field: randomUUID(), owner_field: owner })
+					.set('Authorization', admin);
+			}
+
+			const read = `/items/${collectionScoped}`;
+
+			const warmUp = async () => {
+				await request(url).post(`/utils/cache/clear`)
+					.set('Authorization', admin);
+
+				await request(url).get(read)
+					.set('Authorization', auth); // cold → cached, pinned to the union
+
+				const warm = await request(url).get(read)
+					.set('Authorization', auth);
+
+				expect(warm.statusCode).toBe(200);
+				expect(warm.headers[cacheStatusHeader]).toBe('HIT');
+			};
+
+			const writeOwner = async (owner: string) => {
+				await request(url).post(`/items/${collectionScoped}`)
+					.send({ string_field: randomUUID(), owner_field: owner })
+					.set('Authorization', admin);
+
+				return request(url).get(read)
+					.set('Authorization', auth);
+			};
+
+			// A write outside the union (owner-b) spares the read — the union pin, not bare.
+			await warmUp();
+			const afterOutside = await writeOwner(scopedOwnerB);
+			expect(afterOutside.statusCode).toBe(200);
+			expect(afterOutside.headers[cacheStatusHeader]).toBe('HIT');
+
+			// A write to the caller's own slice (a union member) purges it.
+			await warmUp();
+			const afterMine = await writeOwner(me.id);
+			expect(afterMine.statusCode).toBe(200);
+			expect(afterMine.headers[cacheStatusHeader]).toBe('MISS');
+
+			// A write to the shared bucket (the other union member) also purges it.
+			await warmUp();
+			const afterShared = await writeOwner(sharedBucket);
+			expect(afterShared.statusCode).toBe(200);
+			expect(afterShared.headers[cacheStatusHeader]).toBe('MISS');
+		});
+	});
+
+	describe(oneLine`
 		Scoped purge pins a slice read filtered by a relation's primary key — a write to
 		one owner's slice leaves another owner's cached read intact (the relational pin)
 	`, () => {

--- a/tests/blackbox/tests/db/app/cache.test.ts
+++ b/tests/blackbox/tests/db/app/cache.test.ts
@@ -1240,6 +1240,110 @@ describe('App Caching Tests', () => {
 	});
 
 	describe(oneLine`
+		A permission case pins the RESOLVED user id, not the literal $CURRENT_USER token —
+		a write to a row whose owner_field literally holds '$CURRENT_USER' spares the read,
+		a write to the resolved id purges it
+	`, () => {
+		// Regression guard for the resolution the case pin relies on: fetchPermissions →
+		// processPermissions → parseFilter substitutes $CURRENT_USER in the policy rule with
+		// the concrete user id before it becomes ast.cases, so the read pins
+		// owner_field=<me.id>. If that regressed to pinning the literal token, a row with
+		// owner_field='$CURRENT_USER' would share the read's slice and wrongly purge it.
+		it.each(vendors)('%s', async (vendor) => {
+			const env = envs[vendor].envRedisScopedPurge;
+			const url = getUrl(vendor, env);
+			const admin = `Bearer ${USER.ADMIN.TOKEN}`;
+
+			const suffix = randomUUID();
+
+			const role = (
+				await request(url).post('/roles')
+					.send({ name: `cache-case-token-${suffix}` })
+					.set('Authorization', admin)
+			).body.data;
+
+			const policy = (
+				await request(url).post('/policies')
+					.send({
+						name: `cache-case-token-${suffix}`,
+						app_access: true,
+						admin_access: false,
+						roles: [{ role: role.id }],
+					})
+					.set('Authorization', admin)
+			).body.data;
+
+			await request(url).post('/permissions')
+				.send({
+					policy: policy.id,
+					collection: collectionScoped,
+					action: 'read',
+					fields: ['*'],
+					permissions: { owner_field: { _eq: '$CURRENT_USER' } },
+				})
+				.set('Authorization', admin);
+
+			const token = `cache-case-token-${suffix}`;
+
+			const me = (
+				await request(url).post('/users')
+					.send({
+						email: `cache-case-token-${suffix}@example.com`,
+						password: randomUUID(),
+						role: role.id,
+						token,
+						status: 'active',
+					})
+					.set('Authorization', admin)
+			).body.data;
+
+			const auth = `Bearer ${token}`;
+
+			await request(url).post(`/items/${collectionScoped}`)
+				.send({ string_field: randomUUID(), owner_field: me.id })
+				.set('Authorization', admin);
+
+			const read = `/items/${collectionScoped}`;
+
+			await request(url).post(`/utils/cache/clear`)
+				.set('Authorization', admin);
+
+			await request(url).get(read)
+				.set('Authorization', auth); // cold → cached, pinned to owner_field=<me.id>
+
+			const warm = await request(url).get(read)
+				.set('Authorization', auth);
+
+			expect(warm.statusCode).toBe(200);
+			expect(warm.headers[cacheStatusHeader]).toBe('HIT');
+
+			// Write a row whose owner_field is the LITERAL token string. If the case had
+			// pinned '$CURRENT_USER' unresolved, this would share the slice and purge the
+			// read. It must not — the read is pinned to the resolved <me.id>.
+			await request(url).post(`/items/${collectionScoped}`)
+				.send({ string_field: randomUUID(), owner_field: '$CURRENT_USER' })
+				.set('Authorization', admin);
+
+			const afterLiteral = await request(url).get(read)
+				.set('Authorization', auth);
+
+			expect(afterLiteral.statusCode).toBe(200);
+			expect(afterLiteral.headers[cacheStatusHeader]).toBe('HIT');
+
+			// Positive control: a write to the resolved id purges the read.
+			await request(url).post(`/items/${collectionScoped}`)
+				.send({ string_field: randomUUID(), owner_field: me.id })
+				.set('Authorization', admin);
+
+			const afterResolved = await request(url).get(read)
+				.set('Authorization', auth);
+
+			expect(afterResolved.statusCode).toBe(200);
+			expect(afterResolved.headers[cacheStatusHeader]).toBe('MISS');
+		});
+	});
+
+	describe(oneLine`
 		Scoped purge pins a slice read filtered by a relation's primary key — a write to
 		one owner's slice leaves another owner's cached read intact (the relational pin)
 	`, () => {

--- a/tests/blackbox/tests/db/app/cache.test.ts
+++ b/tests/blackbox/tests/db/app/cache.test.ts
@@ -1441,6 +1441,112 @@ describe('App Caching Tests', () => {
 	});
 
 	describe(oneLine`
+		A multilevel permission rule (_and of an owner bound + another condition) still
+		value-scopes the read — the pinner descends the _and, pins the bounding branch,
+		ignores the rest
+	`, () => {
+		// The rule nests: `{ _and: [ { owner_field: _eq $CURRENT_USER }, { string_field:
+		// _nnull } ] }`. A single case AND-bounds, so it pins; the walker descends `_and`,
+		// pins owner_field=<me.id> (the _nnull branch doesn't bound and is skipped). Isolation
+		// must hold exactly like the flat rule: other-owner write spares, own write purges.
+		it.each(vendors)('%s', async (vendor) => {
+			const env = envs[vendor].envRedisScopedPurge;
+			const url = getUrl(vendor, env);
+			const admin = `Bearer ${USER.ADMIN.TOKEN}`;
+
+			const suffix = randomUUID();
+
+			const role = (
+				await request(url).post('/roles')
+					.send({ name: `cache-nested-${suffix}` })
+					.set('Authorization', admin)
+			).body.data;
+
+			const policy = (
+				await request(url).post('/policies')
+					.send({
+						name: `cache-nested-${suffix}`,
+						app_access: true,
+						admin_access: false,
+						roles: [{ role: role.id }],
+					})
+					.set('Authorization', admin)
+			).body.data;
+
+			await request(url).post('/permissions')
+				.send({
+					policy: policy.id,
+					collection: collectionScoped,
+					action: 'read',
+					fields: ['*'],
+					permissions: {
+						_and: [
+							{ owner_field: { _eq: '$CURRENT_USER' } },
+							{ string_field: { _nnull: true } },
+						],
+					},
+				})
+				.set('Authorization', admin);
+
+			const token = `cache-nested-${suffix}`;
+
+			const me = (
+				await request(url).post('/users')
+					.send({
+						email: `cache-nested-${suffix}@example.com`,
+						password: randomUUID(),
+						role: role.id,
+						token,
+						status: 'active',
+					})
+					.set('Authorization', admin)
+			).body.data;
+
+			const auth = `Bearer ${token}`;
+
+			await request(url).post(`/items/${collectionScoped}`)
+				.send({ string_field: randomUUID(), owner_field: me.id })
+				.set('Authorization', admin);
+
+			const read = `/items/${collectionScoped}`;
+
+			await request(url).post(`/utils/cache/clear`)
+				.set('Authorization', admin);
+
+			await request(url).get(read)
+				.set('Authorization', auth); // cold → cached, pinned to owner_field=<me.id>
+
+			const warm = await request(url).get(read)
+				.set('Authorization', auth);
+
+			expect(warm.statusCode).toBe(200);
+			expect(warm.headers[cacheStatusHeader]).toBe('HIT');
+
+			// Other-owner write: an owner=me-pinned read is spared.
+			await request(url).post(`/items/${collectionScoped}`)
+				.send({ string_field: randomUUID(), owner_field: scopedOwnerB })
+				.set('Authorization', admin);
+
+			const afterOther = await request(url).get(read)
+				.set('Authorization', auth);
+
+			expect(afterOther.statusCode).toBe(200);
+			expect(afterOther.headers[cacheStatusHeader]).toBe('HIT');
+
+			// Own-slice write: purges the pinned read.
+			await request(url).post(`/items/${collectionScoped}`)
+				.send({ string_field: randomUUID(), owner_field: me.id })
+				.set('Authorization', admin);
+
+			const afterMine = await request(url).get(read)
+				.set('Authorization', auth);
+
+			expect(afterMine.statusCode).toBe(200);
+			expect(afterMine.headers[cacheStatusHeader]).toBe('MISS');
+		});
+	});
+
+	describe(oneLine`
 		Scoped purge pins a slice read filtered by a relation's primary key — a write to
 		one owner's slice leaves another owner's cached read intact (the relational pin)
 	`, () => {

--- a/tests/blackbox/tests/db/app/cache.test.ts
+++ b/tests/blackbox/tests/db/app/cache.test.ts
@@ -2001,10 +2001,12 @@ describe('App Caching Tests', () => {
 
 			// A write touching NEITHER slice spares the read — the union pin, not bare.
 			await warmUp();
+
 			const afterNeither = await writeRow({
 				field_a: randomUUID(),
 				field_b: randomUUID(),
 			});
+
 			expect(afterNeither.statusCode).toBe(200);
 			expect(afterNeither.headers[cacheStatusHeader]).toBe('HIT');
 

--- a/tests/blackbox/tests/db/app/cache.test.ts
+++ b/tests/blackbox/tests/db/app/cache.test.ts
@@ -20,6 +20,7 @@ import {
 	collectionIgnored,
 	collectionRelated,
 	collectionScoped,
+	collectionScopedMulti,
 	collectionScopedRel,
 	collectionTag,
 	scopedOwnerA,
@@ -1901,6 +1902,115 @@ describe('App Caching Tests', () => {
 
 			expect(afterMine.statusCode).toBe(200);
 			expect(afterMine.headers[cacheStatusHeader]).toBe('MISS');
+		});
+	});
+
+	describe(oneLine`
+		A permission case set binding DIFFERENT scope fields (field_a in one policy, field_b in
+		another) union-pins BOTH — a write to either field's slice purges the read, a write to
+		neither spares it (the multi-field _or lift, not the bare floor)
+	`, () => {
+		// Two read policies OR-join as { _or: [ {field_a:_eq A}, {field_b:_eq B} ] }.
+		// Every branch binds a pinnable field, so the read pins BOTH slices, not bare.
+		// The spare witness (a write touching neither slice) proves it's value-scoped
+		// across the two fields; the two purge witnesses prove either slice drops it.
+		it.each(vendors)('%s', async (vendor) => {
+			const env = envs[vendor].envRedisScopedPurge;
+			const url = getUrl(vendor, env);
+			const admin = `Bearer ${USER.ADMIN.TOKEN}`;
+
+			const suffix = randomUUID();
+			const valA = randomUUID(); // the field_a slice the read is pinned to
+			const valB = randomUUID(); // the field_b slice the read is pinned to
+
+			const role = (
+				await request(url).post('/roles')
+					.send({ name: `cache-multifield-${suffix}` })
+					.set('Authorization', admin)
+			).body.data;
+
+			// One policy per field, each read-permitting a DISTINCT scope field, so
+			// getCases yields two cases both bounding — the multi-field union.
+			for (const rule of [{ field_a: { _eq: valA } }, { field_b: { _eq: valB } }]) {
+				const policy = (
+					await request(url).post('/policies')
+						.send({
+							name: `cache-multifield-${suffix}-${randomUUID()}`,
+							app_access: true,
+							admin_access: false,
+							roles: [{ role: role.id }],
+						})
+						.set('Authorization', admin)
+				).body.data;
+
+				await request(url).post('/permissions')
+					.send({
+						policy: policy.id,
+						collection: collectionScopedMulti,
+						action: 'read',
+						fields: ['*'],
+						permissions: rule,
+					})
+					.set('Authorization', admin);
+			}
+
+			const token = `cache-multifield-${suffix}`;
+
+			await request(url).post('/users')
+				.send({
+					email: `cache-multifield-${suffix}@example.com`,
+					password: randomUUID(),
+					role: role.id,
+					token,
+					status: 'active',
+				})
+				.set('Authorization', admin);
+
+			const auth = `Bearer ${token}`;
+
+			// A row in field_a's pinned slice so the read has data.
+			await request(url).post(`/items/${collectionScopedMulti}`)
+				.send({ field_a: valA })
+				.set('Authorization', admin);
+
+			// No filter — the field_a/field_b bounds come only from the two policy cases.
+			const read = `/items/${collectionScopedMulti}`;
+
+			const warmUp = async () => {
+				await request(url).post(`/utils/cache/clear`)
+					.set('Authorization', admin);
+
+				await request(url).get(read)
+					.set('Authorization', auth); // cold → cached, pinned to A + B slices
+
+				const warm = await request(url).get(read)
+					.set('Authorization', auth);
+
+				expect(warm.headers[cacheStatusHeader]).toBe('HIT');
+			};
+
+			const writeRow = async (item: { field_a?: string; field_b?: string }) => {
+				await request(url).post(`/items/${collectionScopedMulti}`)
+					.send(item)
+					.set('Authorization', admin);
+
+				return request(url).get(read)
+					.set('Authorization', auth);
+			};
+
+			// A write touching NEITHER slice spares the read — the union pin, not bare.
+			await warmUp();
+			const afterNeither = await writeRow({ field_a: randomUUID(), field_b: randomUUID() });
+			expect(afterNeither.statusCode).toBe(200);
+			expect(afterNeither.headers[cacheStatusHeader]).toBe('HIT');
+
+			// A write to the field_a slice purges it.
+			await warmUp();
+			expect((await writeRow({ field_a: valA })).headers[cacheStatusHeader]).toBe('MISS');
+
+			// A write to the field_b slice purges it too.
+			await warmUp();
+			expect((await writeRow({ field_b: valB })).headers[cacheStatusHeader]).toBe('MISS');
 		});
 	});
 });

--- a/tests/blackbox/tests/db/app/cache.test.ts
+++ b/tests/blackbox/tests/db/app/cache.test.ts
@@ -1130,6 +1130,115 @@ describe('App Caching Tests', () => {
 	});
 
 	describe(oneLine`
+		A permission-scoped read (partition in the policy, NOT the API filter) is value-scoped
+		off the injected case: a write to the user's own slice drops their read, a write to
+		another slice spares it
+	`, () => {
+		// The planner case: a student lists /items/slots with no filter, but a policy restricts
+		// them to `owner_field = $CURRENT_USER`. That predicate lives in the permission rule,
+		// injected as `ast.cases`, not in the query — so `pinnedScopedCacheTagsFromCases` is what
+		// scopes the read. Without it the read falls back to the bare collection tag and any other
+		// user's write purges it (the over-purge this fixes). The "spared" witness below is the
+		// proof it's value-scoped and not bare.
+		it.each(vendors)('%s', async (vendor) => {
+			const env = envs[vendor].envRedisScopedPurge;
+			const url = getUrl(vendor, env);
+			const admin = `Bearer ${USER.ADMIN.TOKEN}`;
+
+			// A policy that scopes reads of collectionScoped to the caller's own rows, plus a role
+			// carrying it and a static-token user to read as. Unique names per run avoid collisions.
+			const suffix = randomUUID();
+			const role = (
+				await request(url).post('/roles')
+					.send({ name: `cache-case-scope-${suffix}` })
+					.set('Authorization', admin)
+			).body.data;
+
+			const policy = (
+				await request(url).post('/policies')
+					.send({
+						name: `cache-case-scope-${suffix}`,
+						app_access: true,
+						admin_access: false,
+						roles: [{ role: role.id }],
+					})
+					.set('Authorization', admin)
+			).body.data;
+
+			await request(url).post('/permissions')
+				.send({
+					policy: policy.id,
+					collection: collectionScoped,
+					action: 'read',
+					fields: ['*'],
+					permissions: { owner_field: { _eq: '$CURRENT_USER' } },
+				})
+				.set('Authorization', admin);
+
+			const token = `cache-case-scope-${suffix}`;
+
+			const me = (
+				await request(url).post('/users')
+					.send({
+						email: `cache-case-scope-${suffix}@example.com`,
+						password: randomUUID(),
+						role: role.id,
+						token,
+						status: 'active',
+					})
+					.set('Authorization', admin)
+			).body.data;
+
+			const auth = `Bearer ${token}`;
+
+			// One row in the user's own slice (owner_field=<me.id>) so the read has data + a scope
+			// value; the other-slice write later targets a value the user is NOT pinned to.
+			await request(url).post(`/items/${collectionScoped}`)
+				.send({ string_field: randomUUID(), owner_field: me.id })
+				.set('Authorization', admin);
+
+			// No filter — the owner_field bound comes only from the policy case.
+			const read = `/items/${collectionScoped}`;
+
+			await request(url).post(`/utils/cache/clear`)
+				.set('Authorization', admin);
+
+			await request(url).get(read)
+				.set('Authorization', auth); // cold → cached, case-pinned to owner_field=<me.id>
+
+			const warm = await request(url).get(read)
+				.set('Authorization', auth);
+
+			expect(warm.statusCode).toBe(200);
+			expect(warm.headers[cacheStatusHeader]).toBe('HIT');
+
+			// A write in ANOTHER owner's slice. A bare-tagged read would MISS here; a case-pinned
+			// read to <me.id> is spared.
+			await request(url).post(`/items/${collectionScoped}`)
+				.send({ string_field: randomUUID(), owner_field: scopedOwnerB })
+				.set('Authorization', admin);
+
+			const afterOther = await request(url).get(read)
+				.set('Authorization', auth);
+
+			expect(afterOther.statusCode).toBe(200);
+			expect(afterOther.headers[cacheStatusHeader]).toBe('HIT');
+
+			// A write in the user's OWN slice (owner_field=<me.id>) — the value the case resolved
+			// to. It must purge the read.
+			await request(url).post(`/items/${collectionScoped}`)
+				.send({ string_field: randomUUID(), owner_field: me.id })
+				.set('Authorization', admin);
+
+			const afterMine = await request(url).get(read)
+				.set('Authorization', auth);
+
+			expect(afterMine.statusCode).toBe(200);
+			expect(afterMine.headers[cacheStatusHeader]).toBe('MISS');
+		});
+	});
+
+	describe(oneLine`
 		Scoped purge pins a slice read filtered by a relation's primary key — a write to
 		one owner's slice leaves another owner's cached read intact (the relational pin)
 	`, () => {

--- a/tests/blackbox/tests/db/app/cache.test.ts
+++ b/tests/blackbox/tests/db/app/cache.test.ts
@@ -1788,9 +1788,9 @@ describe('App Caching Tests', () => {
 	});
 
 	describe(oneLine`
-		A permission case whose rule is RELATIONAL (owner_ref.id _eq, the partition on a related
-		pk, not a scalar) still value-scopes the read: a write to the pinned owner's slice purges
-		it, a write to another owner's slice spares it
+		A permission case whose rule is RELATIONAL (owner_ref.id _eq — the
+		partition on a related pk, not a scalar) still value-scopes the read:
+		a write to the pinned owner's slice purges it, another owner's spares it
 	`, () => {
 		// The `{ user_created: { id: { _eq: $CURRENT_USER } } }` shape — the dominant
 		// real pattern — routed through a policy, not the query. The case reaches the
@@ -1906,9 +1906,10 @@ describe('App Caching Tests', () => {
 	});
 
 	describe(oneLine`
-		A permission case set binding DIFFERENT scope fields (field_a in one policy, field_b in
-		another) union-pins BOTH — a write to either field's slice purges the read, a write to
-		neither spares it (the multi-field _or lift, not the bare floor)
+		A permission case set binding DIFFERENT scope fields (field_a in one
+		policy, field_b in another) union-pins BOTH — a write to either field's
+		slice purges the read, a write to neither spares it (the multi-field _or
+		lift, not the bare floor)
 	`, () => {
 		// Two read policies OR-join as { _or: [ {field_a:_eq A}, {field_b:_eq B} ] }.
 		// Every branch binds a pinnable field, so the read pins BOTH slices, not bare.
@@ -2000,7 +2001,10 @@ describe('App Caching Tests', () => {
 
 			// A write touching NEITHER slice spares the read — the union pin, not bare.
 			await warmUp();
-			const afterNeither = await writeRow({ field_a: randomUUID(), field_b: randomUUID() });
+			const afterNeither = await writeRow({
+				field_a: randomUUID(),
+				field_b: randomUUID(),
+			});
 			expect(afterNeither.statusCode).toBe(200);
 			expect(afterNeither.headers[cacheStatusHeader]).toBe('HIT');
 


### PR DESCRIPTION
In the planner a lot of reads get the **bare collection tag** — so one user's write purges every user's cached slice — because the predicate that *could* value-scope them lives in a **permission policy**, not the API filter. A student lists `/items/slots` with no filter; a policy restricts them to `owner_field = $CURRENT_USER`. The read-side pinner only looked at the query filter, saw nothing to pin, and fell back to bare. The scoped cache is defeated exactly where the planner needs it.

The permission predicate is injected into the AST as `ast.cases`. `joinFilterWithCases` combines it with the query filter as `{ _and: [filter, { _or: cases }] }` — which is literally what `run-ast` builds for the SQL `WHERE`. So the read's *effective bound* is that combined filter; I scope the cache off the exact same thing.

### One pinner, `_or`-aware
Rather than a parallel cases path, I generalized the existing `pinnedScopedCacheTagsFromFilter` into a small recursive evaluator. Each node reports its pinned tags **plus whether it *covers* every row it matches** (binds a pinnable field on that row), combined by operator:
- **`_and` / root** → union a field's values; covered if **any** conjunct is (a row satisfies every conjunct). The union over-approximates the intersection — over-purges, never stale.
- **`_or`** → sound only when **every branch is covered** (else a row matching an uncovered branch carries no pinned tag → stale); then union all branches' tags — **across different fields too** (`{ _or: [{ owner }, { dept }] }` pins both, purged if a write touches either). A row matches at least one branch, and that branch's covering tag lies in the union.

`items.ts` then pins off `joinFilterWithCases(updatedQuery.filter, ast.cases)` in a single call — the pin **can't diverge** from what the query actually returns, because it's the same combiner. The previous standalone `pinnedScopedCacheTagsFromCases` is gone; permission cases are just an `_or`.

**Bonus:** a query `?filter[_or][owner][_eq]=A&…=B` that used to fall back to bare now pins `owner ∈ {A,B}` too — same code path.

### Why it's sound
- Cases reach the pinner **already dynamic-var-resolved** (`fetchPermissions` → `processPermissions` → `parseFilter`, the share path too), so `$CURRENT_USER`/`$NOW` are concrete values — the pin matches what a write's row yields. No resolver needed.
- The write side (`scopedCacheTagsFromRows`) tags a mutation by the row's actual value, on **every** scoped field; a write matching the read is bounded on whichever field the pin covers → hits a tag → purges. Over-tagging only over-purges.
- Permission **changes** already `cache.clear()` (`policies`/`roles`/`access`/`permissions` `clearCaches`), so a re-scoped read can't outlive a permission edit.

### Retrocompat
Additive. No case / a case that leaves *all* fields unbound / a non-`_eq`/`_in` or date-ish bound → identical to today (bare). Inert when `scopedCachePurgeEnabled()` is false. `pinnedScopedCacheTagsFromFilter`'s existing behaviour is byte-identical for `_and`/leaf/relational inputs; only the `_or` output changed — from *skip* to *covered-gated union*.

### Proof
- Unit (`scoped-cache-tags.test.ts`): `_or` same-field union, an unbounding `_or` branch → bare, relational-in-`_or`, `_and`-over-`_or`, empty `_or`, `_or` dedup (a value bound by more than one branch collapses to one tag), `_and` same-field union (the over-approximation of the intersection), empty `_in` → bare, **multi-field `_or`** (branches bind *different* scope fields → pin each), and a multi-field `_or` with one branch binding no pinnable field → bare.
- Blackbox (`cache.test.ts`, pg + sqlite3): per-user isolation, `$CURRENT_USER` resolves-not-literal guard, multi-case (two policies, unbounding second) → bare, multilevel `_and`-nested rule, two-policy same-field **union** (write to either owner purges, an owner outside the union spares), a **relational** permission-case rule (`{ owner_ref: { id: { _eq } } }`) value-scoping off the related PK, the query-side `_or` union, and a **multi-field** two-policy set on a dedicated two-scope-field collection (`{ _or: [{ field_a }, { field_b }] }` → a write to either field's slice purges, a write touching neither spares).

### Design notes (settled)
- **No DNF normalization.** Distributing `_and` over `_or` is worst-case exponential on user/policy-controlled filters; the linear over-approximating walk is the bounded form.
- **Root `ast.cases` only** — nested `child.cases` are per-relation and out of scope; scope fields live on the root collection.
- Directus filters have no `_not` (only `_and`/`_or`; negation is per-operator), so nothing can invert a bound past the pinner — negations aren't `_eq`/`_in`, they degrade to bare.

### Out of scope (named)
- M2M / deep-relation owner scoping via cases — the root stays scalar/related-PK.
- The only remaining bare floor is a **genuinely-coarse** case set where *some* branch binds **no** pinnable scope field at all (e.g. a `{ string_field: _nnull }` case) — that branch's rows carry no tag, so the whole `_or` degrades to bare. A multi-**field** set where every branch binds *some* scope field (case A → `owner`, case B → `dept`) **is** union-pinned now, as is the same-**field** multi-policy union (own rows + a shared bucket).
- Supersedes #206 (same goal, stale base). Off `v11.10.1-hhh-dev` so it carries #205 + #210.

### Review (independent deep pass)
Ran a full soundness + CI pass on the recursive pinner — no correctness bug found.
- **Soundness holds.** The `covered`-flag invariant checks out by induction: `covered ⟹` every matched row carries a pinned tag `(field, row.value)` in the node's map. `_and`/root cover if *any* conjunct does (row meets all), `_or` only if *every* branch does (row meets ≥1), leaf iff it bound a pinnable field. Verified on nested AND-of-ORs, multi-field `_or`, same-field `_and` union, and empty `_in`. Over-approximation throughout → over-purge, never stale.
- **Admin / no-accountability path is safe.** `processAst` early-returns before `injectCases`, but `getAstFromQuery` inits `cases: []` (non-optional `Filter[]`), so `joinFilterWithCases(filter, [])` returns the filter and nothing throws. Behaviour = pre-PR.
- **Lint gap fixed** (`550a639f30`): the 90-col wrap of the multi-field `afterNeither` writeRow turned a one-line const multiline → tripped `padding-line-between-statements` in the full Lint job (the changed-line width gate doesn't run it). Blank lines added; Lint + Style + Blackbox pg/sqlite now all green.
- Two minors **considered and declined** (non-blocking): memoizing `collectionScopedCacheFieldRelatedPks` (called once/read, and the sibling getters recompute the same way — inconsistent to fix just one), and making the added `toEqual` assertions order-independent (output is deterministic, so sorting would only add noise without removing real risk).