### PR TITLE
ci(blackbox): drop mysql, mssql, oracle from the full vendor matrix

### DIFF
--- a/.github/workflows/blackbox.yml
+++ b/.github/workflows/blackbox.yml
@@ -52,7 +52,9 @@ jobs:
         id: matrix
         run: |
           if [ "${{ github.event_name }}" = "push" ] || [ "${{ inputs.full }}" = "true" ]; then
-            echo 'vendors=["sqlite3","postgres","mysql","maria","mssql","oracle"]' >> "$GITHUB_OUTPUT"
+            # mysql, mssql, oracle dropped — not supported/maintained on this fork.
+            # Re-add to the array to support: "mysql","mssql","oracle".
+            echo 'vendors=["sqlite3","postgres","maria"]' >> "$GITHUB_OUTPUT"
           else
             echo 'vendors=["sqlite3","postgres"]' >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
The fork doesn't support/maintain mysql, mssql, or oracle — running them in the full blackbox matrix wastes runner time and reds PRs on unsupported/flaky behavior (the fork runner's mssql shard mass-times-out). Full matrix is now sqlite3 + postgres + maria; the three dropped vendors are named in a comment so re-adding is a one-line edit.

Smoke set (no label) is unchanged (sqlite3 + postgres). `get-dbs-to-test.ts` `allVendors` is left intact — it's the type registry, not the run selector.