### PR TITLE
feat(cache): live per-path/method/query TTL rules [PARKED]

### DIFF
--- a/api/src/cache-ttl-rules.ts
+++ b/api/src/cache-ttl-rules.ts
@@ -1,0 +1,121 @@
+import { useEnv } from '@directus/env';
+import type { Knex } from 'knex';
+import { useBus } from './bus/index.js';
+import getDatabase from './database/index.js';
+import { redisConfigAvailable } from './redis/index.js';
+import { getMilliseconds } from './utils/get-milliseconds.js';
+
+const messenger = useBus();
+
+export type CacheQueryShape = 'aggregate' | 'item' | 'list';
+
+export interface CacheTtlRule {
+	path: string; // endpoint prefix, e.g. '/items/articles'
+	method: string; // 'GET' | 'SEARCH' | '*'
+	queryShape: CacheQueryShape | '*';
+	ttl: string | number; // human ('1h') or ms
+	sort: number; // first-match order
+}
+
+export interface CacheTtlDescriptor {
+	path: string;
+	method: string;
+	queryShape: CacheQueryShape;
+}
+
+// null = not yet loaded from the table; [] = loaded, no rules.
+let cachedRules: CacheTtlRule[] | null = null;
+let rulesSubscribed = false;
+
+interface CacheTtlRulesMessage {
+	reload: true;
+}
+
+if (redisConfigAvailable() && !rulesSubscribed) {
+	rulesSubscribed = true;
+
+	// Drop the in-memory copy so the next resolve reloads cluster-wide — same
+	// live-flip pattern as schemaChanged / cacheStatsToggled.
+	messenger.subscribe<CacheTtlRulesMessage>('cacheTtlRulesChanged', () => {
+		cachedRules = null;
+	});
+}
+
+export function classifyCacheQueryShape(sanitizedQuery: Record<string, unknown> | undefined): CacheQueryShape {
+	if (sanitizedQuery?.['aggregate']) return 'aggregate';
+	// A collection read carries list controls; a single-item read does not.
+	if (sanitizedQuery?.['filter'] || sanitizedQuery?.['search'] || sanitizedQuery?.['limit']) return 'list';
+	return 'item';
+}
+
+async function loadCacheTtlRules(knex: Knex): Promise<CacheTtlRule[]> {
+	const rows = await knex
+		.select('path', 'method', 'query_shape', 'ttl', 'sort')
+		.from('directus_cache_ttl_rules')
+		.orderBy('sort', 'asc');
+
+	return rows.map((row) => ({
+		path: row.path,
+		method: row.method,
+		queryShape: row.query_shape,
+		ttl: row.ttl,
+		sort: row.sort,
+	}));
+}
+
+function matchesCacheTtlRule(rule: CacheTtlRule, descriptor: CacheTtlDescriptor): boolean {
+	if (rule.method !== '*' && rule.method.toLowerCase() !== descriptor.method.toLowerCase()) {
+		return false;
+	}
+
+	if (rule.queryShape !== '*' && rule.queryShape !== descriptor.queryShape) {
+		return false;
+	}
+
+	return descriptor.path === rule.path || descriptor.path.startsWith(rule.path);
+}
+
+/**
+ * Resolve the TTL (ms) for a to-be-cached response.
+ *
+ * - First matching rule by `sort` wins; no match falls back to the global CACHE_TTL.
+ * - Rules load lazily into memory and stay until a bus 'cacheTtlRulesChanged' clears them,
+ *   so the hot path never touches the DB once warm.
+ */
+export async function resolveCacheTtl(descriptor: CacheTtlDescriptor): Promise<number | undefined> {
+	if (cachedRules === null) {
+		try {
+			cachedRules = await loadCacheTtlRules(getDatabase());
+		}
+		catch {
+			// Table absent (pre-migration) or read failed: behave as no rules.
+			cachedRules = [];
+		}
+	}
+
+	const match = cachedRules.find((rule) => matchesCacheTtlRule(rule, descriptor));
+
+	return getMilliseconds(match ? match.ttl : useEnv()['CACHE_TTL'], undefined);
+}
+
+/** Persist the full rule set and flip every node live. */
+export async function setCacheTtlRules(knex: Knex, rules: CacheTtlRule[]): Promise<void> {
+	await knex.transaction(async (trx) => {
+		await trx('directus_cache_ttl_rules').del();
+
+		if (rules.length) {
+			await trx('directus_cache_ttl_rules').insert(
+				rules.map((rule, index) => ({
+					path: rule.path,
+					method: rule.method,
+					query_shape: rule.queryShape,
+					ttl: String(rule.ttl),
+					sort: rule.sort ?? index,
+				})),
+			);
+		}
+	});
+
+	cachedRules = null;
+	messenger.publish<CacheTtlRulesMessage>('cacheTtlRulesChanged', { reload: true });
+}

--- a/api/src/database/migrations/20260721A-add-cache-ttl-rules.ts
+++ b/api/src/database/migrations/20260721A-add-cache-ttl-rules.ts
@@ -1,0 +1,16 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+	await knex.schema.createTable('directus_cache_ttl_rules', (table) => {
+		table.increments('id').primary();
+		table.string('path').notNullable(); // endpoint prefix
+		table.string('method', 10).notNullable().defaultTo('*');
+		table.string('query_shape', 12).notNullable().defaultTo('*');
+		table.string('ttl').notNullable(); // human ('1h') or ms string
+		table.integer('sort').notNullable().defaultTo(0);
+	});
+}
+
+export async function down(knex: Knex): Promise<void> {
+	await knex.schema.dropTable('directus_cache_ttl_rules');
+}

--- a/api/src/middleware/respond.ts
+++ b/api/src/middleware/respond.ts
@@ -1,6 +1,7 @@
 import { useEnv } from '@directus/env';
 import { parse as parseBytesConfiguration } from 'bytes';
 import type { RequestHandler } from 'express';
+import { classifyCacheQueryShape, resolveCacheTtl } from '../cache-ttl-rules.js';
 import { getCache, setCacheValue } from '../cache.js';
 import getDatabase from '../database/index.js';
 import { useLogger } from '../logger/index.js';
@@ -14,7 +15,6 @@ import asyncHandler from '../utils/async-handler.js';
 import { getCacheControlHeader } from '../utils/get-cache-headers.js';
 import { getCacheKey } from '../utils/get-cache-key.js';
 import { getDateFormatted } from '../utils/get-date-formatted.js';
-import { getMilliseconds } from '../utils/get-milliseconds.js';
 import { stringByteSize } from '../utils/get-string-byte-size.js';
 import { permissionsCachable } from '../utils/permissions-cachable.js';
 
@@ -105,9 +105,15 @@ export const respond: RequestHandler = asyncHandler(async (req, res) => {
 	) {
 		const key = await getCacheKey(req);
 
+		const ttlMs = await resolveCacheTtl({
+			path: req.originalUrl.split('?')[0]!,
+			method: req.method,
+			queryShape: classifyCacheQueryShape(req.sanitizedQuery),
+		});
+
 		try {
-			await setCacheValue(cache, key, res.locals['payload'], getMilliseconds(env['CACHE_TTL']));
-			await setCacheValue(cache, `${key}__expires_at`, { exp: Date.now() + getMilliseconds(env['CACHE_TTL'], 0) });
+			await setCacheValue(cache, key, res.locals['payload'], ttlMs);
+			await setCacheValue(cache, `${key}__expires_at`, { exp: Date.now() + (ttlMs ?? 0) });
 
 			await tagScopedCacheKeys(
 				key,
@@ -129,7 +135,7 @@ export const respond: RequestHandler = asyncHandler(async (req, res) => {
 						cache,
 						`${key}__tags`,
 						{ tags: serializeScopedCacheTags(pins) },
-						getMilliseconds(env['CACHE_TTL']),
+						ttlMs,
 					);
 				}
 			}
@@ -138,7 +144,7 @@ export const respond: RequestHandler = asyncHandler(async (req, res) => {
 			logger.warn(err, `[cache] Couldn't set key ${key}. ${err}`);
 		}
 
-		res.setHeader('Cache-Control', getCacheControlHeader(req, getMilliseconds(env['CACHE_TTL']), true, true));
+		res.setHeader('Cache-Control', getCacheControlHeader(req, ttlMs, true, true));
 		res.setHeader('Vary', 'Origin, Cache-Control');
 	}
 	else {


### PR DESCRIPTION
## Why

Today one global `CACHE_TTL` (default `5m`) is applied to **every** cached response. With `CACHE_AUTO_PURGE` on, writes already invalidate scoped entries, so the TTL only actually bites entries that *aren't* purged — i.e. stable-but-expensive reads (aggregations, low-churn deep reads). Those are exactly the ones I'd like to keep cached much longer to take pressure off Postgres, while volatile endpoints stay short. A single knob can't express that.

This makes the TTL a **first-match rule set** keyed on `path` + `method` + `query shape` (aggregate / item / list), falling back to the global `CACHE_TTL` on no match — so an empty table is byte-for-byte the current behavior.

## How

- `directus_cache_ttl_rules` table (`path` prefix, `method`, `query_shape`, `ttl`, `sort`).
- `cache-ttl-rules.ts`: `resolveCacheTtl(descriptor)` — lazy in-memory load, first-match by `sort`. Cleared cluster-wide by a `cacheTtlRulesChanged` bus message (same live-flip as `schemaChanged` / `cacheStatsToggled`), so **edits apply live without redeploy** and the hot path never hits the DB once warm.
- `respond.ts`: resolve the TTL once and thread it through the stored value, `__expires_at`, `__tags`, **and** the CDN `Cache-Control` header (previously all read the global env directly).

## Chosen tradeoffs (open to pushback)

- **Rules store, not the descriptor table.** The Redis/PG descriptor is per-*key* telemetry created *after* a fill — wrong shape and wrong lifecycle to author a *policy* that must be known *before* the entry exists. Kept separate.
- **Custom endpoints over `/items`.** A `directus_*` table can't be CRUD'd via `/items` (forbidden), so config will go through `/utils/cache/ttl-rules` (matches the existing `/utils/cache/*` family) rather than a registered system collection.
- **Query shape is coarse** (aggregate / item / list). Enough to separate expensive aggregates from cheap item reads; open to a finer axis if you want one.

## Parked / TODO before un-drafting

- [ ] `GET`/`POST /utils/cache/ttl-rules` controller endpoints (`setCacheTtlRules` already exists).
- [ ] Admin Cache page: "Apply recommended TTL" action wiring the existing p95 recommendation into a rule.
- [ ] `cache-ttl-rules.test.ts` (classifier decoys, first-match/sort, wildcards, prefix match, missing-table fallback, bus reload).

## Out of scope

- Per-entry live override (extend/shorten one existing cached entry from the page) — that *is* a good fit for the descriptor handle, but it's a separate firefighting feature, not this policy layer.

Stacked on `v11.10.1-feat/scoped-cache-derived-paths` (needs its `respond.ts` scoped-cache fill block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)