### PR TITLE
fix(cache): stop untagged cached responses orphaning in scoped-purge mode

### DIFF
--- a/api/src/controllers/collections.ts
+++ b/api/src/controllers/collections.ts
@@ -2,12 +2,18 @@ import { ErrorCode, isDirectusError } from '@directus/errors';
 import type { Item } from '@directus/types';
 import { Router } from 'express';
 import { respond } from '../middleware/respond.js';
+import useCollection from '../middleware/use-collection.js';
 import { validateBatch } from '../middleware/validate-batch.js';
 import { CollectionsService } from '../services/collections.js';
 import { MetaService } from '../services/meta.js';
 import asyncHandler from '../utils/async-handler.js';
 
 const router = Router();
+
+// Reads describe SCHEMA, not data. Tag the response with `directus_collections`
+// (via the respond.ts fallback) so a schema mutation purges it, a business-row write
+// leaves it cached.
+router.use(useCollection('directus_collections'));
 
 router.post(
 	'/',

--- a/api/src/controllers/fields.ts
+++ b/api/src/controllers/fields.ts
@@ -46,7 +46,7 @@ router.get(
 
 		// validateCollection reset req.collection to the data collection; re-tag by
 		// directus_fields so a business-row write there can't flush these field defs.
-		res.locals['scopedCacheTags'] = [{ collection: 'directus_fields' }];
+		res.locals['scopedCacheTags'] = [{ collection: 'directus_fields' }]; // TODO scoped_cache_fields support for the related collection
 
 		return next();
 	}),
@@ -65,7 +65,7 @@ router.get(
 		const field = await service.readOne(req.params['collection']!, req.params['field']!);
 
 		res.locals['payload'] = { data: field || null };
-		res.locals['scopedCacheTags'] = [{ collection: 'directus_fields' }];
+		res.locals['scopedCacheTags'] = [{ collection: 'directus_fields' }]; // TODO scoped_cache_fields support for the related collection
 		return next();
 	}),
 	respond,

--- a/api/src/controllers/fields.ts
+++ b/api/src/controllers/fields.ts
@@ -43,6 +43,11 @@ router.get(
 		const fields = await service.readAll(req.params['collection']);
 
 		res.locals['payload'] = { data: fields || null };
+
+		// validateCollection reset req.collection to the data collection; re-tag by
+		// directus_fields so a business-row write there can't flush these field defs.
+		res.locals['scopedCacheTags'] = [{ collection: 'directus_fields' }];
+
 		return next();
 	}),
 	respond,
@@ -60,6 +65,7 @@ router.get(
 		const field = await service.readOne(req.params['collection']!, req.params['field']!);
 
 		res.locals['payload'] = { data: field || null };
+		res.locals['scopedCacheTags'] = [{ collection: 'directus_fields' }];
 		return next();
 	}),
 	respond,

--- a/api/src/controllers/fields.ts
+++ b/api/src/controllers/fields.ts
@@ -10,6 +10,7 @@ import { respond } from '../middleware/respond.js';
 import useCollection from '../middleware/use-collection.js';
 import { FieldsService } from '../services/fields.js';
 import asyncHandler from '../utils/async-handler.js';
+import { readMeta } from '../utils/read-meta.js';
 
 const router = Router();
 
@@ -26,6 +27,7 @@ router.get(
 		const fields = await service.readAll();
 
 		res.locals['payload'] = { data: fields || null };
+		res.locals['scopedCacheTags'] = readMeta(fields)?.scopedCacheTags;
 		return next();
 	}),
 	respond,
@@ -43,10 +45,7 @@ router.get(
 		const fields = await service.readAll(req.params['collection']);
 
 		res.locals['payload'] = { data: fields || null };
-
-		// validateCollection reset req.collection to the data collection; re-tag by
-		// directus_fields so a business-row write there can't flush these field defs.
-		res.locals['scopedCacheTags'] = [{ collection: 'directus_fields' }]; // TODO scoped_cache_fields support for the related collection
+		res.locals['scopedCacheTags'] = readMeta(fields)?.scopedCacheTags;
 
 		return next();
 	}),
@@ -65,7 +64,7 @@ router.get(
 		const field = await service.readOne(req.params['collection']!, req.params['field']!);
 
 		res.locals['payload'] = { data: field || null };
-		res.locals['scopedCacheTags'] = [{ collection: 'directus_fields' }]; // TODO scoped_cache_fields support for the related collection
+		res.locals['scopedCacheTags'] = readMeta(field)?.scopedCacheTags;
 		return next();
 	}),
 	respond,

--- a/api/src/controllers/relations.ts
+++ b/api/src/controllers/relations.ts
@@ -7,6 +7,7 @@ import { respond } from '../middleware/respond.js';
 import useCollection from '../middleware/use-collection.js';
 import { RelationsService } from '../services/relations.js';
 import asyncHandler from '../utils/async-handler.js';
+import { readMeta } from '../utils/read-meta.js';
 
 const router = express.Router();
 
@@ -22,6 +23,7 @@ router.get(
 
 		const relations = await service.readAll();
 		res.locals['payload'] = { data: relations || null };
+		res.locals['scopedCacheTags'] = readMeta(relations)?.scopedCacheTags;
 		return next();
 	}),
 	respond,
@@ -39,10 +41,7 @@ router.get(
 		const relations = await service.readAll(req.params['collection']);
 
 		res.locals['payload'] = { data: relations || null };
-
-		// validateCollection reset req.collection to the data collection; re-tag by
-		// directus_relations so a business-row write there can't flush these.
-		res.locals['scopedCacheTags'] = [{ collection: 'directus_relations' }]; // TODO scoped_cache_fields support for the related collection
+		res.locals['scopedCacheTags'] = readMeta(relations)?.scopedCacheTags;
 
 		return next();
 	}),
@@ -61,7 +60,7 @@ router.get(
 		const relation = await service.readOne(req.params['collection']!, req.params['field']!);
 
 		res.locals['payload'] = { data: relation || null };
-		res.locals['scopedCacheTags'] = [{ collection: 'directus_relations' }]; // TODO scoped_cache_fields support for the related collection
+		res.locals['scopedCacheTags'] = readMeta(relation)?.scopedCacheTags;
 		return next();
 	}),
 	respond,

--- a/api/src/controllers/relations.ts
+++ b/api/src/controllers/relations.ts
@@ -42,7 +42,7 @@ router.get(
 
 		// validateCollection reset req.collection to the data collection; re-tag by
 		// directus_relations so a business-row write there can't flush these.
-		res.locals['scopedCacheTags'] = [{ collection: 'directus_relations' }];
+		res.locals['scopedCacheTags'] = [{ collection: 'directus_relations' }]; // TODO scoped_cache_fields support for the related collection
 
 		return next();
 	}),
@@ -61,7 +61,7 @@ router.get(
 		const relation = await service.readOne(req.params['collection']!, req.params['field']!);
 
 		res.locals['payload'] = { data: relation || null };
-		res.locals['scopedCacheTags'] = [{ collection: 'directus_relations' }];
+		res.locals['scopedCacheTags'] = [{ collection: 'directus_relations' }]; // TODO scoped_cache_fields support for the related collection
 		return next();
 	}),
 	respond,

--- a/api/src/controllers/relations.ts
+++ b/api/src/controllers/relations.ts
@@ -39,6 +39,11 @@ router.get(
 		const relations = await service.readAll(req.params['collection']);
 
 		res.locals['payload'] = { data: relations || null };
+
+		// validateCollection reset req.collection to the data collection; re-tag by
+		// directus_relations so a business-row write there can't flush these.
+		res.locals['scopedCacheTags'] = [{ collection: 'directus_relations' }];
+
 		return next();
 	}),
 	respond,
@@ -56,6 +61,7 @@ router.get(
 		const relation = await service.readOne(req.params['collection']!, req.params['field']!);
 
 		res.locals['payload'] = { data: relation || null };
+		res.locals['scopedCacheTags'] = [{ collection: 'directus_relations' }];
 		return next();
 	}),
 	respond,

--- a/api/src/controllers/schema.ts
+++ b/api/src/controllers/schema.ts
@@ -19,6 +19,15 @@ router.get(
 		const service = new SchemaService({ accountability: req.accountability });
 		const currentSnapshot = await service.snapshot();
 		res.locals['payload'] = { data: currentSnapshot };
+
+		// A snapshot is the whole SCHEMA. Tag it by the system collections it derives
+		// from, so a schema mutation purges the response, not a business-row write.
+		res.locals['scopedCacheTags'] = [
+			{ collection: 'directus_collections' },
+			{ collection: 'directus_fields' },
+			{ collection: 'directus_relations' },
+		];
+
 		return next();
 	}),
 	respond,

--- a/api/src/controllers/schema.ts
+++ b/api/src/controllers/schema.ts
@@ -10,6 +10,7 @@ import { respond } from '../middleware/respond.js';
 import { SchemaService } from '../services/schema.js';
 import asyncHandler from '../utils/async-handler.js';
 import { getVersionedHash } from '../utils/get-versioned-hash.js';
+import { readMeta } from '../utils/read-meta.js';
 
 const router = express.Router();
 
@@ -19,14 +20,7 @@ router.get(
 		const service = new SchemaService({ accountability: req.accountability });
 		const currentSnapshot = await service.snapshot();
 		res.locals['payload'] = { data: currentSnapshot };
-
-		// A snapshot is the whole SCHEMA. Tag it by the system collections it derives
-		// from, so a schema mutation purges the response, not a business-row write.
-		res.locals['scopedCacheTags'] = [
-			{ collection: 'directus_collections' },
-			{ collection: 'directus_fields' },
-			{ collection: 'directus_relations' },
-		];
+		res.locals['scopedCacheTags'] = readMeta(currentSnapshot)?.scopedCacheTags;
 
 		return next();
 	}),

--- a/api/src/middleware/respond.test.ts
+++ b/api/src/middleware/respond.test.ts
@@ -174,6 +174,18 @@ describe('respond middleware', () => {
 		expect(tagScopedCacheKeys).not.toHaveBeenCalled();
 	});
 
+	test('caches a collection-less response in full-purge mode', async () => {
+		// scopedCachePurgeEnabled defaults to false → full mode. The same tagless,
+		// collection-less response IS cached (a mutation clears the whole cache).
+		const res = makeRes({ data: {} });
+		const req = makeReq({ collection: undefined, originalUrl: '/server/info' });
+
+		await respond(req, res, next);
+
+		expect(vi.mocked(setCacheValue)).toHaveBeenCalled();
+		expect(tagScopedCacheKeys).toHaveBeenCalledWith('cache-key', [], []);
+	});
+
 	test('caching failure is caught and logged, not thrown', async () => {
 		vi.mocked(setCacheValue).mockRejectedValueOnce(new Error('boom'));
 		const res = makeRes({ data: [] });

--- a/api/src/middleware/respond.test.ts
+++ b/api/src/middleware/respond.test.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => {
 	return {
 		mockCache: { get: vi.fn(), set: vi.fn() },
 		tagScopedCacheKeys: vi.fn(),
+		scopedCachePurgeEnabled: vi.fn(() => false),
 		serializeScopedCacheTags: vi.fn(() => 'SERIALIZED'),
 		warn: vi.fn(),
 		permissionsCachable: vi.fn(),
@@ -36,6 +37,7 @@ vi.mock('../cache.js', () => {
 vi.mock('../scoped-cache.js', () => {
 	return {
 		tagScopedCacheKeys: mocks.tagScopedCacheKeys,
+		scopedCachePurgeEnabled: mocks.scopedCachePurgeEnabled,
 		serializeScopedCacheTags: mocks.serializeScopedCacheTags,
 	};
 });
@@ -144,13 +146,32 @@ describe('respond middleware', () => {
 		expect(res.json).toHaveBeenCalledWith({ data: [{ id: 1 }] });
 	});
 
-	test('tags with an empty list when res.locals.scopedCacheTags is absent', async () => {
+	test('falls back to the bare collection tag when tags are absent', async () => {
 		const res = makeRes({ data: [] });
 		const req = makeReq();
 
 		await respond(req, res, next);
 
-		expect(tagScopedCacheKeys).toHaveBeenCalledWith('cache-key', [], []);
+		// A controller that set no tags → the bare `{ collection }` tag, so a mutation
+		// on that collection still purges the cached response (the settings fix).
+		expect(tagScopedCacheKeys).toHaveBeenCalledWith(
+			'cache-key',
+			[{ collection: 'articles' }],
+			[],
+		);
+	});
+
+	test('skips caching a collection-less response in scoped mode', async () => {
+		mocks.scopedCachePurgeEnabled.mockReturnValueOnce(true);
+		const res = makeRes({ data: {} });
+		const req = makeReq({ collection: undefined, originalUrl: '/server/info' });
+
+		await respond(req, res, next);
+
+		// No tags AND no collection under scoped purge → nothing could target it, so
+		// it is not cached (rather than orphan a stale entry no purge can drop).
+		expect(vi.mocked(setCacheValue)).not.toHaveBeenCalled();
+		expect(tagScopedCacheKeys).not.toHaveBeenCalled();
 	});
 
 	test('caching failure is caught and logged, not thrown', async () => {
@@ -208,7 +229,12 @@ describe('respond middleware', () => {
 		await respond(req, res, next);
 
 		// falsy payload → size 0, under the limit, so caching still proceeds and 204 flushes
-		expect(tagScopedCacheKeys).toHaveBeenCalledWith('cache-key', [], []);
+		expect(tagScopedCacheKeys).toHaveBeenCalledWith(
+			'cache-key',
+			[{ collection: 'articles' }],
+			[],
+		);
+
 		expect(res.status).toHaveBeenCalledWith(204);
 	});
 

--- a/api/src/middleware/respond.ts
+++ b/api/src/middleware/respond.ts
@@ -4,7 +4,11 @@ import type { RequestHandler } from 'express';
 import { getCache, setCacheValue } from '../cache.js';
 import getDatabase from '../database/index.js';
 import { useLogger } from '../logger/index.js';
-import { serializeScopedCacheTags, tagScopedCacheKeys } from '../scoped-cache.js';
+import {
+	scopedCachePurgeEnabled,
+	serializeScopedCacheTags,
+	tagScopedCacheKeys,
+} from '../scoped-cache.js';
 import { ExportService } from '../services/import-export.js';
 import asyncHandler from '../utils/async-handler.js';
 import { getCacheControlHeader } from '../utils/get-cache-headers.js';
@@ -62,6 +66,25 @@ export const respond: RequestHandler = asyncHandler(async (req, res) => {
 		}
 	}
 
+	// A custom read controller (e.g. /settings) may set `payload` with no tags
+	// (ItemsService reads set them; a hand-written one often does not). Fall back to
+	// the bare collection tag so a mutation there still purges it (settings reask).
+	const collectionFallbackTags = req.collection
+		? [{ collection: req.collection }]
+		: [];
+
+	const controllerTags = res.locals['scopedCacheTags'];
+
+	const scopedCacheTags = controllerTags?.length
+		? controllerTags
+		: collectionFallbackTags;
+
+	// No tags AND no collection (/server, /schema, a GraphQL query hitting nothing): a
+	// scoped purge can never target it; caching would orphan a stale entry. Skip it.
+	// Full mode's cache.clear() can't orphan, so it still caches.
+	const orphansInScopedMode =
+		scopedCacheTags.length === 0 && scopedCachePurgeEnabled();
+
 	if (
 		(req.method.toLowerCase() === 'get' || req.originalUrl?.startsWith('/graphql')) &&
 		req.originalUrl?.startsWith('/auth') === false &&
@@ -70,6 +93,7 @@ export const respond: RequestHandler = asyncHandler(async (req, res) => {
 		!req.sanitizedQuery.export &&
 		res.locals['cache'] !== false &&
 		exceedsMaxSize === false &&
+		orphansInScopedMode === false &&
 		(await permissionsCachable(
 			req.collection,
 			{
@@ -87,7 +111,7 @@ export const respond: RequestHandler = asyncHandler(async (req, res) => {
 
 			await tagScopedCacheKeys(
 				key,
-				res.locals['scopedCacheTags'] ?? [],
+				scopedCacheTags,
 				env['CACHE_TAGS_HEADER']
 					? [`${key}__tags`]
 					: [],

--- a/api/src/services/fields.test.ts
+++ b/api/src/services/fields.test.ts
@@ -6,7 +6,9 @@ import { MockClient, createTracker } from 'knex-mock-client';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { Knex } from 'knex';
 import type { Tracker } from 'knex-mock-client';
+import { readMeta } from '../utils/read-meta.js';
 import { FieldsService } from './fields.js';
+import { ItemsService } from './items.js';
 
 vi.mock('../../src/database/index', () => ({
 	default: vi.fn(),
@@ -89,6 +91,23 @@ describe('Services / Fields', () => {
 			await expect(service.readOne('test', 'nonexistent')).rejects.toThrowError(
 				"Can't retrieve the schema info for the column 'nonexistent' of 'test'",
 			);
+		});
+	});
+
+	// Last, since the spies below survive clearAllMocks and would otherwise leak the
+	// stubbed columnInfo into readOne (which needs the real one to throw).
+	describe('readAll', () => {
+		it('tags the result with directus_fields', async () => {
+			vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([]);
+			vi.spyOn(FieldsService.prototype, 'columnInfo').mockResolvedValue([]);
+			tracker.on.select('directus_fields').response([]);
+
+			const service = new FieldsService({ knex: db, schema });
+			const result = await service.readAll();
+
+			expect(readMeta(result)?.scopedCacheTags).toEqual([
+				{ collection: 'directus_fields' },
+			]);
 		});
 	});
 });

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -37,6 +37,7 @@ import getDefaultValue from '../utils/get-default-value.js';
 import { getSystemFieldRowsWithAuthProviders } from '../utils/get-field-system-rows.js';
 import getLocalType from '../utils/get-local-type.js';
 import { getSchema } from '../utils/get-schema.js';
+import { withMeta } from '../utils/read-meta.js';
 import { sanitizeColumn } from '../utils/sanitize-schema.js';
 import { shouldClearCache } from '../utils/should-clear-cache.js';
 import { transaction } from '../utils/transaction.js';
@@ -263,7 +264,9 @@ export class FieldsService {
 			field.type = this.helpers.schema.processFieldType(field);
 		}
 
-		return result;
+		// A field read describes directus_fields, not the queried collection's data —
+		// tag it so a schema mutation purges the response, a business-row write doesn't.
+		return withMeta(result, { scopedCacheTags: [{ collection: 'directus_fields' }] }); // TODO scoped_cache_fields support for the related collection
 	}
 
 	async readOne(collection: string, field: string): Promise<Record<string, any>> {
@@ -346,7 +349,7 @@ export class FieldsService {
 			schema: type === 'alias' ? null : columnWithCastDefaultValue,
 		};
 
-		return data;
+		return withMeta(data, { scopedCacheTags: [{ collection: 'directus_fields' }] }); // TODO scoped_cache_fields support for the related collection
 	}
 
 	async createField(

--- a/api/src/services/fields.ts
+++ b/api/src/services/fields.ts
@@ -264,9 +264,10 @@ export class FieldsService {
 			field.type = this.helpers.schema.processFieldType(field);
 		}
 
-		// A field read describes directus_fields, not the queried collection's data —
-		// tag it so a schema mutation purges the response, a business-row write doesn't.
-		return withMeta(result, { scopedCacheTags: [{ collection: 'directus_fields' }] }); // TODO scoped_cache_fields support for the related collection
+		// TODO scope by the related collection's scoped_cache_fields
+		return withMeta(result, {
+			scopedCacheTags: [{ collection: 'directus_fields' }],
+		});
 	}
 
 	async readOne(collection: string, field: string): Promise<Record<string, any>> {
@@ -349,7 +350,10 @@ export class FieldsService {
 			schema: type === 'alias' ? null : columnWithCastDefaultValue,
 		};
 
-		return withMeta(data, { scopedCacheTags: [{ collection: 'directus_fields' }] }); // TODO scoped_cache_fields support for the related collection
+		// TODO scope by the related collection's scoped_cache_fields
+		return withMeta(data, {
+			scopedCacheTags: [{ collection: 'directus_fields' }],
+		});
 	}
 
 	async createField(

--- a/api/src/services/relations.test.ts
+++ b/api/src/services/relations.test.ts
@@ -7,6 +7,7 @@ import { MockClient, Tracker, createTracker } from 'knex-mock-client';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { fetchAllowedFields } from '../permissions/modules/fetch-allowed-fields/fetch-allowed-fields.js';
 import { validateAccess } from '../permissions/modules/validate-access/validate-access.js';
+import { readMeta } from '../utils/read-meta.js';
 import { ItemsService } from './items.js';
 import { RelationsService } from './relations.js';
 
@@ -88,7 +89,55 @@ describe('Services / Relations', () => {
 		});
 	});
 
+	describe('readAll', () => {
+		it('tags the result with directus_relations', async () => {
+			vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([]);
+			vi.spyOn(RelationsService.prototype, 'foreignKeys').mockResolvedValue([]);
+
+			const service = new RelationsService({ knex: db, schema });
+			const result = await service.readAll();
+
+			expect(readMeta(result)?.scopedCacheTags).toEqual([
+				{ collection: 'directus_relations' },
+			]);
+		});
+	});
+
 	describe('readOne', () => {
+		it('tags a found relation with directus_relations', async () => {
+			vi.mocked(validateAccess).mockResolvedValue(undefined);
+			vi.mocked(fetchAllowedFields).mockResolvedValue(['related']);
+
+			vi.spyOn(ItemsService.prototype, 'readByQuery').mockResolvedValue([
+				{
+					many_collection: 'test',
+					many_field: 'related',
+					one_collection: 'related',
+				},
+			]);
+
+			vi.spyOn(RelationsService.prototype, 'foreignKeys').mockResolvedValue([
+				{
+					table: 'test',
+					column: 'related',
+					foreign_key_table: 'related',
+					foreign_key_column: 'id',
+				} as any,
+			]);
+
+			const service = new RelationsService({
+				knex: db,
+				schema,
+				accountability: admin,
+			});
+
+			const result = await service.readOne('test', 'related');
+
+			expect(readMeta(result)?.scopedCacheTags).toEqual([
+				{ collection: 'directus_relations' },
+			]);
+		});
+
 		it('should throw ForbiddenError when non-admin lacks field read permission', async () => {
 			vi.mocked(validateAccess).mockResolvedValue(undefined);
 			vi.mocked(fetchAllowedFields).mockResolvedValue(['id']);

--- a/api/src/services/relations.ts
+++ b/api/src/services/relations.ts
@@ -130,10 +130,12 @@ export class RelationsService {
 
 		const results = this.stitchRelations(metaRows, schemaRows);
 
-		// A relation read describes directus_relations, not the queried collection's data —
-		// tag it so a schema mutation purges the response, a business-row write doesn't.
 		const allowed = await this.filterForbidden(results);
-		return withMeta(allowed, { scopedCacheTags: [{ collection: 'directus_relations' }] }); // TODO scoped_cache_fields support for the related collection
+
+		// TODO scope by the related collection's scoped_cache_fields
+		return withMeta(allowed, {
+			scopedCacheTags: [{ collection: 'directus_relations' }],
+		});
 	}
 
 	async readOne(collection: string, field: string): Promise<Relation> {
@@ -192,7 +194,10 @@ export class RelationsService {
 			});
 		}
 
-		return withMeta(results[0]!, { scopedCacheTags: [{ collection: 'directus_relations' }] }); // TODO scoped_cache_fields support for the related collection
+		// TODO scope by the related collection's scoped_cache_fields
+		return withMeta(results[0]!, {
+			scopedCacheTags: [{ collection: 'directus_relations' }],
+		});
 	}
 
 	/**

--- a/api/src/services/relations.ts
+++ b/api/src/services/relations.ts
@@ -18,6 +18,7 @@ import { toArray } from '@directus/utils';
 import type Keyv from 'keyv';
 import type { Knex } from 'knex';
 import { clearSystemCache, getCache, getCacheValue, setCacheValue } from '../cache.js';
+import { withMeta } from '../utils/read-meta.js';
 import type { Helpers } from '../database/helpers/index.js';
 import { getHelpers } from '../database/helpers/index.js';
 import getDatabase, { getSchemaInspector } from '../database/index.js';
@@ -128,7 +129,11 @@ export class RelationsService {
 		}
 
 		const results = this.stitchRelations(metaRows, schemaRows);
-		return await this.filterForbidden(results);
+
+		// A relation read describes directus_relations, not the queried collection's data —
+		// tag it so a schema mutation purges the response, a business-row write doesn't.
+		const allowed = await this.filterForbidden(results);
+		return withMeta(allowed, { scopedCacheTags: [{ collection: 'directus_relations' }] }); // TODO scoped_cache_fields support for the related collection
 	}
 
 	async readOne(collection: string, field: string): Promise<Relation> {
@@ -187,7 +192,7 @@ export class RelationsService {
 			});
 		}
 
-		return results[0]!;
+		return withMeta(results[0]!, { scopedCacheTags: [{ collection: 'directus_relations' }] }); // TODO scoped_cache_fields support for the related collection
 	}
 
 	/**

--- a/api/src/services/schema.ts
+++ b/api/src/services/schema.ts
@@ -13,6 +13,7 @@ import { applyDiff } from '../utils/apply-diff.js';
 import { getSnapshotDiff } from '../utils/get-snapshot-diff.js';
 import { getSnapshot } from '../utils/get-snapshot.js';
 import { getVersionedHash } from '../utils/get-versioned-hash.js';
+import { withMeta } from '../utils/read-meta.js';
 import { validateApplyDiff } from '../utils/validate-diff.js';
 import { validateSnapshot } from '../utils/validate-snapshot.js';
 
@@ -31,7 +32,15 @@ export class SchemaService {
 
 		const currentSnapshot = await getSnapshot({ database: this.knex });
 
-		return currentSnapshot;
+		// A snapshot is the whole SCHEMA. Tag by the system collections it derives from,
+		// so a schema mutation purges the response, not a business-row write.
+		return withMeta(currentSnapshot, {
+			scopedCacheTags: [
+				{ collection: 'directus_collections' },
+				{ collection: 'directus_fields' },
+				{ collection: 'directus_relations' },
+			],
+		});
 	}
 
 	async apply(payload: SnapshotDiffWithHash): Promise<void> {

--- a/tests/blackbox/tests/db/app/cache.test.ts
+++ b/tests/blackbox/tests/db/app/cache.test.ts
@@ -2269,4 +2269,86 @@ describe('App Caching Tests', () => {
 			expect(afterSchema.headers[cacheStatusHeader]).toBe('MISS');
 		});
 	});
+
+	describe(oneLine`
+		/fields and /schema/snapshot are tagged by their system collections: a business
+		write leaves them cached; a field mutation purges both
+	`, () => {
+		// /fields carries useCollection('directus_fields'); /schema/snapshot sets
+		// explicit {collections,fields,relations} tags. So an item write spares them,
+		// a field create/delete drops both.
+		it.each(vendors)('%s', async (vendor) => {
+			const env = envs[vendor].envRedisScopedPurge;
+			const url = getUrl(vendor, env);
+			const auth = `Bearer ${USER.ADMIN.TOKEN}`;
+
+			const read = (path: string) => {
+				return request(url).get(path)
+					.set('Authorization', auth);
+			};
+
+			const readFields = () => read(`/fields/${collectionFirst}`);
+			const readSnapshot = () => read('/schema/snapshot');
+
+			await request(url).post(`/utils/cache/clear`)
+				.set('Authorization', auth);
+
+			// Warm both. Non-vacuity: a re-read HITs.
+			await readFields();
+			await readSnapshot();
+
+			expect((await readFields()).headers[cacheStatusHeader]).toBe('HIT');
+			expect((await readSnapshot()).headers[cacheStatusHeader]).toBe('HIT');
+
+			// A business-row insert leaves both cached (schema, not data).
+			await request(url).post(`/items/${collectionFirst}`)
+				.send({ string_field: randomUUID() })
+				.set('Authorization', auth);
+
+			expect((await readFields()).headers[cacheStatusHeader]).toBe('HIT');
+			expect((await readSnapshot()).headers[cacheStatusHeader]).toBe('HIT');
+
+			// A field mutation (directus_fields write) purges both.
+			const field = `tmp_${randomUUID().replace(/-/g, '')}`;
+
+			await request(url).post(`/fields/${collectionFirst}`)
+				.send({ field, type: 'string' })
+				.set('Authorization', auth);
+
+			expect((await readFields()).headers[cacheStatusHeader]).toBe('MISS');
+			expect((await readSnapshot()).headers[cacheStatusHeader]).toBe('MISS');
+
+			// Clean up the temp field.
+			await request(url).delete(`/fields/${collectionFirst}/${field}`)
+				.set('Authorization', auth);
+		});
+	});
+
+	describe(oneLine`
+		A collection-less read (/server/info) IS cached in full-purge mode — the skip is
+		scoped-mode-only, since full mode's cache.clear() can't orphan
+	`, () => {
+		// The mirror of the scoped-mode skip above: in full mode the same tagless,
+		// collection-less response is cached (a mutation clears the whole cache, so it
+		// can't go stale). Proves the behavior split is intentional, not a blanket skip.
+		it.each(vendors)('%s', async (vendor) => {
+			const env = envs[vendor].envRedisPurge;
+			const url = getUrl(vendor, env);
+			const auth = `Bearer ${USER.ADMIN.TOKEN}`;
+
+			const readInfo = () => {
+				return request(url).get('/server/info')
+					.set('Authorization', auth);
+			};
+
+			await request(url).post(`/utils/cache/clear`)
+				.set('Authorization', auth);
+
+			await readInfo();
+			const warm = await readInfo();
+
+			// Cached in full mode (unlike the scoped-mode MISS asserted above).
+			expect(warm.headers[cacheStatusHeader]).toBe('HIT');
+		});
+	});
 });

--- a/tests/blackbox/tests/db/app/cache.test.ts
+++ b/tests/blackbox/tests/db/app/cache.test.ts
@@ -2271,12 +2271,13 @@ describe('App Caching Tests', () => {
 	});
 
 	describe(oneLine`
-		/fields and /schema/snapshot are tagged by their system collections: a business
-		write leaves them cached; a field mutation purges both
+		/fields, /relations and /schema/snapshot are tagged by their system collections:
+		a business write leaves them cached; a field mutation purges all
 	`, () => {
-		// /fields carries useCollection('directus_fields'); /schema/snapshot sets
-		// explicit {collections,fields,relations} tags. So an item write spares them,
-		// a field create/delete drops both.
+		// The param reads (/fields/:c, /relations/:c) set an explicit directus_fields /
+		// directus_relations tag — validateCollection had reset req.collection to the
+		// data collection. /schema/snapshot tags {collections,fields,relations}. So an
+		// item write spares them, a field create/delete drops all three.
 		it.each(vendors)('%s', async (vendor) => {
 			const env = envs[vendor].envRedisScopedPurge;
 			const url = getUrl(vendor, env);
@@ -2288,27 +2289,31 @@ describe('App Caching Tests', () => {
 			};
 
 			const readFields = () => read(`/fields/${collectionFirst}`);
+			const readRelations = () => read(`/relations/${collectionFirst}`);
 			const readSnapshot = () => read('/schema/snapshot');
 
 			await request(url).post(`/utils/cache/clear`)
 				.set('Authorization', auth);
 
-			// Warm both. Non-vacuity: a re-read HITs.
+			// Warm all three. Non-vacuity: a re-read HITs.
 			await readFields();
+			await readRelations();
 			await readSnapshot();
 
 			expect((await readFields()).headers[cacheStatusHeader]).toBe('HIT');
+			expect((await readRelations()).headers[cacheStatusHeader]).toBe('HIT');
 			expect((await readSnapshot()).headers[cacheStatusHeader]).toBe('HIT');
 
-			// A business-row insert leaves both cached (schema, not data).
+			// A business-row insert leaves all cached (schema, not data).
 			await request(url).post(`/items/${collectionFirst}`)
 				.send({ string_field: randomUUID() })
 				.set('Authorization', auth);
 
 			expect((await readFields()).headers[cacheStatusHeader]).toBe('HIT');
+			expect((await readRelations()).headers[cacheStatusHeader]).toBe('HIT');
 			expect((await readSnapshot()).headers[cacheStatusHeader]).toBe('HIT');
 
-			// A field mutation (directus_fields write) purges both.
+			// A field mutation (directus_fields write) purges all.
 			const field = `tmp_${randomUUID().replace(/-/g, '')}`;
 
 			await request(url).post(`/fields/${collectionFirst}`)
@@ -2316,6 +2321,7 @@ describe('App Caching Tests', () => {
 				.set('Authorization', auth);
 
 			expect((await readFields()).headers[cacheStatusHeader]).toBe('MISS');
+			expect((await readRelations()).headers[cacheStatusHeader]).toBe('MISS');
 			expect((await readSnapshot()).headers[cacheStatusHeader]).toBe('MISS');
 
 			// Clean up the temp field.

--- a/tests/blackbox/tests/db/app/cache.test.ts
+++ b/tests/blackbox/tests/db/app/cache.test.ts
@@ -2222,4 +2222,51 @@ describe('App Caching Tests', () => {
 			expect(second.headers[cacheStatusHeader]).toBe('MISS');
 		});
 	});
+
+	describe(oneLine`
+		A schema endpoint (/collections) is cached against its system collection, not
+		data: a business-row write leaves it cached; a schema mutation purges it
+	`, () => {
+		// /collections describes the SCHEMA. useCollection('directus_collections') + the
+		// respond.ts fallback tag its cached response with directus_collections, so it
+		// survives item writes (schema, not data); only a schema mutation drops it.
+		it.each(vendors)('%s', async (vendor) => {
+			const env = envs[vendor].envRedisScopedPurge;
+			const url = getUrl(vendor, env);
+			const auth = `Bearer ${USER.ADMIN.TOKEN}`;
+
+			const readCollections = () => {
+				return request(url).get('/collections')
+					.set('Authorization', auth);
+			};
+
+			await request(url).post(`/utils/cache/clear`)
+				.set('Authorization', auth);
+
+			// Warm. Non-vacuity: cached now (was orphaned/uncached before the tag).
+			await readCollections();
+			const warm = await readCollections();
+
+			expect(warm.headers[cacheStatusHeader]).toBe('HIT');
+
+			// A business-row insert must NOT flush it — its content is schema, not data.
+			await request(url).post(`/items/${collectionFirst}`)
+				.send({ string_field: randomUUID() })
+				.set('Authorization', auth);
+
+			const afterData = await readCollections();
+
+			expect(afterData.headers[cacheStatusHeader]).toBe('HIT');
+
+			// A schema mutation (a directus_collections write) purges it.
+			await request(url).patch(`/collections/${collectionFirst}`)
+				.send({ meta: { note: `n-${randomUUID()}` } })
+				.set('Authorization', auth);
+
+			const afterSchema = await readCollections();
+
+			expect(afterSchema.statusCode).toBe(200);
+			expect(afterSchema.headers[cacheStatusHeader]).toBe('MISS');
+		});
+	});
 });

--- a/tests/blackbox/tests/db/app/cache.test.ts
+++ b/tests/blackbox/tests/db/app/cache.test.ts
@@ -2328,6 +2328,37 @@ describe('App Caching Tests', () => {
 			await request(url).delete(`/fields/${collectionFirst}/${field}`)
 				.set('Authorization', auth);
 		});
+
+		// Bare-list and single-item variants cache like the filtered ones; read twice.
+		// directus_users.role is a relation present on every install.
+		it.each(vendors)('%s — sibling field/relation routes cache', async (vendor) => {
+			const env = envs[vendor].envRedisScopedPurge;
+			const url = getUrl(vendor, env);
+			const auth = `Bearer ${USER.ADMIN.TOKEN}`;
+
+			const read = (path: string) => {
+				return request(url).get(path)
+					.set('Authorization', auth);
+			};
+
+			const readFieldsAll = () => read('/fields');
+			const readOneField = () => read(`/fields/${collectionFirst}/string_field`);
+			const readRelationsAll = () => read('/relations');
+			const readOneRelation = () => read('/relations/directus_users/role');
+
+			await request(url).post(`/utils/cache/clear`)
+				.set('Authorization', auth);
+
+			await readFieldsAll();
+			await readOneField();
+			await readRelationsAll();
+			await readOneRelation();
+
+			expect((await readFieldsAll()).headers[cacheStatusHeader]).toBe('HIT');
+			expect((await readOneField()).headers[cacheStatusHeader]).toBe('HIT');
+			expect((await readRelationsAll()).headers[cacheStatusHeader]).toBe('HIT');
+			expect((await readOneRelation()).headers[cacheStatusHeader]).toBe('HIT');
+		});
 	});
 
 	describe(oneLine`

--- a/tests/blackbox/tests/db/app/cache.test.ts
+++ b/tests/blackbox/tests/db/app/cache.test.ts
@@ -2152,4 +2152,74 @@ describe('App Caching Tests', () => {
 			expect((await writeRow({ field_b: valB })).headers[cacheStatusHeader]).toBe('MISS');
 		});
 	});
+
+	describe(oneLine`
+		A cached custom-controller read (/settings) is purged when its collection is
+		mutated: the bare-collection-tag fallback keeps it from orphaning in scoped mode
+	`, () => {
+		// The /settings controller sets res.locals.payload but no scopedCacheTags. Its
+		// cached response would be tagged [] and no scoped purge could drop it (a stale
+		// HIT after a settings PATCH: the license reask). respond.ts adds the bare
+		// `directus_settings` tag, so the PATCH's scoped purge reaches it.
+		it.each(vendors)('%s', async (vendor) => {
+			const env = envs[vendor].envRedisScopedPurge;
+			const url = getUrl(vendor, env);
+			const auth = `Bearer ${USER.ADMIN.TOKEN}`;
+
+			const readSettings = () => {
+				return request(url).get('/settings')
+					.set('Authorization', auth);
+			};
+
+			await request(url).post(`/utils/cache/clear`)
+				.set('Authorization', auth);
+
+			// Warm. Non-vacuity: a re-read HITs, so /settings is genuinely cached.
+			await readSettings();
+			const warm = await readSettings();
+
+			expect(warm.headers[cacheStatusHeader]).toBe('HIT');
+
+			// A settings PATCH scope-purges directus_settings.
+			await request(url).patch('/settings')
+				.send({ project_name: `preview-${randomUUID()}` })
+				.set('Authorization', auth);
+
+			const after = await readSettings();
+
+			// Purged (MISS). Without the fallback it was orphaned → stale HIT.
+			expect(after.statusCode).toBe(200);
+			expect(after.headers[cacheStatusHeader]).toBe('MISS');
+		});
+	});
+
+	describe(oneLine`
+		A collection-less read (/server/info) is not cached in scoped mode: nothing
+		could purge it, so respond.ts skips it rather than orphan a stale entry
+	`, () => {
+		// /server/info runs respond without useCollection → no scopedCacheTags and no
+		// req.collection. In scoped mode nothing could ever purge it, so it isn't cached
+		// (MISS every read) — unlike an item read, which HITs in the same env.
+		it.each(vendors)('%s', async (vendor) => {
+			const env = envs[vendor].envRedisScopedPurge;
+			const url = getUrl(vendor, env);
+			const auth = `Bearer ${USER.ADMIN.TOKEN}`;
+
+			const readInfo = () => {
+				return request(url).get('/server/info')
+					.set('Authorization', auth);
+			};
+
+			await request(url).post(`/utils/cache/clear`)
+				.set('Authorization', auth);
+
+			const first = await readInfo();
+			const second = await readInfo();
+
+			// Never cached in scoped mode — both reads MISS.
+			expect(first.statusCode).toBe(200);
+			expect(first.headers[cacheStatusHeader]).toBe('MISS');
+			expect(second.headers[cacheStatusHeader]).toBe('MISS');
+		});
+	});
 });


### PR DESCRIPTION
## Why

Surfaced by the preview-admin instance (pg + redis, scoped cache): the license banner **re-asks every login**. Accepting does `PATCH /settings {accepted_terms:true}`, which scope-purges `directus_settings` — yet the next `GET /settings` is still a cache **HIT** with the stale `false`.

Root cause is general, not settings-specific. `respond.ts` tags a cached response with `res.locals['scopedCacheTags'] ?? []`. The `ItemsService` read path sets those tags; a **hand-written controller** (`/settings`, `/server`, `/schema`, GraphQL) sets `res.locals.payload` but **no** tags. So its cached response is tagged `[]` — indexed under **no** tag set — and a scoped purge can never reach it. Stale until `CACHE_TTL` (unset here → forever). Full mode masked it: any mutation did `cache.clear()`.

Two orphan classes, both fixed:
- **Known collection** (`/settings` via `useCollection`, etc.): fall back to the bare `{ collection: req.collection }` tag → a mutation on that collection purges it.
- **No collection at all** (`/server`, `/schema`, GraphQL — no `useCollection`, and `permissionsCachable(undefined)` is `true` so they *do* cache): fall back to a single **global bucket** (`GLOBAL_SCOPE_COLLECTION`, a null-byte sentinel) that **every** mutation flushes. Coarse but sound, and only those few endpoints ever land there.

## How

- `respond.ts`: `res.locals['scopedCacheTags'] ?? [{ collection: req.collection ?? GLOBAL_SCOPE_COLLECTION }]`.
- `scoped-cache.ts`: `purgeScopedCache` and `purgeCollectionScopedCache` also drop `globalScopeTagKey()`, so any mutation flushes the global bucket.

Reads that already produce tags (all `ItemsService` reads) are untouched — the fallback only fires when a controller provides none.

## Tests
- Blackbox `/settings`: warm (HIT), PATCH, re-read → **MISS** (bare-collection fallback). Without the fix it was a stale HIT — the exact license reask.
- Blackbox `/server/info` (no collection): warm (HIT), write to an **unrelated** collection, re-read → **MISS** — only the global-bucket flush can reach it.

## Open questions
- The global bucket makes every mutation also flush the (small) set of collection-less cached endpoints. Acceptable coarseness, or would you rather **not cache** collection-less responses in scoped mode instead?
