### PR TITLE
fix(items): translate DB errors on the delete path (#280)

### DIFF
--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -1,4 +1,8 @@
-import { ForbiddenError, InvalidForeignKeyError, InvalidPayloadError } from '@directus/errors';
+import {
+	ForbiddenError,
+	InvalidForeignKeyError,
+	InvalidPayloadError,
+} from '@directus/errors';
 import { SchemaBuilder } from '@directus/schema-builder';
 import { UserIntegrityCheckFlag } from '@directus/types';
 import { oneLine } from '@directus/utils';
@@ -629,10 +633,11 @@ describe('Integration Tests', () => {
 				filterSpy.mockRestore();
 			});
 
-			it('translates a raw DB constraint error from the delete write (parity with create/update)', async () => {
-				const fkError: any = new Error(
-					'update or delete on table "parent" violates foreign key constraint "child_parent_foreign" on table "child"',
-				);
+			it('translates a raw DB error from a direct delete write', async () => {
+				const fkError: any = new Error(oneLine`
+					update or delete on table "parent" violates foreign key
+					constraint "child_parent_foreign" on table "child"
+				`);
 
 				fkError.code = '23503';
 				fkError.table = 'child';
@@ -640,7 +645,9 @@ describe('Integration Tests', () => {
 
 				tracker.on.delete('test').simulateError(fkError);
 
-				await expect(service.deleteMany([1])).rejects.toThrow(InvalidForeignKeyError);
+				await expect(service.deleteMany([1])).rejects.toThrow(
+					InvalidForeignKeyError,
+				);
 			});
 		});
 

--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -1,4 +1,4 @@
-import { ForbiddenError, InvalidPayloadError } from '@directus/errors';
+import { ForbiddenError, InvalidForeignKeyError, InvalidPayloadError } from '@directus/errors';
 import { SchemaBuilder } from '@directus/schema-builder';
 import { UserIntegrityCheckFlag } from '@directus/types';
 import { oneLine } from '@directus/utils';
@@ -627,6 +627,20 @@ describe('Integration Tests', () => {
 
 				transactionSpy.mockRestore();
 				filterSpy.mockRestore();
+			});
+
+			it('translates a raw DB constraint error from the delete write (parity with create/update)', async () => {
+				const fkError: any = new Error(
+					'update or delete on table "parent" violates foreign key constraint "child_parent_foreign" on table "child"',
+				);
+
+				fkError.code = '23503';
+				fkError.table = 'child';
+				fkError.detail = 'Key (id)=(1) is still referenced from table "child".';
+
+				tracker.on.delete('test').simulateError(fkError);
+
+				await expect(service.deleteMany([1])).rejects.toThrow(InvalidForeignKeyError);
 			});
 		});
 

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -1772,8 +1772,15 @@ implements AbstractService<Item> {
 		}
 
 		await transaction(this.knex, async (trx) => {
-			await trx(this.collection).whereIn(primaryKeyField, keys)
-				.delete();
+			try {
+				await trx(this.collection).whereIn(primaryKeyField, keys)
+					.delete();
+			}
+			catch (err: any) {
+				// Parity with createOne/updateMany: a direct delete's FK/constraint
+				// violation must surface as a translated Directus error, not raw knex.
+				throw await translateDatabaseError(err, {}, this.knex);
+			}
 
 			if (opts.userIntegrityCheckFlags) {
 				if (opts.onRequireUserIntegrityCheck) {

--- a/tests/blackbox/tests/db/routes/items/db-error-translation.seed.ts
+++ b/tests/blackbox/tests/db/routes/items/db-error-translation.seed.ts
@@ -33,8 +33,9 @@ export const seedDBStructure = () => {
 				//   insert reaches the database and surfaces as RECORD_NOT_UNIQUE.
 				// - contains_null: a nullable field the test later alters to NOT NULL while
 				//   a row holds null, surfacing CONTAINS_NULL_VALUES from the schema alter.
-				// - fk_parent/fk_child: the child gets an M2O below, so pointing it at a
-				//   missing parent id surfaces INVALID_FOREIGN_KEY.
+				// - fk_parent/fk_child: the child gets a NO ACTION M2O below, so pointing
+				//   it at a missing parent id surfaces INVALID_FOREIGN_KEY on insert, and
+				//   deleting a still-referenced parent surfaces it on delete.
 				await CreateCollections(vendor, {
 					collections: [
 						{
@@ -68,7 +69,7 @@ export const seedDBStructure = () => {
 					collection: collectionFkChild,
 					field: 'parent',
 					otherCollection: collectionFkParent,
-					relationSchema: { on_delete: 'SET NULL' },
+					relationSchema: { on_delete: 'NO ACTION' },
 				});
 
 				expect(true).toBeTruthy();

--- a/tests/blackbox/tests/db/routes/items/db-error-translation.test.ts
+++ b/tests/blackbox/tests/db/routes/items/db-error-translation.test.ts
@@ -106,9 +106,12 @@ describe('translateDatabaseError', () => {
 				.delete(`/items/${collectionFkParent}/${parentId}`)
 				.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
 
-			// Assert
+			// Assert: the translated Directus error, not the raw driver string.
+			// Only the 'Invalid foreign key' prefix is stable across vendors —
+			// sqlite yields it bare, pg appends the field/collection.
 			expect(response.statusCode).toBe(400);
 			expect(response.body.errors[0].extensions.code).toBe('INVALID_FOREIGN_KEY');
+			expect(response.body.errors[0].message).toContain('Invalid foreign key');
 		});
 	});
 });

--- a/tests/blackbox/tests/db/routes/items/db-error-translation.test.ts
+++ b/tests/blackbox/tests/db/routes/items/db-error-translation.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'vitest';
 import {
 	collectionContainsNull,
 	collectionFkChild,
+	collectionFkParent,
 	collectionUnique,
 } from './db-error-translation.seed';
 
@@ -77,6 +78,32 @@ describe('translateDatabaseError', () => {
 			const response = await request(getUrl(vendor))
 				.post(`/items/${collectionFkChild}`)
 				.send({ parent: 999999 })
+				.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+			// Assert
+			expect(response.statusCode).toBe(400);
+			expect(response.body.errors[0].extensions.code).toBe('INVALID_FOREIGN_KEY');
+		});
+	});
+
+	describe('delete a still-referenced parent -> INVALID_FOREIGN_KEY', () => {
+		it.each(vendors)('%s', async (vendor) => {
+			// Setup: a parent and a child pointing at it
+			const parent = await request(getUrl(vendor))
+				.post(`/items/${collectionFkParent}`)
+				.send({})
+				.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+			const parentId = parent.body.data.id;
+
+			await request(getUrl(vendor))
+				.post(`/items/${collectionFkChild}`)
+				.send({ parent: parentId })
+				.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+			// Action: delete the still-referenced parent
+			const response = await request(getUrl(vendor))
+				.delete(`/items/${collectionFkParent}/${parentId}`)
 				.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
 
 			// Assert

--- a/tests/blackbox/tests/db/routes/items/db-error-translation.test.ts
+++ b/tests/blackbox/tests/db/routes/items/db-error-translation.test.ts
@@ -111,7 +111,9 @@ describe('translateDatabaseError', () => {
 			// Pin the full string where we know it; other vendors (Full matrix)
 			// still assert the translated prefix.
 			const exactMessage: Record<string, string> = {
-				postgres: `Invalid foreign key for field "id" in collection "${collectionFkChild}".`,
+				postgres:
+					`Invalid foreign key for field "id" ` +
+					`in collection "${collectionFkChild}".`,
 				sqlite3: 'Invalid foreign key.',
 			};
 

--- a/tests/blackbox/tests/db/routes/items/db-error-translation.test.ts
+++ b/tests/blackbox/tests/db/routes/items/db-error-translation.test.ts
@@ -106,12 +106,25 @@ describe('translateDatabaseError', () => {
 				.delete(`/items/${collectionFkParent}/${parentId}`)
 				.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
 
-			// Assert: the translated Directus error, not the raw driver string.
-			// Only the 'Invalid foreign key' prefix is stable across vendors —
-			// sqlite yields it bare, pg appends the field/collection.
+			// The translated message is vendor-specific: sqlite can't extract the
+			// column so it yields the bare prefix, pg names the field/collection.
+			// Pin the full string where we know it; other vendors (Full matrix)
+			// still assert the translated prefix.
+			const exactMessage: Record<string, string> = {
+				postgres: `Invalid foreign key for field "id" in collection "${collectionFkChild}".`,
+				sqlite3: 'Invalid foreign key.',
+			};
+
+			// Assert
 			expect(response.statusCode).toBe(400);
 			expect(response.body.errors[0].extensions.code).toBe('INVALID_FOREIGN_KEY');
-			expect(response.body.errors[0].message).toContain('Invalid foreign key');
+
+			if (exactMessage[vendor]) {
+				expect(response.body.errors[0].message).toBe(exactMessage[vendor]);
+			}
+			else {
+				expect(response.body.errors[0].message).toContain('Invalid foreign key');
+			}
 		});
 	});
 });


### PR DESCRIPTION
Fixes #280.

## Why

`ItemsService` translates raw driver errors into structured Directus errors on **create** and **update**, but the **delete** path ran its write outside any try/catch. So a constraint violation from a *direct* delete — the classic FK `RESTRICT`/`NO ACTION` (`23503`) when you delete a parent that still has children — leaked the raw knex/pg error to the API consumer, instead of the `InvalidForeignKeyError` (HTTP 400, `{ collection, field, value }`) the same underlying error yields on create/update. Same root cause, inconsistent surface depending on the verb.

## How

Wrap the write in `deleteMany` in the same try/catch → `translateDatabaseError` that `createOne`/`updateMany` already use, and rethrow. `deleteOne` and `deleteByQuery` both delegate to `deleteMany`, so the whole delete family is covered in one place. I pass `{}` as the `data` arg — a delete carries no payload, so the translated error's `value` is `null` (the translators guard `field ? data[field] : null`).

## Why it slipped through

A delete that runs *nested* inside a relational create/update (a cascade within `createMany`/`updateMany`) was already translated, because it inherits that method's try/catch — so existing tests never exercised the gap. The new unit test drives a **direct** `deleteMany`, makes the mocked delete throw a pg `23503`, and asserts an `InvalidForeignKeyError` surfaces. I verified it's non-vacuous: it fails on the base (raw error leaks) and passes with the fix.

## Open questions

- Pass `{}` vs a shared sentinel for the no-payload `data` arg — went with the inline `{}`; happy to change if you'd rather a named const.
- The same gap exists upstream in `directus/directus`; want me to send this there too?

🤖 Generated with [Claude Code](https://claude.com/claude-code)