### PR TITLE
ci(check): stop double-running the gate on feature-branch pushes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,7 +10,16 @@ name: Check
 on:
   pull_request:
 
+  # Skip push on feature branches — they always have a PR, so `pull_request`
+  # already runs the full gate (and it alone carries the diff-scoped Style gate).
+  # push stays on the integration branches, which get direct commits and need the
+  # coverage upload codecov tracks. Covers both `feat/x` and `v11.10.1-feat/x`.
   push:
+    branches-ignore:
+      - feat/**
+      - fix/**
+      - '*-feat/**'
+      - '*-fix/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why

A commit to a PR-head branch fires **both** `push` and `pull_request` on `check.yml`. The concurrency group keys on `github.ref`, which differs between the events (`refs/heads/<branch>` vs `refs/pull/N/merge`), so `cancel-in-progress` never dedupes them — **Unit Tests + Lint run twice** per feature-branch push (e.g. every push on #213).

## What

Skip `push` on feature branches only:

```yaml
push:
  branches-ignore: [feat/**, fix/**, '*-feat/**', '*-fix/**']
```

Feature branches always have an open PR, so the `pull_request` run already executes the full gate — and it *alone* carries the diff-scoped **Style (changes)** job (`if: github.event_name == 'pull_request'`). `push` stays on the integration branches (`hhh-dev`, `hhh-main`, `main`, the stacked copies), which get direct commits and need the coverage upload. Both events already upload coverage, so feature PRs lose nothing.

## Notes / open questions

- Patterns cover both conventions in use: `feat/analytics` and `v11.10.1-feat/db-…`. Anchored so `prefix/…`/`hotfix/…`-style names aren't caught by accident — flag if a feature-branch naming I missed should also be excluded.
- A feature branch **without** a PR yet gets no push run until the PR opens — acceptable (transient), and the reason the header comment originally kept `push:` unfiltered.
- Out of scope: the same double-run affects `blackbox-pr.yml`? No — that's `pull_request`-only already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)