### PR TITLE
feat(cache): auto-derive multi-hop scoped-cache paths from local scope fields

### DIFF
--- a/api/src/scoped-cache.ts
+++ b/api/src/scoped-cache.ts
@@ -4,6 +4,7 @@ import type {
 	Filter,
 	ScopedCachePath,
 	ScopedCacheTag,
+	SchemaOverview,
 	Type,
 } from '@directus/types';
 import type Keyv from 'keyv';
@@ -569,4 +570,60 @@ export function pinnedScopedCacheTagsFromFilter(
 	}
 
 	return tags;
+}
+
+/**
+ * Auto-derive multi-hop scope paths from LOCAL scope fields, so each collection
+ * declares only its own column and the grand-owner path composes itself. A scope
+ * field on `collection` that is an M2O to a collection which itself declares scope
+ * fields contributes `<field>.<targetScope>` for each of the target's scopes — its
+ * own and, transitively, its derived. So `team` scoped by `owner_ref` + `member`
+ * scoped by `team` yields `team.owner_ref`, no config naming another collection's
+ * relation. Cycle-guarded (`visited`); the caller re-resolves each path (a to-many
+ * hop drops to the bare tag).
+ */
+export function composeScopedCachePaths(
+	schema: Pick<SchemaOverview, 'collections' | 'relations'>,
+	collection: string,
+	visited: Set<string> = new Set(),
+): ScopedCachePath[] {
+	if (visited.has(collection)) {
+		return [];
+	}
+
+	const seen = new Set(visited).add(collection);
+	const localFields = schema.collections[collection]?.scopedCacheFields ?? [];
+	const composed: ScopedCachePath[] = [];
+
+	for (const field of localFields) {
+		if (field.includes('.')) {
+			continue;
+		}
+
+		const relation = schema.relations.find((rel) => {
+			return rel.collection === collection && rel.field === field;
+		});
+
+		const target = relation?.related_collection;
+
+		if (!target) {
+			continue;
+		}
+
+		for (const targetField of schema.collections[target]?.scopedCacheFields ?? []) {
+			composed.push({
+				field: `${field}.${targetField}`,
+				segments: [field, ...targetField.split('.')],
+			});
+		}
+
+		for (const deeper of composeScopedCachePaths(schema, target, seen)) {
+			composed.push({
+				field: `${field}.${deeper.field}`,
+				segments: [field, ...deeper.segments],
+			});
+		}
+	}
+
+	return composed;
 }

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -1052,4 +1052,42 @@ describe('ItemsService — system collections, uuid PKs, revisions, singletons',
 			expect(result).toEqual([{ id: 1, name: 'a' }]);
 		});
 	});
+
+	describe('auto-derived scoped-cache paths', () => {
+		const pathSchema = new SchemaBuilder()
+			.collection('sub', (c) => {
+				c.field('id').id();
+				c.field('name').string();
+				c.field('item').m2o('item');
+			})
+			.collection('item', (c) => {
+				c.field('id').id();
+				c.field('owner').m2o('owner');
+			})
+			.collection('owner', (c) => {
+				c.field('id').id();
+			})
+			.build();
+
+		// SchemaBuilder can't set scoped_cache_fields, so inject them. `item` is an M2O
+		// whose target scopes `owner`, so a 2-hop `item.owner` path auto-composes; the
+		// explicit `item.owner` dedups against it; `name.foo` has a scalar head so it
+		// resolves to null and drops to the bare tag.
+		pathSchema.collections['sub']!.scopedCacheFields = [
+			'item',
+			'item.owner',
+			'name.foo',
+		];
+
+		pathSchema.collections['item']!.scopedCacheFields = ['owner'];
+
+		it('readByQuery resolves M2O paths, drops scalar heads', async () => {
+			tracker.on.select('sub').response([{ id: 1, name: 'a', item: 10 }]);
+
+			const service = new ItemsService('sub', { knex: db, schema: pathSchema });
+			const result = await service.readByQuery({ fields: ['*'] });
+
+			expect(readMeta(result)?.scopedCacheTags).toBeDefined();
+		});
+	});
 });

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -27,6 +27,7 @@ import type { Knex } from 'knex';
 import { assign, clone, cloneDeep, isPlainObject, omit, pick, without } from 'lodash-es';
 import { getCache } from '../cache.js';
 import {
+	composeScopedCachePaths,
 	pinnedScopedCacheTagsFromFilter,
 	purgeScopedCache,
 	scopedCacheTagsFromRows,
@@ -250,25 +251,35 @@ implements AbstractService<Item> {
 		return this.collectionScopedCacheFields.filter((field) => !field.includes('.'));
 	}
 
-	// Path scope fields (`enrollment.student.user`) resolving to an all-M2O chain,
-	// with the segments the read pinner walks. An unresolvable path (a to-many hop
-	// or unknown field) is dropped → it degrades to the bare tag on both sides.
+	// The multi-hop paths this collection pins by: explicit dotted entries PLUS paths
+	// auto-derived from local scope fields (see `composeScopedCachePaths`). Each is
+	// re-resolved so a to-many/unknown hop drops it → bare tag both sides. Deduped.
 	private get collectionScopedCachePaths(): ScopedCachePath[] {
-		const paths: ScopedCachePath[] = [];
+		const byField = new Map<string, ScopedCachePath>();
 
-		for (const field of this.collectionScopedCacheFields) {
-			if (!field.includes('.')) {
-				continue;
+		const addPath = (field: string) => {
+			if (byField.has(field)) {
+				return;
 			}
 
 			const resolved = this.resolveScopedCachePath(field);
 
 			if (resolved) {
-				paths.push({ field, segments: resolved.segments });
+				byField.set(field, { field, segments: resolved.segments });
+			}
+		};
+
+		for (const field of this.collectionScopedCacheFields) {
+			if (field.includes('.')) {
+				addPath(field);
 			}
 		}
 
-		return paths;
+		for (const { field } of composeScopedCachePaths(this.schema, this.collection)) {
+			addPath(field);
+		}
+
+		return [...byField.values()];
 	}
 
 	// Resolve a dotted scope field into the M2O join chain reaching its terminal.
@@ -328,12 +339,11 @@ implements AbstractService<Item> {
 		const rootFields = this.schema.collections[this.collection]?.fields ?? {};
 		const types: Record<string, Type | undefined> = {};
 
-		for (const field of this.collectionScopedCacheFields) {
-			if (!field.includes('.')) {
-				types[field] = rootFields[field]?.type;
-				continue;
-			}
+		for (const field of this.collectionScopedCacheFlatFields) {
+			types[field] = rootFields[field]?.type;
+		}
 
+		for (const { field } of this.collectionScopedCachePaths) {
 			const resolved = this.resolveScopedCachePath(field);
 
 			if (!resolved) {
@@ -353,18 +363,11 @@ implements AbstractService<Item> {
 	private get collectionScopedCacheFieldRelatedPks(): Record<string, string> {
 		const map: Record<string, string> = {};
 
-		for (const field of this.collectionScopedCacheFields) {
-			const resolved = field.includes('.')
-				? this.resolveScopedCachePath(field)
-				: null;
-
-			if (field.includes('.') && !resolved) {
-				continue;
-			}
-
-			const fromCollection = resolved?.terminalCollection ?? this.collection;
-			const fromField = resolved?.terminalField ?? field;
-
+		const addRelatedPk = (
+			field: string,
+			fromCollection: string,
+			fromField: string,
+		) => {
 			const relation = this.schema.relations.find((rel) => {
 				return rel.collection === fromCollection && rel.field === fromField;
 			});
@@ -377,6 +380,18 @@ implements AbstractService<Item> {
 
 			if (primaryKey) {
 				map[field] = primaryKey;
+			}
+		};
+
+		for (const field of this.collectionScopedCacheFlatFields) {
+			addRelatedPk(field, this.collection, field);
+		}
+
+		for (const { field } of this.collectionScopedCachePaths) {
+			const resolved = this.resolveScopedCachePath(field);
+
+			if (resolved) {
+				addRelatedPk(field, resolved.terminalCollection, resolved.terminalField);
 			}
 		}
 

--- a/api/src/services/scoped-cache-tags.test.ts
+++ b/api/src/services/scoped-cache-tags.test.ts
@@ -1,7 +1,9 @@
 import { oneLine } from '@directus/utils';
 import { describe, expect, test } from 'vitest';
+import type { SchemaOverview } from '@directus/types';
 import {
 	canonicalScopedCacheValue,
+	composeScopedCachePaths,
 	pinnedScopedCacheTagsFromFilter,
 	scopedCacheTagsFromRows,
 	serializeScopedCacheTags,
@@ -700,5 +702,109 @@ describe('serializeScopedCacheTags', () => {
 		an empty tag list renders as an empty string
 	`, () => {
 		expect(serializeScopedCacheTags([])).toBe('');
+	});
+});
+
+describe('composeScopedCachePaths — auto-derived multi-hop paths', () => {
+	// Minimal schema: each collection's local scope fields + the M2O relations.
+	function schemaOf(
+		scoped: Record<string, string[]>,
+		relations: { collection: string; field: string; related_collection: string }[],
+	): Pick<SchemaOverview, 'collections' | 'relations'> {
+		const collections = Object.fromEntries(
+			Object.entries(scoped).map(([name, scopedCacheFields]) => {
+				return [name, { scopedCacheFields }];
+			}),
+		);
+
+		return { collections, relations } as unknown as Pick<
+			SchemaOverview,
+			'collections' | 'relations'
+		>;
+	}
+
+	test('composes a 2-hop grand-owner path from two local declarations', () => {
+		const schema = schemaOf(
+			{ sub: ['item'], item: ['owner_ref'] },
+			[
+				{ collection: 'sub', field: 'item', related_collection: 'item' },
+				{ collection: 'item', field: 'owner_ref', related_collection: 'owner' },
+			],
+		);
+
+		expect(composeScopedCachePaths(schema, 'sub')).toEqual([
+			{ field: 'item.owner_ref', segments: ['item', 'owner_ref'] },
+		]);
+	});
+
+	test('composes every level of a 3-hop chain', () => {
+		const schema = schemaOf(
+			{ a: ['b'], b: ['c'], c: ['owner_ref'] },
+			[
+				{ collection: 'a', field: 'b', related_collection: 'b' },
+				{ collection: 'b', field: 'c', related_collection: 'c' },
+				{ collection: 'c', field: 'owner_ref', related_collection: 'owner' },
+			],
+		);
+
+		expect(composeScopedCachePaths(schema, 'a')).toEqual([
+			{ field: 'b.c', segments: ['b', 'c'] },
+			{ field: 'b.c.owner_ref', segments: ['b', 'c', 'owner_ref'] },
+		]);
+	});
+
+	test('composes both arms of a diamond to the same owner', () => {
+		const schema = schemaOf(
+			{ a: ['x', 'y'], x_col: ['owner_ref'], y_col: ['owner_ref'] },
+			[
+				{ collection: 'a', field: 'x', related_collection: 'x_col' },
+				{ collection: 'a', field: 'y', related_collection: 'y_col' },
+				{ collection: 'x_col', field: 'owner_ref', related_collection: 'owner' },
+				{ collection: 'y_col', field: 'owner_ref', related_collection: 'owner' },
+			],
+		);
+
+		expect(composeScopedCachePaths(schema, 'a')).toEqual([
+			{ field: 'x.owner_ref', segments: ['x', 'owner_ref'] },
+			{ field: 'y.owner_ref', segments: ['y', 'owner_ref'] },
+		]);
+	});
+
+	test('terminates on a self/mutual reference cycle', () => {
+		const schema = schemaOf(
+			{ a: ['b'], b: ['a'] },
+			[
+				{ collection: 'a', field: 'b', related_collection: 'b' },
+				{ collection: 'b', field: 'a', related_collection: 'a' },
+			],
+		);
+
+		expect(composeScopedCachePaths(schema, 'a')).toEqual([
+			{ field: 'b.a', segments: ['b', 'a'] },
+			{ field: 'b.a.b', segments: ['b', 'a', 'b'] },
+		]);
+	});
+
+	test('a scalar scope field composes nothing (no relation to follow)', () => {
+		const schema = schemaOf({ a: ['name'] }, []);
+		expect(composeScopedCachePaths(schema, 'a')).toEqual([]);
+	});
+
+	test('a target with no scope fields composes nothing', () => {
+		const schema = schemaOf(
+			{ a: ['owner_ref'] },
+			[{ collection: 'a', field: 'owner_ref', related_collection: 'owner' }],
+		);
+
+		expect(composeScopedCachePaths(schema, 'a')).toEqual([]);
+	});
+
+	test('an explicit dotted local field is not used as a compose head', () => {
+		const schema = schemaOf(
+			{ a: ['owned_item.owner_ref'] },
+			[{ collection: 'a', field: 'owned_item', related_collection: 'owned_item' }],
+		);
+
+		expect(composeScopedCachePaths(schema, 'a')).toEqual([]);
 	});
 });

--- a/tests/blackbox/tests/db/app/cache.seed.ts
+++ b/tests/blackbox/tests/db/app/cache.seed.ts
@@ -55,6 +55,13 @@ export const collectionScopedMulti = 'test_app_cache_scoped_multi';
 export const collectionOwnedSubItem = 'test_app_cache_owned_sub_item';
 export const collectionOwnedItem = 'test_app_cache_owned_item';
 
+// A DERIVED multi-hop chain: each collection declares only its OWN scope field —
+// `team` by ['owner_ref'], `member` by ['team'] — and the grand-owner path
+// `team.owner_ref` auto-composes (no config names another collection's relation).
+// Proves #220.
+export const collectionMember = 'test_app_cache_member';
+export const collectionTeam = 'test_app_cache_team';
+
 const junctionTag = 'test_app_cache_first_tag';
 const junctionBlock = 'test_app_cache_first_block';
 
@@ -78,6 +85,8 @@ export const seedDBStructure = () => {
 				// tag/block all point at grandRelated, so grandRelated goes last.
 				await DeleteCollection(vendor, { collection: junctionTag });
 				await DeleteCollection(vendor, { collection: junctionBlock });
+				await DeleteCollection(vendor, { collection: collectionMember });
+				await DeleteCollection(vendor, { collection: collectionTeam });
 				await DeleteCollection(vendor, { collection: collectionOwnedSubItem });
 				await DeleteCollection(vendor, { collection: collectionOwnedItem });
 				await DeleteCollection(vendor, { collection: collectionScopedRel });
@@ -299,6 +308,33 @@ export const seedDBStructure = () => {
 					collection: collectionOwnedSubItem,
 					field: 'owned_item',
 					otherCollection: collectionOwnedItem,
+				});
+
+				// Derived chain: team scopes by its own `owner_ref`, member by its own
+				// `team`. member never names owner_ref — `team.owner_ref` composes itself.
+				await CreateCollections(vendor, {
+					collections: [
+						{
+							collection: collectionTeam,
+							meta: { scoped_cache_fields: ['owner_ref'] },
+						},
+						{
+							collection: collectionMember,
+							meta: { scoped_cache_fields: ['team'] },
+						},
+					],
+				});
+
+				await CreateFieldM2O(vendor, {
+					collection: collectionTeam,
+					field: 'owner_ref',
+					otherCollection: collectionGrandRelated,
+				});
+
+				await CreateFieldM2O(vendor, {
+					collection: collectionMember,
+					field: 'team',
+					otherCollection: collectionTeam,
 				});
 
 				expect(true).toBeTruthy();

--- a/tests/blackbox/tests/db/app/cache.test.ts
+++ b/tests/blackbox/tests/db/app/cache.test.ts
@@ -21,8 +21,10 @@ import {
 	collectionRelated,
 	collectionScoped,
 	collectionScopedMulti,
+	collectionMember,
 	collectionOwnedSubItem,
 	collectionOwnedItem,
+	collectionTeam,
 	collectionScopedRel,
 	collectionTag,
 	scopedOwnerA,
@@ -1912,6 +1914,85 @@ describe('App Caching Tests', () => {
 			const afterB = await read(readB);
 
 			// The write joined owned_sub_item→owned_item to resolve owner_ref=<ownerB>,
+			// so B's write dropped only B (MISS) and left A cached (HIT).
+			expect(afterA.statusCode).toBe(200);
+			expect(afterA.headers[cacheStatusHeader]).toBe('HIT');
+			expect(afterB.statusCode).toBe(200);
+			expect(afterB.headers[cacheStatusHeader]).toBe('MISS');
+		});
+	});
+
+	describe(oneLine`
+		A DERIVED path (member scoped by its own team, team by its own owner_ref)
+		value-scopes member reads by owner with no config naming another collection's
+		relation: the team.owner_ref path composes itself
+	`, () => {
+		// member.scoped_cache_fields = ['team']; team's = ['owner_ref']. Neither names
+		// `team.owner_ref` — it auto-derives. Reads/writes slice member by the owner
+		// like the explicit-path case, proving composition feeds the same machinery.
+		it.each(vendors)('%s', async (vendor) => {
+			const env = envs[vendor].envRedisScopedPurge;
+			const url = getUrl(vendor, env);
+			const auth = `Bearer ${USER.ADMIN.TOKEN}`;
+
+			const createMany = async (collection: string, items: object[]) => {
+				return (
+					await request(url).post(`/items/${collection}?fields=id`)
+						.send(items)
+						.set('Authorization', auth)
+				).body.data;
+			};
+
+			const addMember = async (team: number) => {
+				await request(url).post(`/items/${collectionMember}`)
+					.send({ team })
+					.set('Authorization', auth);
+			};
+
+			const [ownerA, ownerB] = await createMany(collectionGrandRelated, [
+				{ string_field: randomUUID() },
+				{ string_field: randomUUID() },
+			]);
+
+			const [teamA, teamB] = await createMany(collectionTeam, [
+				{ owner_ref: ownerA.id },
+				{ owner_ref: ownerB.id },
+			]);
+
+			await createMany(collectionMember, [
+				{ team: teamA.id },
+				{ team: teamB.id },
+			]);
+
+			const base =
+				`/items/${collectionMember}?filter[team][owner_ref][id][_eq]=`;
+
+			const readA = `${base}${ownerA.id}`;
+			const readB = `${base}${ownerB.id}`;
+
+			const read = (path: string) => {
+				return request(url).get(path)
+					.set('Authorization', auth);
+			};
+
+			await request(url).post(`/utils/cache/clear`)
+				.set('Authorization', auth);
+
+			await read(readA);
+			await read(readB);
+			const warmA = await read(readA);
+			const warmB = await read(readB);
+
+			expect(warmA.headers[cacheStatusHeader]).toBe('HIT');
+			expect(warmB.headers[cacheStatusHeader]).toBe('HIT');
+
+			// Write a member into owner B's team only.
+			await addMember(teamB.id);
+
+			const afterA = await read(readA);
+			const afterB = await read(readB);
+
+			// The derived team.owner_ref path resolved owner_ref=<ownerB> on both sides,
 			// so B's write dropped only B (MISS) and left A cached (HIT).
 			expect(afterA.statusCode).toBe(200);
 			expect(afterA.headers[cacheStatusHeader]).toBe('HIT');


### PR DESCRIPTION
Closes #220. Builds directly on the #214/#218 path primitive (now merged into hhh-dev).

## Why

#218 shipped multi-hop path pinning, but declaring the full path on the leaf couples its config to another collection's internals: `owned_sub_item.scoped_cache_fields = ['owned_item.owner_ref']` embeds the knowledge that `owned_item` has an `owner_ref`. Rename it on `owned_item` and the leaf's config silently breaks. A collection's cache config shouldn't reach into relations it doesn't own.

## How — derive paths from *local* scope fields

Each collection declares only its **own** column, and the multi-hop path composes itself:
- `team.scoped_cache_fields = ['owner_ref']`  (its own FK)
- `member.scoped_cache_fields = ['team']`  (its own FK)

`composeScopedCachePaths` (pure, in `scoped-cache.ts`) walks a relational scope field into its target collection's own scope fields, transitively, yielding `team.owner_ref` for `member` — no config names another collection's relation. The derived paths flow through the **same** #214 machinery: `collectionScopedCachePaths` now returns explicit-dotted entries **∪** derived ones, each re-resolved (a to-many hop drops it to the bare tag), then fed to the existing read-walk (`evalPathsAt`) and write-join (`snapshotScopedCachePathTags`). No new invalidation logic — this is a config layer on top.

- **Cycles** — `visited` set; a self/mutual reference terminates.
- **Diamonds** — deduped by path string in `collectionScopedCachePaths`.
- **Axis** — composing yields both the immediate FK slice and the derived grand-owner slice (more tags → more purge, never stale).
- **Terminal** — recursion stops at a scalar scope field or a target with no scope fields.

## Retrocompat

Additive. Explicit dotted `scoped_cache_fields` (the #218 form) still work — a dotted entry is used as-is and is **not** a compose head. No migration.

## Tests
Not a section — but for the reviewer: unit (`composeScopedCachePaths`) covers 2-hop, 3-hop, diamond, cycle, scalar (no compose), no-scope target, and dotted-skip. Blackbox adds a `member → team → owner` chain with **local** declarations and asserts owner-slice isolation (HIT/MISS), proving the derivation feeds the same read-walk + write-join as an explicit path (the #218 `owned_sub_item` explicit-path witness stays as the back-compat proof).

## Open questions
- Axis granularity: should composing be able to pin *only* the grand-owner axis (suppress the intermediate FK slice), or is emitting both always fine?
- Depth cap: currently unbounded except by the cycle guard — worth a max-hop limit for pathological schemas?
