### PR TITLE
ci(preview): add a re-run link to the preview admin comment

### DIFF
--- a/.github/workflows/preview-admin.yml
+++ b/.github/workflows/preview-admin.yml
@@ -199,6 +199,7 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           SHA: ${{ github.event.pull_request.head.sha }}
           IDLE_MINUTES: ${{ inputs.idle_minutes || 15 }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           # Backticks are escaped (\`) so they stay literal markdown, not shell
           # command substitution; $URL/$ADMIN_PASSWORD/$SHA still expand.
@@ -209,6 +210,7 @@ jobs:
             echo "- **Login:** admin@example.com / \`${ADMIN_PASSWORD}\`"
             echo "- Seeded: \`items\` → \`sub_items\` (both with \`user_created\`)."
             echo "- Ephemeral: auto-shuts-down after ${IDLE_MINUTES} min idle; the link dies with the run."
+            echo "- **Re-run:** [🔄 boot a fresh preview](${RUN_URL}) — then \"Re-run all jobs\"."
           } > /tmp/preview-comment.md
 
           gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --body-file /tmp/preview-comment.md


### PR DESCRIPTION
## Why

A preview is ephemeral — the tunnel and password die when the run idle-shuts-down. When you want another look, you currently have to dig into the Actions tab. This adds a one-click way back from the PR comment itself.

## What

The comment now ends with a **Re-run** link pointing at the current run's page. Opening it → **Re-run all jobs** boots a fresh instance (new URL + password) and posts a new comment.

Markdown comments have no native buttons, so it's a link, not a real button. Re-running the same run re-previews the **same commit** the comment is about (which is usually what you want); to preview a different ref, the manual `workflow_dispatch` is still there.