### PR TITLE
fix(api): await action hooks by default so read-backs see hook-created rows

### DIFF
--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -261,7 +261,7 @@ describe('Integration Tests', () => {
 				}
 			});
 
-			it('does not await action handlers by default (fire-and-forget)', async () => {
+			it('awaits action handlers by default', async () => {
 				let actionCompleted = false;
 
 				const handler = () =>
@@ -276,9 +276,32 @@ describe('Integration Tests', () => {
 
 				try {
 					await service.createOne({ name: 'Test' });
-					// Without awaitActionHooks, createOne resolves without waiting for the macrotask handler.
-					expect(actionCompleted).toBe(false);
+					// This fork awaits action hooks by default.
+					expect(actionCompleted).toBe(true);
 				} finally {
+					emitter.offAction('test.items.create', handler);
+				}
+			});
+
+			it('skips awaiting when awaitActionHooks is false', async () => {
+				let actionCompleted = false;
+
+				const handler = () => {
+					return new Promise<void>((resolve) => {
+						setTimeout(() => {
+							actionCompleted = true;
+							resolve();
+						}, 0);
+					});
+				};
+
+				emitter.onAction('test.items.create', handler);
+
+				try {
+					await service.createOne({ name: 'Test' }, { awaitActionHooks: false });
+					expect(actionCompleted).toBe(false);
+				}
+				finally {
 					emitter.offAction('test.items.create', handler);
 				}
 			});

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -57,10 +57,9 @@ import { PayloadService } from './payload.js';
 const env = useEnv();
 
 /**
- * Emit a mutation's action events (the item's own event plus any queued nested ones) in parallel.
- * They run together, so a slow handler on one event doesn't serialize the rest. By default the
- * mutation does not wait for them (Directus' historical fire-and-forget behaviour); pass
- * `awaitActionHooks` to block until every handler has settled.
+ * Emit a mutation's action events in parallel. This fork awaits them by default so a
+ * mutation read-back sees rows its action hooks create (e.g. the notifying fan-out).
+ * Pass `awaitActionHooks: false` for the historical fire-and-forget behaviour.
  */
 async function emitActionEvents(actionEvents: ActionEventParams[], opts: MutationOptions): Promise<void> {
 	const emitting = Promise.all(
@@ -70,7 +69,7 @@ async function emitActionEvents(actionEvents: ActionEventParams[], opts: Mutatio
 				: emitter.emitAction(actionEvent.event, actionEvent.meta, actionEvent.context),),
 	);
 
-	if (opts.awaitActionHooks) {
+	if (opts.awaitActionHooks !== false) {
 		await emitting;
 	}
 	else {


### PR DESCRIPTION
## Why

`awaitActionHooks` landed on `v11.10.1-hhh-dev` but stayed **opt-in and dormant** — no caller sets it, so it never activates. The consequence: an action hook that creates rows (the planner's `grouped_notification` recipient + notification fan-out) runs fire-and-forget, so the triggering mutation's read-back comes back empty. `v11.9.2-hhh-dev` awaited action hooks by default; that behaviour never ported here.

This flips `emitActionEvents` to **await by default** (opt out with `awaitActionHooks: false`). `emitter.emitAction` already catches + logs per-event errors, so awaiting waits for handlers without propagating their failures into the mutation.

## Scope / open questions

- This is a **global** behaviour change: every mutation now waits for its action hooks (matching v11.9.2). Slow hooks (flows/webhooks) will add latency to the response — is default-on what you want here, or would you rather gate it behind an env flag?
- Only the mutation path routes through `emitActionEvents`; read action hooks stay fire-and-forget (unchanged).

Assisted-by: Claude:claude-opus-4-8