### PR TITLE
ci(preview): comment the preview link + login on the PR

### DIFF
--- a/.github/workflows/preview-admin.yml
+++ b/.github/workflows/preview-admin.yml
@@ -32,6 +32,8 @@ concurrency:
 
 permissions:
   contents: read
+  # Post the preview link + throwaway credentials as a PR comment (pull_request_target runs).
+  pull-requests: write
 
 jobs:
   preview:
@@ -186,6 +188,30 @@ jobs:
           console.log('seeded items + sub_items');
           JS
           node /tmp/seed.mjs
+
+      - name: Comment the preview link on the PR
+        # PR events only — a workflow_dispatch run has no PR to comment on (URL +
+        # password still land on the run summary). URL/ADMIN_PASSWORD come from
+        # $GITHUB_ENV of the earlier steps. Throwaway instance, dies with the run.
+        if: github.event_name == 'pull_request_target'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          IDLE_MINUTES: ${{ inputs.idle_minutes || 15 }}
+        run: |
+          # Backticks are escaped (\`) so they stay literal markdown, not shell
+          # command substitution; $URL/$ADMIN_PASSWORD/$SHA still expand.
+          {
+            echo "### 🔎 Preview admin — \`${SHA}\`"
+            echo ""
+            echo "- **URL:** ${URL}/admin"
+            echo "- **Login:** admin@example.com / \`${ADMIN_PASSWORD}\`"
+            echo "- Seeded: \`items\` → \`sub_items\` (both with \`user_created\`)."
+            echo "- Ephemeral: auto-shuts-down after ${IDLE_MINUTES} min idle; the link dies with the run."
+          } > /tmp/preview-comment.md
+
+          gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --body-file /tmp/preview-comment.md
 
       - name: Stream logs + publish URL + idle shutdown
         env:


### PR DESCRIPTION
## Why

The Preview Admin workflow boots an ephemeral Directus behind a cloudflared tunnel, but the URL + admin password only ever landed on the **run Summary** — you had to open the Actions run to grab them. This posts them straight into the PR discussion so a reviewer is one click from the live preview.

## What

- New step **Comment the preview link on the PR** (pull_request_target runs only — a manual `workflow_dispatch` has no PR, and still gets the Summary).
- Posts URL `/admin`, the `admin@example.com` login + password, the seeded collections, and the idle-shutdown note via `gh pr comment`.
- Adds `pull-requests: write` to `permissions`.

## Security note (accepted)

The fork is **public**, so the comment (password included) is world-visible for the preview's life. Accepted because the instance is throwaway: random password, no real data (only seeded `items`/`sub_items`), auto-shuts-down after ~15min idle, and the tunnel dies with the run. If that ever feels too loose, the password can move to the members-only Summary and the comment carry only the link.

## Propagation

`workflow_dispatch` runs resolve this file from the **default branch** (`pr-controle`), so manual previews get the comment as soon as this merges. Auto-runs on a `Preview`-labelled PR based on `v11.10.1-hhh-dev` resolve the workflow from **that base** — where `preview-admin.yml` doesn't exist yet. To get auto-preview comments on the active feature PRs, the workflow (with this change) still needs to land on `v11.10.1-hhh-dev`.

## Open question

Each push to a Preview-labelled PR boots a fresh preview → a new comment per boot. Fine as a "dump", but I can make it a single sticky comment that updates in place if you'd rather not accumulate them.