### PR TITLE
feat(errors): enrich foreign-key violation translation (#287)

### DIFF
--- a/api/src/database/errors/dialects/mysql.test.ts
+++ b/api/src/database/errors/dialects/mysql.test.ts
@@ -203,6 +203,7 @@ describe('foreign key violation', () => {
 			constraint: 'fk',
 			relatedCollection: 'authors',
 			reason: 'invalid_reference',
+			operation: null,
 		});
 	});
 
@@ -216,7 +217,10 @@ describe('foreign key violation', () => {
 			sql: 'delete from `enrollment` where `id` = ?',
 		});
 
-		const result = extractError(error, {}, 'enrollment');
+		const result = extractError(error, {}, {
+			collection: 'enrollment',
+			operation: 'delete',
+		});
 
 		expect(result).toBeInstanceOf(InvalidForeignKeyError);
 
@@ -227,6 +231,7 @@ describe('foreign key violation', () => {
 			constraint: 'fk',
 			relatedCollection: 'student_enrollment',
 			reason: 'still_referenced',
+			operation: 'delete',
 		});
 	});
 

--- a/api/src/database/errors/dialects/mysql.test.ts
+++ b/api/src/database/errors/dialects/mysql.test.ts
@@ -182,8 +182,8 @@ describe('not null violation (ER_BAD_NULL_ERROR)', () => {
 	});
 });
 
-describe('foreign key violation (ER_NO_REFERENCED_ROW_2)', () => {
-	it('maps to InvalidForeignKeyError with collection and field', () => {
+describe('foreign key violation', () => {
+	it('maps an invalid reference, naming the parent + constraint', () => {
 		const error = mysqlError({
 			code: 'ER_NO_REFERENCED_ROW_2',
 			sqlMessage:
@@ -200,6 +200,33 @@ describe('foreign key violation (ER_NO_REFERENCED_ROW_2)', () => {
 			collection: 'articles',
 			field: 'author',
 			value: 42,
+			constraint: 'fk',
+			relatedCollection: 'authors',
+			reason: 'invalid_reference',
+		});
+	});
+
+	it('maps a still-referenced delete to the operated parent', () => {
+		const error = mysqlError({
+			code: 'ER_ROW_IS_REFERENCED_2',
+			sqlMessage:
+				'Cannot delete or update a parent row: a foreign key constraint ' +
+				'fails (`db`.`student_enrollment`, CONSTRAINT `fk` FOREIGN KEY ' +
+				'(`enrollment`) REFERENCES `enrollment` (`id`))',
+			sql: 'delete from `enrollment` where `id` = ?',
+		});
+
+		const result = extractError(error, {}, 'enrollment');
+
+		expect(result).toBeInstanceOf(InvalidForeignKeyError);
+
+		expect((result as any).extensions).toEqual({
+			collection: 'enrollment',
+			field: 'enrollment',
+			value: null,
+			constraint: 'fk',
+			relatedCollection: 'student_enrollment',
+			reason: 'still_referenced',
 		});
 	});
 

--- a/api/src/database/errors/dialects/mysql.ts
+++ b/api/src/database/errors/dialects/mysql.ts
@@ -6,7 +6,7 @@ import {
 	ValueOutOfRangeError,
 	ValueTooLongError,
 } from '@directus/errors';
-import type { MySQLError } from './types.js';
+import type { DatabaseErrorContext, MySQLError } from './types.js';
 import type { Item } from '@directus/types';
 
 enum MySQLErrorCodes {
@@ -25,7 +25,7 @@ enum MySQLErrorCodes {
 export function extractError(
 	error: MySQLError,
 	data: Partial<Item>,
-	operatedCollection?: string,
+	context?: DatabaseErrorContext,
 ): MySQLError | Error {
 	switch (error.code) {
 		case MySQLErrorCodes.UNIQUE_VIOLATION:
@@ -38,7 +38,7 @@ export function extractError(
 			return notNullViolation();
 		case MySQLErrorCodes.FOREIGN_KEY_VIOLATION:
 		case MySQLErrorCodes.FOREIGN_KEY_STILL_REFERENCED:
-			return foreignKeyViolation(operatedCollection);
+			return foreignKeyViolation(context);
 		// Note: MariaDB throws data truncated for null value error
 		case MySQLErrorCodes.ER_INVALID_USE_OF_NULL:
 		case MySQLErrorCodes.WARN_DATA_TRUNCATED:
@@ -148,7 +148,7 @@ export function extractError(
 		});
 	}
 
-	function foreignKeyViolation(operatedCollection?: string) {
+	function foreignKeyViolation(context?: DatabaseErrorContext) {
 		const betweenTicks = /`([^`]+)`/g;
 
 		// The constraint clause is in sqlMessage; error.sql isn't parsed (a delete
@@ -174,7 +174,7 @@ export function extractError(
 			? 'still_referenced'
 			: 'invalid_reference';
 
-		const collection = operatedCollection ?? childTable;
+		const collection = context?.collection ?? childTable;
 
 		const relatedCollection = stillReferenced
 			? childTable
@@ -192,6 +192,7 @@ export function extractError(
 			constraint,
 			relatedCollection,
 			reason,
+			operation: context?.operation ?? null,
 		});
 	}
 

--- a/api/src/database/errors/dialects/mysql.ts
+++ b/api/src/database/errors/dialects/mysql.ts
@@ -14,12 +14,19 @@ enum MySQLErrorCodes {
 	NUMERIC_VALUE_OUT_OF_RANGE = 'ER_WARN_DATA_OUT_OF_RANGE',
 	ER_DATA_TOO_LONG = 'ER_DATA_TOO_LONG',
 	NOT_NULL_VIOLATION = 'ER_BAD_NULL_ERROR',
+	// Insert/update a child with a bad parent reference.
 	FOREIGN_KEY_VIOLATION = 'ER_NO_REFERENCED_ROW_2',
+	// Delete/update a parent a child still references (RESTRICT/NO ACTION).
+	FOREIGN_KEY_STILL_REFERENCED = 'ER_ROW_IS_REFERENCED_2',
 	ER_INVALID_USE_OF_NULL = 'ER_INVALID_USE_OF_NULL',
 	WARN_DATA_TRUNCATED = 'WARN_DATA_TRUNCATED',
 }
 
-export function extractError(error: MySQLError, data: Partial<Item>): MySQLError | Error {
+export function extractError(
+	error: MySQLError,
+	data: Partial<Item>,
+	operatedCollection?: string,
+): MySQLError | Error {
 	switch (error.code) {
 		case MySQLErrorCodes.UNIQUE_VIOLATION:
 			return uniqueViolation();
@@ -30,7 +37,8 @@ export function extractError(error: MySQLError, data: Partial<Item>): MySQLError
 		case MySQLErrorCodes.NOT_NULL_VIOLATION:
 			return notNullViolation();
 		case MySQLErrorCodes.FOREIGN_KEY_VIOLATION:
-			return foreignKeyViolation();
+		case MySQLErrorCodes.FOREIGN_KEY_STILL_REFERENCED:
+			return foreignKeyViolation(operatedCollection);
 		// Note: MariaDB throws data truncated for null value error
 		case MySQLErrorCodes.ER_INVALID_USE_OF_NULL:
 		case MySQLErrorCodes.WARN_DATA_TRUNCATED:
@@ -140,22 +148,50 @@ export function extractError(error: MySQLError, data: Partial<Item>): MySQLError
 		});
 	}
 
-	function foreignKeyViolation() {
+	function foreignKeyViolation(operatedCollection?: string) {
 		const betweenTicks = /`([^`]+)`/g;
-		const betweenParens = /\(([^)]+)\)/g;
 
+		// The constraint clause is in sqlMessage; error.sql isn't parsed (a delete
+		// carries no value parens, so requiring them would drop the delete case).
 		const tickMatches = error.sqlMessage.match(betweenTicks);
-		const parenMatches = error.sql.match(betweenParens);
 
-		if (!tickMatches || !parenMatches) return error;
+		if (!tickMatches) {
+			return error;
+		}
 
-		const collection = tickMatches[1]!.slice(1, -1)!;
-		const field = tickMatches[3]!.slice(1, -1)!;
+		// Tick groups in the constraint clause: [1]=child table, [2]=constraint,
+		// [3]=child column, [4]=parent table. On delete the referrer child is [1]
+		// and the user acted on the parent, so prefer the operated-on collection.
+		const childTable = tickMatches[1]!.slice(1, -1);
+		const field = tickMatches[3]!.slice(1, -1);
+		const constraint = tickMatches[2]?.slice(1, -1) ?? null;
+		const parentTable = tickMatches[4]?.slice(1, -1) ?? null;
+
+		const stillReferenced =
+			error.code === MySQLErrorCodes.FOREIGN_KEY_STILL_REFERENCED;
+
+		const reason = stillReferenced
+			? 'still_referenced'
+			: 'invalid_reference';
+
+		const collection = operatedCollection ?? childTable;
+
+		const relatedCollection = stillReferenced
+			? childTable
+			: parentTable;
+
+		const value =
+			field && data[field] !== undefined
+				? data[field]
+				: null;
 
 		return new InvalidForeignKeyError({
 			collection,
 			field,
-			value: field ? data[field] : null,
+			value,
+			constraint,
+			relatedCollection,
+			reason,
 		});
 	}
 

--- a/api/src/database/errors/dialects/postgres.test.ts
+++ b/api/src/database/errors/dialects/postgres.test.ts
@@ -266,6 +266,23 @@ describe('foreign key violation (23503)', () => {
 		expect((result as any).extensions.relatedCollection).toBe('student_enrollment');
 	});
 
+	it('names only the referring child on the read path (no context)', () => {
+		// No operated collection → the still-referenced parent is unknowable, so
+		// collection stays null (never the child) and only the referrer is named.
+		const error = pgError({
+			code: '23503',
+			table: 'student_enrollment',
+			detail: 'Key (id)=(5) is still referenced from table "student_enrollment".',
+		});
+
+		const result = extractError(error, {});
+		const ext = (result as any).extensions;
+
+		expect(ext.reason).toBe('still_referenced');
+		expect(ext.collection).toBeNull();
+		expect(ext.relatedCollection).toBe('student_enrollment');
+	});
+
 	it('falls back to the driver table without an operated collection', () => {
 		const error = pgError({
 			code: '23503',

--- a/api/src/database/errors/dialects/postgres.test.ts
+++ b/api/src/database/errors/dialects/postgres.test.ts
@@ -230,6 +230,42 @@ describe('foreign key violation (23503)', () => {
 		});
 	});
 
+	it('resolves the direction from the operation, not the localized detail', () => {
+		// A create whose detail text (misleadingly) says "still referenced" must
+		// still resolve to invalid_reference — the operation is authoritative and
+		// locale-independent, unlike pg's lc_messages-localized detail.
+		const error = pgError({
+			code: '23503',
+			table: 'articles',
+			detail: 'Key (author)=(42) is still referenced from table "authors".',
+		});
+
+		const result = extractError(error, { author: 42 }, {
+			collection: 'articles',
+			operation: 'create',
+		});
+
+		expect((result as any).extensions.reason).toBe('invalid_reference');
+	});
+
+	it('classifies a delete as still_referenced on a non-English detail', () => {
+		const error = pgError({
+			code: '23503',
+			table: 'student_enrollment',
+			// French lc_messages; only the (id)=(5) parens are locale-stable.
+			detail: 'La clé (id)=(5) est encore référencée depuis « student_enrollment ».',
+		});
+
+		const result = extractError(error, {}, {
+			collection: 'enrollment',
+			operation: 'delete',
+		});
+
+		expect((result as any).extensions.reason).toBe('still_referenced');
+		expect((result as any).extensions.collection).toBe('enrollment');
+		expect((result as any).extensions.relatedCollection).toBe('student_enrollment');
+	});
+
 	it('falls back to the driver table without an operated collection', () => {
 		const error = pgError({
 			code: '23503',

--- a/api/src/database/errors/dialects/postgres.test.ts
+++ b/api/src/database/errors/dialects/postgres.test.ts
@@ -195,6 +195,7 @@ describe('foreign key violation (23503)', () => {
 			constraint: 'articles_author_authors_foreign',
 			relatedCollection: 'authors',
 			reason: 'invalid_reference',
+			operation: null,
 		});
 	});
 
@@ -211,7 +212,10 @@ describe('foreign key violation (23503)', () => {
 		});
 
 		// The delete ran on the parent `enrollment`; threaded from the call site.
-		const result = extractError(error, {}, 'enrollment');
+		const result = extractError(error, {}, {
+			collection: 'enrollment',
+			operation: 'delete',
+		});
 
 		expect(result).toBeInstanceOf(InvalidForeignKeyError);
 
@@ -222,6 +226,7 @@ describe('foreign key violation (23503)', () => {
 			constraint: 'student_enrollment_enrollment_foreign',
 			relatedCollection: 'student_enrollment',
 			reason: 'still_referenced',
+			operation: 'delete',
 		});
 	});
 

--- a/api/src/database/errors/dialects/postgres.test.ts
+++ b/api/src/database/errors/dialects/postgres.test.ts
@@ -176,10 +176,11 @@ describe('not null violation (23502)', () => {
 });
 
 describe('foreign key violation (23503)', () => {
-	it('maps to InvalidForeignKeyError with the field pulled from detail', () => {
+	it('maps an invalid reference, naming the referenced parent + constraint', () => {
 		const error = pgError({
 			code: '23503',
 			table: 'articles',
+			constraint: 'articles_author_authors_foreign',
 			detail: 'Key (author)=(42) is not present in table "authors".',
 		});
 
@@ -191,7 +192,50 @@ describe('foreign key violation (23503)', () => {
 			collection: 'articles',
 			field: 'author',
 			value: 42,
+			constraint: 'articles_author_authors_foreign',
+			relatedCollection: 'authors',
+			reason: 'invalid_reference',
 		});
+	});
+
+	it(oneLine`
+		maps a still-referenced delete to the operated-on parent, naming the
+		referring child and the still_referenced reason
+	`, () => {
+		const error = pgError({
+			code: '23503',
+			// pg reports the child (referrer) as error.table on a delete-restrict.
+			table: 'student_enrollment',
+			constraint: 'student_enrollment_enrollment_foreign',
+			detail: 'Key (id)=(5) is still referenced from table "student_enrollment".',
+		});
+
+		// The delete ran on the parent `enrollment`; threaded from the call site.
+		const result = extractError(error, {}, 'enrollment');
+
+		expect(result).toBeInstanceOf(InvalidForeignKeyError);
+
+		expect((result as any).extensions).toEqual({
+			collection: 'enrollment',
+			field: 'id',
+			value: '5',
+			constraint: 'student_enrollment_enrollment_foreign',
+			relatedCollection: 'student_enrollment',
+			reason: 'still_referenced',
+		});
+	});
+
+	it('falls back to the driver table without an operated collection', () => {
+		const error = pgError({
+			code: '23503',
+			table: 'articles',
+			detail: 'Key (author)=(42) is not present in table "authors".',
+		});
+
+		const result = extractError(error, { author: 42 });
+
+		expect((result as any).extensions.collection).toBe('articles');
+		expect((result as any).extensions.constraint).toBeNull();
 	});
 
 	it('returns the raw error when detail has no parenthesised group', () => {

--- a/api/src/database/errors/dialects/postgres.ts
+++ b/api/src/database/errors/dialects/postgres.ts
@@ -126,10 +126,22 @@ export function extractError(
 		const field = matches[0]!.slice(1, -1);
 		const detailValue = matches[1]?.slice(1, -1) ?? null;
 
-		// pg detail phrasing gives the direction: "is not present in table X" is a
-		// bad parent reference; "is still referenced from table X" is a parent a
-		// child still points at (delete/update under RESTRICT).
-		const stillReferenced = detail.includes('is still referenced');
+		// Drive the direction from the operation where it's unambiguous — a create
+		// can only be a bad parent reference, a delete only a still-referenced parent
+		// — because pg's `detail` is localized by lc_messages and its English phrasing
+		// can't be relied on. An update can be either direction, so there fall back to
+		// the detail text ("is still referenced" vs "is not present").
+		let stillReferenced;
+
+		if (context?.operation === 'delete') {
+			stillReferenced = true;
+		}
+		else if (context?.operation === 'create') {
+			stillReferenced = false;
+		}
+		else {
+			stillReferenced = detail.includes('is still referenced');
+		}
 
 		const reason = stillReferenced
 			? 'still_referenced'

--- a/api/src/database/errors/dialects/postgres.ts
+++ b/api/src/database/errors/dialects/postgres.ts
@@ -20,7 +20,11 @@ enum PostgresErrorCodes {
 	VALUE_LIMIT_VIOLATION = '22001',
 }
 
-export function extractError(error: PostgresError, data: Partial<Item>): PostgresError | Error {
+export function extractError(
+	error: PostgresError,
+	data: Partial<Item>,
+	operatedCollection?: string,
+): PostgresError | Error {
 	// Recognized constraint/data codes are handled first, so a real violation
 	// whose message happens to contain a pool phrase (a stored value like "pool
 	// is probably full") can never be misread as exhaustion. Only errors with no
@@ -35,7 +39,7 @@ export function extractError(error: PostgresError, data: Partial<Item>): Postgre
 		case PostgresErrorCodes.NOT_NULL_VIOLATION:
 			return notNullViolation();
 		case PostgresErrorCodes.FOREIGN_KEY_VIOLATION:
-			return foreignKeyViolation();
+			return foreignKeyViolation(operatedCollection);
 		default:
 			return getPoolExhaustedError(error) ?? error;
 	}
@@ -109,21 +113,55 @@ export function extractError(error: PostgresError, data: Partial<Item>): Postgre
 		});
 	}
 
-	function foreignKeyViolation() {
-		const { table, detail } = error;
+	function foreignKeyViolation(operatedCollection?: string) {
+		const { table, detail, constraint } = error;
 
 		const betweenParens = /\(([^)]+)\)/g;
 		const matches = detail.match(betweenParens);
 
-		if (!matches) return error;
+		if (!matches) {
+			return error;
+		}
 
-		const collection = table;
-		const field = matches[0].slice(1, -1);
+		const field = matches[0]!.slice(1, -1);
+		const detailValue = matches[1]?.slice(1, -1) ?? null;
+
+		// pg detail phrasing gives the direction: "is not present in table X" is a
+		// bad parent reference; "is still referenced from table X" is a parent a
+		// child still points at (delete/update under RESTRICT).
+		const stillReferenced = detail.includes('is still referenced');
+
+		const reason = stillReferenced
+			? 'still_referenced'
+			: 'invalid_reference';
+
+		const relatedMatch = detail.match(
+			/(?:present in|referenced from) table "([^"]+)"/,
+		);
+
+		const relatedTable = relatedMatch?.[1] ?? null;
+
+		// On delete the driver's `table` is the child (referrer) while the user acted
+		// on the parent — prefer the operated-on collection, falling back to the
+		// driver table on the read path.
+		const collection = operatedCollection ?? table;
+
+		const relatedCollection = stillReferenced
+			? table
+			: relatedTable;
+
+		const value =
+			field && data[field] !== undefined
+				? data[field]
+				: detailValue;
 
 		return new InvalidForeignKeyError({
 			collection,
 			field,
-			value: field ? data[field] : null,
+			value,
+			constraint: constraint ?? null,
+			relatedCollection,
+			reason,
 		});
 	}
 }

--- a/api/src/database/errors/dialects/postgres.ts
+++ b/api/src/database/errors/dialects/postgres.ts
@@ -153,10 +153,13 @@ export function extractError(
 
 		const relatedTable = relatedMatch?.[1] ?? null;
 
-		// On delete the driver's `table` is the child (referrer) while the user acted
-		// on the parent — prefer the operated-on collection, falling back to the
-		// driver table on the read path.
-		const collection = context?.collection ?? table;
+		// On a still-referenced parent the driver's `table` is the child (referrer),
+		// so without the operated collection the parent is unknowable — leave it null
+		// rather than mislabel the child as the parent. A bad reference is on the
+		// operated child itself, which is the driver table.
+		const collection = stillReferenced
+			? context?.collection ?? null
+			: context?.collection ?? table;
 
 		const relatedCollection = stillReferenced
 			? table

--- a/api/src/database/errors/dialects/postgres.ts
+++ b/api/src/database/errors/dialects/postgres.ts
@@ -9,7 +9,7 @@ import {
 	type DatabasePoolExhaustedReason,
 } from '@directus/errors';
 import { isObject } from '@directus/utils';
-import type { PostgresError } from './types.js';
+import type { DatabaseErrorContext, PostgresError } from './types.js';
 import type { Item } from '@directus/types';
 
 enum PostgresErrorCodes {
@@ -23,7 +23,7 @@ enum PostgresErrorCodes {
 export function extractError(
 	error: PostgresError,
 	data: Partial<Item>,
-	operatedCollection?: string,
+	context?: DatabaseErrorContext,
 ): PostgresError | Error {
 	// Recognized constraint/data codes are handled first, so a real violation
 	// whose message happens to contain a pool phrase (a stored value like "pool
@@ -39,7 +39,7 @@ export function extractError(
 		case PostgresErrorCodes.NOT_NULL_VIOLATION:
 			return notNullViolation();
 		case PostgresErrorCodes.FOREIGN_KEY_VIOLATION:
-			return foreignKeyViolation(operatedCollection);
+			return foreignKeyViolation(context);
 		default:
 			return getPoolExhaustedError(error) ?? error;
 	}
@@ -113,7 +113,7 @@ export function extractError(
 		});
 	}
 
-	function foreignKeyViolation(operatedCollection?: string) {
+	function foreignKeyViolation(context?: DatabaseErrorContext) {
 		const { table, detail, constraint } = error;
 
 		const betweenParens = /\(([^)]+)\)/g;
@@ -144,7 +144,7 @@ export function extractError(
 		// On delete the driver's `table` is the child (referrer) while the user acted
 		// on the parent — prefer the operated-on collection, falling back to the
 		// driver table on the read path.
-		const collection = operatedCollection ?? table;
+		const collection = context?.collection ?? table;
 
 		const relatedCollection = stillReferenced
 			? table
@@ -162,6 +162,7 @@ export function extractError(
 			constraint: constraint ?? null,
 			relatedCollection,
 			reason,
+			operation: context?.operation ?? null,
 		});
 	}
 }

--- a/api/src/database/errors/dialects/sqlite.test.ts
+++ b/api/src/database/errors/dialects/sqlite.test.ts
@@ -82,6 +82,18 @@ describe('foreign key constraint', () => {
 			value: null,
 		});
 	});
+
+	it('fills the operated-on collection when threaded from the call site', () => {
+		const error = sqliteError('SQLITE_CONSTRAINT: FOREIGN KEY constraint failed');
+
+		const result = extractError(error, {}, 'enrollment');
+
+		expect((result as any).extensions).toEqual({
+			collection: 'enrollment',
+			field: null,
+			value: null,
+		});
+	});
 });
 
 describe('unhandled message', () => {

--- a/api/src/database/errors/dialects/sqlite.test.ts
+++ b/api/src/database/errors/dialects/sqlite.test.ts
@@ -80,18 +80,23 @@ describe('foreign key constraint', () => {
 			collection: null,
 			field: null,
 			value: null,
+			operation: null,
 		});
 	});
 
-	it('fills the operated-on collection when threaded from the call site', () => {
+	it('fills the operated-on collection + operation when threaded', () => {
 		const error = sqliteError('SQLITE_CONSTRAINT: FOREIGN KEY constraint failed');
 
-		const result = extractError(error, {}, 'enrollment');
+		const result = extractError(error, {}, {
+			collection: 'enrollment',
+			operation: 'delete',
+		});
 
 		expect((result as any).extensions).toEqual({
 			collection: 'enrollment',
 			field: null,
 			value: null,
+			operation: 'delete',
 		});
 	});
 });

--- a/api/src/database/errors/dialects/sqlite.test.ts
+++ b/api/src/database/errors/dialects/sqlite.test.ts
@@ -80,11 +80,14 @@ describe('foreign key constraint', () => {
 			collection: null,
 			field: null,
 			value: null,
+			constraint: null,
+			relatedCollection: null,
+			reason: null,
 			operation: null,
 		});
 	});
 
-	it('fills the operated-on collection + operation when threaded', () => {
+	it('derives the still_referenced direction from a threaded delete', () => {
 		const error = sqliteError('SQLITE_CONSTRAINT: FOREIGN KEY constraint failed');
 
 		const result = extractError(error, {}, {
@@ -96,6 +99,9 @@ describe('foreign key constraint', () => {
 			collection: 'enrollment',
 			field: null,
 			value: null,
+			constraint: null,
+			relatedCollection: null,
+			reason: 'still_referenced',
 			operation: 'delete',
 		});
 	});

--- a/api/src/database/errors/dialects/sqlite.ts
+++ b/api/src/database/errors/dialects/sqlite.ts
@@ -4,7 +4,7 @@ import {
 	NotNullViolationError,
 	RecordNotUniqueError,
 } from '@directus/errors';
-import type { SQLiteError } from './types.js';
+import type { DatabaseErrorContext, SQLiteError } from './types.js';
 import type { Item } from '@directus/types';
 
 // NOTE:
@@ -14,7 +14,7 @@ import type { Item } from '@directus/types';
 export function extractError(
 	error: SQLiteError,
 	data: Partial<Item>,
-	operatedCollection?: string,
+	context?: DatabaseErrorContext,
 ): SQLiteError | Error {
 	if (error.message.includes('SQLITE_CONSTRAINT: NOT NULL')) {
 		return notNullConstraint(error);
@@ -41,9 +41,10 @@ export function extractError(
 		 * threaded in from the call site (null on the read path).
 		 */
 		return new InvalidForeignKeyError({
-			collection: operatedCollection ?? null,
+			collection: context?.collection ?? null,
 			field: null,
 			value: null,
+			operation: context?.operation ?? null,
 		});
 	}
 

--- a/api/src/database/errors/dialects/sqlite.ts
+++ b/api/src/database/errors/dialects/sqlite.ts
@@ -11,7 +11,11 @@ import type { Item } from '@directus/types';
 // - Sqlite doesn't have varchar with length support, so no ValueTooLongError
 // - Sqlite doesn't have a max range for numbers, so no ValueOutOfRangeError
 
-export function extractError(error: SQLiteError, data: Partial<Item>): SQLiteError | Error {
+export function extractError(
+	error: SQLiteError,
+	data: Partial<Item>,
+	operatedCollection?: string,
+): SQLiteError | Error {
 	if (error.message.includes('SQLITE_CONSTRAINT: NOT NULL')) {
 		return notNullConstraint(error);
 	}
@@ -32,10 +36,15 @@ export function extractError(error: SQLiteError, data: Partial<Item>): SQLiteErr
 	if (error.message.includes('SQLITE_CONSTRAINT: FOREIGN KEY')) {
 		/**
 		 * NOTE:
-		 * SQLite doesn't return any useful information in it's foreign key constraint failed error, so
-		 * we can't extract the table/column/value accurately
+		 * SQLite's foreign key constraint failed error carries no table/column/value
+		 * and no direction, so the only field we can fill is the operated-on collection
+		 * threaded in from the call site (null on the read path).
 		 */
-		return new InvalidForeignKeyError({ collection: null, field: null, value: null });
+		return new InvalidForeignKeyError({
+			collection: operatedCollection ?? null,
+			field: null,
+			value: null,
+		});
 	}
 
 	return error;

--- a/api/src/database/errors/dialects/sqlite.ts
+++ b/api/src/database/errors/dialects/sqlite.ts
@@ -34,17 +34,30 @@ export function extractError(
 	}
 
 	if (error.message.includes('SQLITE_CONSTRAINT: FOREIGN KEY')) {
-		/**
-		 * NOTE:
-		 * SQLite's foreign key constraint failed error carries no table/column/value
-		 * and no direction, so the only field we can fill is the operated-on collection
-		 * threaded in from the call site (null on the read path).
-		 */
+		// SQLite's error carries no table/column/value/direction. The operated
+		// collection is threaded from the call site, and the direction can be derived
+		// from the operation (a delete blocks a still-referenced parent, a create is a
+		// bad reference) — an update is left unknown. Constraint/related stay null so
+		// the extensions shape matches the other dialects.
+		const operation = context?.operation ?? null;
+
+		let reason: 'still_referenced' | 'invalid_reference' | null = null;
+
+		if (operation === 'delete') {
+			reason = 'still_referenced';
+		}
+		else if (operation === 'create') {
+			reason = 'invalid_reference';
+		}
+
 		return new InvalidForeignKeyError({
 			collection: context?.collection ?? null,
 			field: null,
 			value: null,
-			operation: context?.operation ?? null,
+			constraint: null,
+			relatedCollection: null,
+			reason,
+			operation,
 		});
 	}
 

--- a/api/src/database/errors/dialects/types.ts
+++ b/api/src/database/errors/dialects/types.ts
@@ -44,3 +44,11 @@ export type SQLiteError = {
 };
 
 export type SQLError = MSSQLError & MySQLError & PostgresError & SQLiteError & OracleError & Error;
+
+// Call-site context a driver error can't carry: the collection the caller operated
+// on (the driver reports the child on a delete/RESTRICT, not the acted-on parent)
+// and which operation it was (to name delete vs update in the message).
+export interface DatabaseErrorContext {
+	collection?: string;
+	operation?: 'create' | 'update' | 'delete';
+}

--- a/api/src/database/errors/translate.test.ts
+++ b/api/src/database/errors/translate.test.ts
@@ -230,7 +230,7 @@ describe('database.error filter hook', () => {
 });
 
 describe('raw driver message + operated collection', () => {
-	it('keeps the raw message (non-enumerable) and logs it once translated', async () => {
+	it('keeps the raw message non-enumerable and logs it', async () => {
 		vi.mocked(getDatabaseClient).mockReturnValue('postgres');
 
 		const raw = {

--- a/api/src/database/errors/translate.test.ts
+++ b/api/src/database/errors/translate.test.ts
@@ -1,6 +1,7 @@
 import {
 	ContainsNullValuesError,
 	DatabasePoolExhaustedError,
+	InvalidForeignKeyError,
 	NotNullViolationError,
 	RecordNotUniqueError,
 } from '@directus/errors';
@@ -10,6 +11,8 @@ import { getDatabaseClient } from '../index.js';
 import emitter from '../../emitter.js';
 import { extractDatabaseError, translateDatabaseError } from './translate.js';
 import type { SQLError } from './dialects/types.js';
+
+const logger = vi.hoisted(() => ({ debug: vi.fn() }));
 
 vi.mock('../index.js', () => {
 	return {
@@ -22,6 +25,10 @@ vi.mock('../../emitter.js', () => {
 	return {
 		default: { emitFilter: vi.fn(async (_event, payload) => payload) },
 	};
+});
+
+vi.mock('../../logger/index.js', () => {
+	return { useLogger: () => logger };
 });
 
 afterEach(() => {
@@ -219,5 +226,56 @@ describe('database.error filter hook', () => {
 		const result = await translateDatabaseError({ code: '99999' } as SQLError, {});
 
 		expect(result).toBe(overridden);
+	});
+});
+
+describe('raw driver message + operated collection', () => {
+	it('keeps the raw message (non-enumerable) and logs it once translated', async () => {
+		vi.mocked(getDatabaseClient).mockReturnValue('postgres');
+
+		const raw = {
+			code: '23503',
+			table: 'articles',
+			detail: 'Key (author)=(42) is not present in table "authors".',
+			message: 'insert ... violates foreign key constraint "fk"',
+		} as SQLError;
+
+		const result = await extractDatabaseError(raw, { author: 42 });
+
+		expect(result).toBeInstanceOf(InvalidForeignKeyError);
+		expect((result as any).rawDatabaseError).toBe(raw.message);
+		// Non-enumerable, so it never serializes into the response by accident.
+		expect(Object.keys(result)).not.toContain('rawDatabaseError');
+		expect(logger.debug).toHaveBeenCalledWith(raw, expect.any(String));
+	});
+
+	it('forwards the operated collection to the dialect', async () => {
+		vi.mocked(getDatabaseClient).mockReturnValue('postgres');
+
+		const result = await extractDatabaseError(
+			{
+				code: '23503',
+				table: 'student_enrollment',
+				detail:
+					'Key (id)=(5) is still referenced ' +
+					'from table "student_enrollment".',
+			} as SQLError,
+			{},
+			undefined,
+			'enrollment',
+		);
+
+		expect((result as any).extensions.collection).toBe('enrollment');
+		expect((result as any).extensions.reason).toBe('still_referenced');
+	});
+
+	it('attaches no raw message when nothing was translated', async () => {
+		vi.mocked(getDatabaseClient).mockReturnValue('unknown' as any);
+		const raw = { code: 'x', message: 'y' } as SQLError;
+
+		const result = await extractDatabaseError(raw, {});
+
+		expect((result as any).rawDatabaseError).toBeUndefined();
+		expect(logger.debug).not.toHaveBeenCalled();
 	});
 });

--- a/api/src/database/errors/translate.test.ts
+++ b/api/src/database/errors/translate.test.ts
@@ -249,7 +249,7 @@ describe('raw driver message + operated collection', () => {
 		expect(logger.debug).toHaveBeenCalledWith(raw, expect.any(String));
 	});
 
-	it('forwards the operated collection to the dialect', async () => {
+	it('forwards the operated collection + operation to the dialect', async () => {
 		vi.mocked(getDatabaseClient).mockReturnValue('postgres');
 
 		const result = await extractDatabaseError(
@@ -262,11 +262,12 @@ describe('raw driver message + operated collection', () => {
 			} as SQLError,
 			{},
 			undefined,
-			'enrollment',
+			{ collection: 'enrollment', operation: 'delete' },
 		);
 
 		expect((result as any).extensions.collection).toBe('enrollment');
 		expect((result as any).extensions.reason).toBe('still_referenced');
+		expect((result as any).extensions.operation).toBe('delete');
 	});
 
 	it('attaches no raw message when nothing was translated', async () => {

--- a/api/src/database/errors/translate.ts
+++ b/api/src/database/errors/translate.ts
@@ -7,7 +7,7 @@ import { extractError as oracle } from './dialects/oracle.js';
 import { extractError as postgres } from './dialects/postgres.js';
 import { extractError as sqlite } from './dialects/sqlite.js';
 import type { Knex } from 'knex';
-import type { SQLError } from './dialects/types.js';
+import type { DatabaseErrorContext, SQLError } from './dialects/types.js';
 import type { Item } from '@directus/types';
 
 /**
@@ -24,7 +24,7 @@ export async function extractDatabaseError(
 	error: SQLError,
 	data: Partial<Item>,
 	database?: Knex,
-	operatedCollection?: string,
+	context?: DatabaseErrorContext,
 ): Promise<any> {
 	// Dispatch on the connection the query actually ran on — a granted named
 	// connection may be a different client than the default pool.
@@ -34,14 +34,14 @@ export async function extractDatabaseError(
 
 	switch (client) {
 		case 'mysql':
-			translated = mysql(error, data, operatedCollection);
+			translated = mysql(error, data, context);
 			break;
 		case 'cockroachdb':
 		case 'postgres':
-			translated = postgres(error, data, operatedCollection);
+			translated = postgres(error, data, context);
 			break;
 		case 'sqlite':
-			translated = sqlite(error, data, operatedCollection);
+			translated = sqlite(error, data, context);
 			break;
 		case 'oracle':
 			translated = oracle(error);
@@ -78,13 +78,13 @@ export async function translateDatabaseError(
 	error: SQLError,
 	data: Partial<Item>,
 	database?: Knex,
-	operatedCollection?: string,
+	context?: DatabaseErrorContext,
 ): Promise<any> {
 	const defaultError = await extractDatabaseError(
 		error,
 		data,
 		database,
-		operatedCollection,
+		context,
 	);
 
 	const hookError = await emitter.emitFilter(

--- a/api/src/database/errors/translate.ts
+++ b/api/src/database/errors/translate.ts
@@ -1,5 +1,6 @@
 import getDatabase, { getDatabaseClient } from '../index.js';
 import emitter from '../../emitter.js';
+import { useLogger } from '../../logger/index.js';
 import { extractError as mssql } from './dialects/mssql.js';
 import { extractError as mysql } from './dialects/mysql.js';
 import { extractError as oracle } from './dialects/oracle.js';
@@ -23,26 +24,50 @@ export async function extractDatabaseError(
 	error: SQLError,
 	data: Partial<Item>,
 	database?: Knex,
+	operatedCollection?: string,
 ): Promise<any> {
 	// Dispatch on the connection the query actually ran on — a granted named
 	// connection may be a different client than the default pool.
 	const client = getDatabaseClient(database);
 
+	let translated: any;
+
 	switch (client) {
 		case 'mysql':
-			return mysql(error, data);
+			translated = mysql(error, data, operatedCollection);
+			break;
 		case 'cockroachdb':
 		case 'postgres':
-			return postgres(error, data);
+			translated = postgres(error, data, operatedCollection);
+			break;
 		case 'sqlite':
-			return sqlite(error, data);
+			translated = sqlite(error, data, operatedCollection);
+			break;
 		case 'oracle':
-			return oracle(error);
+			translated = oracle(error);
+			break;
 		case 'mssql':
-			return await mssql(error, data);
+			translated = await mssql(error, data);
+			break;
 		default:
-			return error;
+			translated = error;
 	}
+
+	// When a raw driver error was translated to a Directus error, keep its raw
+	// message: logged server-side here, and the error handler exposes it in the
+	// response in development only (like `stack`). It carries SQL text + values —
+	// exactly what translation strips from prod responses — so it never leaks there.
+	if (translated !== error && translated instanceof Error) {
+		Object.defineProperty(translated, 'rawDatabaseError', {
+			value: error.message,
+			enumerable: false,
+			configurable: true,
+		});
+
+		useLogger().debug(error, 'Translated database error');
+	}
+
+	return translated;
 }
 
 /**
@@ -53,8 +78,14 @@ export async function translateDatabaseError(
 	error: SQLError,
 	data: Partial<Item>,
 	database?: Knex,
+	operatedCollection?: string,
 ): Promise<any> {
-	const defaultError = await extractDatabaseError(error, data, database);
+	const defaultError = await extractDatabaseError(
+		error,
+		data,
+		database,
+		operatedCollection,
+	);
 
 	const hookError = await emitter.emitFilter(
 		'database.error',

--- a/api/src/middleware/error-handler.test.ts
+++ b/api/src/middleware/error-handler.test.ts
@@ -7,7 +7,7 @@ import http from 'node:http';
 import type { AddressInfo } from 'node:net';
 import type { Logger } from 'pino';
 import type { Knex } from 'knex';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import getDatabase, {
 	getConnectionNameForAccountability,
 	getDatabaseForAccountability,
@@ -125,6 +125,67 @@ describe('Error handler behaves correctly in express app', () => {
 			}),
 			'Unexpected error in error handler',
 		);
+	});
+
+	describe('raw database error is dev-only', () => {
+		afterEach(() => {
+			vi.unstubAllEnvs();
+		});
+
+		const rawMessage = 'delete from "x" violates foreign key constraint "fk"';
+
+		const FkError = createError(
+			'INVALID_FOREIGN_KEY',
+			'Invalid foreign key.',
+			400,
+		);
+
+		const fkErrorWithRaw = () => {
+			const err = new FkError();
+
+			Object.defineProperty(err, 'rawDatabaseError', {
+				value: rawMessage,
+				enumerable: false,
+			});
+
+			return err;
+		};
+
+		test('exposes the raw driver message in development', async () => {
+			expect.assertions(1);
+			vi.stubEnv('NODE_ENV', 'development');
+			const port = await startApp(() => {
+				throw fkErrorWithRaw();
+			});
+
+			try {
+				await axios(`http://0:${port}`);
+			}
+			catch (axiosError) {
+				expect((axiosError as AxiosError).response?.data).toMatchObject({
+					errors: [{ extensions: { databaseError: rawMessage } }],
+				});
+			}
+		});
+
+		test('omits it outside development', async () => {
+			expect.assertions(1);
+			vi.stubEnv('NODE_ENV', 'production');
+			const port = await startApp(() => {
+				throw fkErrorWithRaw();
+			});
+
+			try {
+				await axios(`http://0:${port}`);
+			}
+			catch (axiosError) {
+				const data = (axiosError as AxiosError).response?.data as {
+					errors: { extensions: Record<string, unknown> }[];
+				};
+
+				expect(data.errors[0]!.extensions['databaseError']).toBeUndefined();
+			}
+		});
 	});
 });
 

--- a/api/src/middleware/error-handler.test.ts
+++ b/api/src/middleware/error-handler.test.ts
@@ -154,6 +154,7 @@ describe('Error handler behaves correctly in express app', () => {
 		test('exposes the raw driver message in development', async () => {
 			expect.assertions(1);
 			vi.stubEnv('NODE_ENV', 'development');
+
 			const port = await startApp(() => {
 				throw fkErrorWithRaw();
 			});
@@ -171,6 +172,7 @@ describe('Error handler behaves correctly in express app', () => {
 		test('omits it outside development', async () => {
 			expect.assertions(1);
 			vi.stubEnv('NODE_ENV', 'production');
+
 			const port = await startApp(() => {
 				throw fkErrorWithRaw();
 			});

--- a/api/src/middleware/error-handler.ts
+++ b/api/src/middleware/error-handler.ts
@@ -87,6 +87,16 @@ export const errorHandler = asyncErrorHandler(async (err, req, res) => {
 			((error as DeepPartial<ApiError>).extensions ??= {})['stack'] = error.stack;
 		}
 
+		// In dev mode, surface the raw driver message a DB error was translated from
+		// (carried on the translated error by translate.ts). It holds SQL text +
+		// values, so like `stack` it stays out of the production response.
+		const withRaw = error as { rawDatabaseError?: string };
+
+		if (getNodeEnv() === 'development' && withRaw.rawDatabaseError) {
+			((error as DeepPartial<ApiError>).extensions ??= {})['databaseError'] =
+				withRaw.rawDatabaseError;
+		}
+
 		if (isDirectusError(error)) {
 			logger.debug(error);
 

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -739,7 +739,7 @@ implements AbstractService<Item> {
 					err,
 					data,
 					this.knex,
-					this.collection,
+					{ collection: this.collection, operation: 'create' },
 				);
 
 				if (isDirectusError(dbError, ErrorCode.RecordNotUnique) && dbError.extensions.primaryKey) {
@@ -1421,7 +1421,10 @@ implements AbstractService<Item> {
 						.whereIn(primaryKeyField, keys);
 				}
 				catch (err: any) {
-					throw await translateDatabaseError(err, data, this.knex, this.collection);
+					throw await translateDatabaseError(err, data, this.knex, {
+						collection: this.collection,
+						operation: 'update',
+					});
 				}
 			}
 
@@ -1784,7 +1787,10 @@ implements AbstractService<Item> {
 			catch (err: any) {
 				// Parity with createOne/updateMany: a direct delete's FK/constraint
 				// violation must surface as a translated Directus error, not raw knex.
-				throw await translateDatabaseError(err, {}, this.knex, this.collection);
+				throw await translateDatabaseError(err, {}, this.knex, {
+					collection: this.collection,
+					operation: 'delete',
+				});
 			}
 
 			if (opts.userIntegrityCheckFlags) {

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -735,7 +735,12 @@ implements AbstractService<Item> {
 				}
 			}
 			catch (err: any) {
-				const dbError = await translateDatabaseError(err, data, this.knex);
+				const dbError = await translateDatabaseError(
+					err,
+					data,
+					this.knex,
+					this.collection,
+				);
 
 				if (isDirectusError(dbError, ErrorCode.RecordNotUnique) && dbError.extensions.primaryKey) {
 					// This is a MySQL specific thing we need to handle here, since MySQL does not return the field name
@@ -1416,7 +1421,7 @@ implements AbstractService<Item> {
 						.whereIn(primaryKeyField, keys);
 				}
 				catch (err: any) {
-					throw await translateDatabaseError(err, data, this.knex);
+					throw await translateDatabaseError(err, data, this.knex, this.collection);
 				}
 			}
 
@@ -1779,7 +1784,7 @@ implements AbstractService<Item> {
 			catch (err: any) {
 				// Parity with createOne/updateMany: a direct delete's FK/constraint
 				// violation must surface as a translated Directus error, not raw knex.
-				throw await translateDatabaseError(err, {}, this.knex);
+				throw await translateDatabaseError(err, {}, this.knex, this.collection);
 			}
 
 			if (opts.userIntegrityCheckFlags) {

--- a/packages/errors/src/errors/invalid-foreign-key.test.ts
+++ b/packages/errors/src/errors/invalid-foreign-key.test.ts
@@ -48,3 +48,34 @@ test('Constructs the message without the key', () => {
 	const result = messageConstructor(sample);
 	expect(result).toBe(`Invalid foreign key for field "${sample.field}" in collection "${sample.collection}".`);
 });
+
+test('Appends the referenced collection for an invalid reference', () => {
+	sample.relatedCollection = 'authors';
+	sample.reason = 'invalid_reference';
+
+	const result = messageConstructor(sample);
+
+	expect(result).toBe(
+		[
+			`Invalid foreign key "${sample.value}" for field "${sample.field}"`,
+			`in collection "${sample.collection}" (references "authors").`,
+		].join(' '),
+	);
+});
+
+test('Reasons about a still-referenced record naming the referrer', () => {
+	const result = messageConstructor({
+		collection: 'enrollment',
+		field: 'id',
+		value: null,
+		relatedCollection: 'student_enrollment',
+		reason: 'still_referenced',
+	});
+
+	expect(result).toBe(
+		[
+			'Record in collection "enrollment" is still referenced',
+			'by collection "student_enrollment".',
+		].join(' '),
+	);
+});

--- a/packages/errors/src/errors/invalid-foreign-key.test.ts
+++ b/packages/errors/src/errors/invalid-foreign-key.test.ts
@@ -79,3 +79,39 @@ test('Reasons about a still-referenced record naming the referrer', () => {
 		].join(' '),
 	);
 });
+
+test('names a delete that is blocked by a still-referenced child', () => {
+	const result = messageConstructor({
+		collection: 'enrollment',
+		field: 'id',
+		value: null,
+		relatedCollection: 'student_enrollment',
+		reason: 'still_referenced',
+		operation: 'delete',
+	});
+
+	expect(result).toBe(
+		[
+			'Cannot delete collection "enrollment": it is still',
+			'referenced by collection "student_enrollment".',
+		].join(' '),
+	);
+});
+
+test('names an update that is blocked by a still-referenced child', () => {
+	const result = messageConstructor({
+		collection: 'enrollment',
+		field: 'id',
+		value: null,
+		relatedCollection: 'student_enrollment',
+		reason: 'still_referenced',
+		operation: 'update',
+	});
+
+	expect(result).toBe(
+		[
+			'Cannot update collection "enrollment": it is still',
+			'referenced by collection "student_enrollment".',
+		].join(' '),
+	);
+});

--- a/packages/errors/src/errors/invalid-foreign-key.test.ts
+++ b/packages/errors/src/errors/invalid-foreign-key.test.ts
@@ -133,3 +133,33 @@ test('falls back to the collection when the pk is unknown (mysql/sqlite)', () =>
 		].join(' '),
 	);
 });
+
+test('falls back to the collection for a composite key', () => {
+	const result = messageConstructor({
+		collection: 'enrollment',
+		field: 'a, b',
+		value: '1, 2',
+		relatedCollection: 'student_enrollment',
+		reason: 'still_referenced',
+		operation: 'delete',
+	});
+
+	expect(result).toBe(
+		[
+			'Cannot delete collection "enrollment": it is still',
+			'referenced by collection "student_enrollment".',
+		].join(' '),
+	);
+});
+
+test('keeps a zero foreign key value in the message', () => {
+	const result = messageConstructor({
+		collection: 'articles',
+		field: 'author',
+		value: 0 as unknown as string,
+	});
+
+	expect(result).toBe(
+		'Invalid foreign key "0" for field "author" in collection "articles".',
+	);
+});

--- a/packages/errors/src/errors/invalid-foreign-key.test.ts
+++ b/packages/errors/src/errors/invalid-foreign-key.test.ts
@@ -80,7 +80,43 @@ test('Reasons about a still-referenced record naming the referrer', () => {
 	);
 });
 
-test('names a delete that is blocked by a still-referenced child', () => {
+test('names the blocked row as collection:pk on delete', () => {
+	const result = messageConstructor({
+		collection: 'enrollment',
+		field: 'id',
+		value: '5',
+		relatedCollection: 'student_enrollment',
+		reason: 'still_referenced',
+		operation: 'delete',
+	});
+
+	expect(result).toBe(
+		[
+			'Cannot delete "enrollment:5": it is still referenced',
+			'by collection "student_enrollment".',
+		].join(' '),
+	);
+});
+
+test('names the blocked row for an update too', () => {
+	const result = messageConstructor({
+		collection: 'enrollment',
+		field: 'id',
+		value: '5',
+		relatedCollection: 'student_enrollment',
+		reason: 'still_referenced',
+		operation: 'update',
+	});
+
+	expect(result).toBe(
+		[
+			'Cannot update "enrollment:5": it is still referenced',
+			'by collection "student_enrollment".',
+		].join(' '),
+	);
+});
+
+test('falls back to the collection when the pk is unknown (mysql/sqlite)', () => {
 	const result = messageConstructor({
 		collection: 'enrollment',
 		field: 'id',
@@ -93,24 +129,6 @@ test('names a delete that is blocked by a still-referenced child', () => {
 	expect(result).toBe(
 		[
 			'Cannot delete collection "enrollment": it is still',
-			'referenced by collection "student_enrollment".',
-		].join(' '),
-	);
-});
-
-test('names an update that is blocked by a still-referenced child', () => {
-	const result = messageConstructor({
-		collection: 'enrollment',
-		field: 'id',
-		value: null,
-		relatedCollection: 'student_enrollment',
-		reason: 'still_referenced',
-		operation: 'update',
-	});
-
-	expect(result).toBe(
-		[
-			'Cannot update collection "enrollment": it is still',
 			'referenced by collection "student_enrollment".',
 		].join(' '),
 	);

--- a/packages/errors/src/errors/invalid-foreign-key.test.ts
+++ b/packages/errors/src/errors/invalid-foreign-key.test.ts
@@ -152,6 +152,20 @@ test('falls back to the collection for a composite key', () => {
 	);
 });
 
+test('names only the referrer when the parent is unknown (read path)', () => {
+	const result = messageConstructor({
+		collection: null,
+		field: 'id',
+		value: '5',
+		relatedCollection: 'student_enrollment',
+		reason: 'still_referenced',
+	});
+
+	expect(result).toBe(
+		'Record is still referenced by collection "student_enrollment".',
+	);
+});
+
 test('keeps a zero foreign key value in the message', () => {
 	const result = messageConstructor({
 		collection: 'articles',

--- a/packages/errors/src/errors/invalid-foreign-key.ts
+++ b/packages/errors/src/errors/invalid-foreign-key.ts
@@ -32,9 +32,13 @@ export const messageConstructor = (extensions: InvalidForeignKeyErrorExtensions)
 		if (operation === 'delete' || operation === 'update') {
 			let message = `Cannot ${operation}`;
 
-			// Name the exact row (`collection:pk`) when the driver gave us its key
-			// (pg does), else fall back to the collection.
-			if (collection && value) {
+			// Name the exact row (`collection:pk`) when the driver gave us a single
+			// key value (pg does). Skip a composite key (comma in the field) since
+			// `collection:1, 2` reads wrong, and fall back to the collection.
+			const hasSingleKey =
+				value != null && !!field && !field.includes(',');
+
+			if (collection && hasSingleKey) {
 				message += ` "${collection}:${value}"`;
 			}
 			else if (collection) {
@@ -67,7 +71,7 @@ export const messageConstructor = (extensions: InvalidForeignKeyErrorExtensions)
 
 	let message = 'Invalid foreign key';
 
-	if (value) {
+	if (value != null && value !== '') {
 		message += ` "${value}"`;
 	}
 

--- a/packages/errors/src/errors/invalid-foreign-key.ts
+++ b/packages/errors/src/errors/invalid-foreign-key.ts
@@ -36,7 +36,7 @@ export const messageConstructor = (extensions: InvalidForeignKeyErrorExtensions)
 			// key value (pg does). Skip a composite key (comma in the field) since
 			// `collection:1, 2` reads wrong, and fall back to the collection.
 			const hasSingleKey =
-				value != null && !!field && !field.includes(',');
+				value != null && value !== '' && !!field && !field.includes(',');
 
 			if (collection && hasSingleKey) {
 				message += ` "${collection}:${value}"`;

--- a/packages/errors/src/errors/invalid-foreign-key.ts
+++ b/packages/errors/src/errors/invalid-foreign-key.ts
@@ -5,23 +5,46 @@ import { createError, ErrorCode } from '../index.js';
 // because a child still references it (RESTRICT/NO ACTION) — the opposite direction.
 export type ForeignKeyViolationReason = 'invalid_reference' | 'still_referenced';
 
+export type ForeignKeyViolationOperation = 'create' | 'update' | 'delete';
+
 export interface InvalidForeignKeyErrorExtensions {
 	collection: string | null;
 	field: string | null;
 	value: string | null;
 	// The FK constraint name and the other table in the relationship (the referenced
 	// parent for `invalid_reference`, the referencing child for `still_referenced`),
-	// plus which direction the violation is — all optional since not every dialect
-	// exposes them.
+	// the direction, and the operation the caller attempted — all optional since not
+	// every dialect exposes them and the operation is only known at the call site.
 	constraint?: string | null;
 	relatedCollection?: string | null;
 	reason?: ForeignKeyViolationReason | null;
+	operation?: ForeignKeyViolationOperation | null;
 }
 
 export const messageConstructor = (extensions: InvalidForeignKeyErrorExtensions) => {
-	const { collection, field, value, relatedCollection, reason } = extensions;
+	const { collection, field, value, relatedCollection, reason, operation } =
+		extensions;
 
 	if (reason === 'still_referenced') {
+		// The operation is known only at the call site; when it's a delete or an
+		// update, name it so the message points straight at what failed. Otherwise
+		// (the read path) stay operation-agnostic.
+		if (operation === 'delete' || operation === 'update') {
+			let message = `Cannot ${operation}`;
+
+			if (collection) {
+				message += ` collection "${collection}"`;
+			}
+
+			message += ': it is still referenced';
+
+			if (relatedCollection) {
+				message += ` by collection "${relatedCollection}"`;
+			}
+
+			return `${message}.`;
+		}
+
 		let message = 'Record';
 
 		if (collection) {

--- a/packages/errors/src/errors/invalid-foreign-key.ts
+++ b/packages/errors/src/errors/invalid-foreign-key.ts
@@ -32,7 +32,12 @@ export const messageConstructor = (extensions: InvalidForeignKeyErrorExtensions)
 		if (operation === 'delete' || operation === 'update') {
 			let message = `Cannot ${operation}`;
 
-			if (collection) {
+			// Name the exact row (`collection:pk`) when the driver gave us its key
+			// (pg does), else fall back to the collection.
+			if (collection && value) {
+				message += ` "${collection}:${value}"`;
+			}
+			else if (collection) {
 				message += ` collection "${collection}"`;
 			}
 

--- a/packages/errors/src/errors/invalid-foreign-key.ts
+++ b/packages/errors/src/errors/invalid-foreign-key.ts
@@ -1,12 +1,42 @@
 import { createError, ErrorCode } from '../index.js';
 
+// `invalid_reference`: a write named a parent row that doesn't exist (insert/update
+// a child with a bad FK). `still_referenced`: a parent row can't be deleted/updated
+// because a child still references it (RESTRICT/NO ACTION) — the opposite direction.
+export type ForeignKeyViolationReason = 'invalid_reference' | 'still_referenced';
+
 export interface InvalidForeignKeyErrorExtensions {
 	collection: string | null;
 	field: string | null;
 	value: string | null;
+	// The FK constraint name and the other table in the relationship (the referenced
+	// parent for `invalid_reference`, the referencing child for `still_referenced`),
+	// plus which direction the violation is — all optional since not every dialect
+	// exposes them.
+	constraint?: string | null;
+	relatedCollection?: string | null;
+	reason?: ForeignKeyViolationReason | null;
 }
 
-export const messageConstructor = ({ collection, field, value }: InvalidForeignKeyErrorExtensions) => {
+export const messageConstructor = (extensions: InvalidForeignKeyErrorExtensions) => {
+	const { collection, field, value, relatedCollection, reason } = extensions;
+
+	if (reason === 'still_referenced') {
+		let message = 'Record';
+
+		if (collection) {
+			message += ` in collection "${collection}"`;
+		}
+
+		message += ' is still referenced';
+
+		if (relatedCollection) {
+			message += ` by collection "${relatedCollection}"`;
+		}
+
+		return `${message}.`;
+	}
+
 	let message = 'Invalid foreign key';
 
 	if (value) {
@@ -21,9 +51,11 @@ export const messageConstructor = ({ collection, field, value }: InvalidForeignK
 		message += ` in collection "${collection}"`;
 	}
 
-	message += `.`;
+	if (relatedCollection) {
+		message += ` (references "${relatedCollection}")`;
+	}
 
-	return message;
+	return `${message}.`;
 };
 
 export const InvalidForeignKeyError = createError<InvalidForeignKeyErrorExtensions>(

--- a/tests/blackbox/tests/db/routes/items/db-error-translation.test.ts
+++ b/tests/blackbox/tests/db/routes/items/db-error-translation.test.ts
@@ -82,7 +82,16 @@ describe('translateDatabaseError', () => {
 
 			// Assert
 			expect(response.statusCode).toBe(400);
-			expect(response.body.errors[0].extensions.code).toBe('INVALID_FOREIGN_KEY');
+
+			const error = response.body.errors[0];
+			expect(error.extensions.code).toBe('INVALID_FOREIGN_KEY');
+
+			// pg names the invalid_reference direction + the referenced parent.
+			if (vendor === 'postgres') {
+				expect(error.extensions.reason).toBe('invalid_reference');
+				expect(error.extensions.collection).toBe(collectionFkChild);
+				expect(error.extensions.relatedCollection).toBe(collectionFkParent);
+			}
 		});
 	});
 
@@ -106,26 +115,34 @@ describe('translateDatabaseError', () => {
 				.delete(`/items/${collectionFkParent}/${parentId}`)
 				.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
 
-			// The translated message is vendor-specific: sqlite can't extract the
-			// column so it yields the bare prefix, pg names the field/collection.
-			// Pin the full string where we know it; other vendors (Full matrix)
-			// still assert the translated prefix.
+			// The translated message is vendor-specific. pg/mysql read the direction
+			// from the driver error, so they name the operated-on parent as still
+			// referenced by the child. sqlite exposes nothing, so it only names the
+			// parent (threaded from the call site) under the default wording.
 			const exactMessage: Record<string, string> = {
 				postgres:
-					`Invalid foreign key for field "id" ` +
-					`in collection "${collectionFkChild}".`,
-				sqlite3: 'Invalid foreign key.',
+					`Record in collection "${collectionFkParent}" is still ` +
+					`referenced by collection "${collectionFkChild}".`,
+				sqlite3: `Invalid foreign key in collection "${collectionFkParent}".`,
 			};
 
 			// Assert
 			expect(response.statusCode).toBe(400);
-			expect(response.body.errors[0].extensions.code).toBe('INVALID_FOREIGN_KEY');
+
+			const error = response.body.errors[0];
+			expect(error.extensions.code).toBe('INVALID_FOREIGN_KEY');
 
 			if (exactMessage[vendor]) {
-				expect(response.body.errors[0].message).toBe(exactMessage[vendor]);
+				expect(error.message).toBe(exactMessage[vendor]);
 			}
-			else {
-				expect(response.body.errors[0].message).toContain('Invalid foreign key');
+
+			// pg carries the full enrichment: the still_referenced direction, the
+			// operated-on parent, and the referring child.
+			if (vendor === 'postgres') {
+				expect(error.extensions.reason).toBe('still_referenced');
+				expect(error.extensions.collection).toBe(collectionFkParent);
+				expect(error.extensions.relatedCollection).toBe(collectionFkChild);
+				expect(error.extensions.constraint).toBeTruthy();
 			}
 		});
 	});

--- a/tests/blackbox/tests/db/routes/items/db-error-translation.test.ts
+++ b/tests/blackbox/tests/db/routes/items/db-error-translation.test.ts
@@ -121,11 +121,14 @@ describe('translateDatabaseError', () => {
 			// so it only names the parent under the default wording.
 			const exactMessage: Record<string, string> = {
 				// pg reads the blocked row's key from the driver detail, so it names
-				// `collection:pk`; sqlite exposes no key or direction.
+				// `collection:pk` + the referring child. sqlite exposes neither, but
+				// the delete operation still gives it the direction.
 				postgres:
 					`Cannot delete "${collectionFkParent}:${parentId}": it is still ` +
 					`referenced by collection "${collectionFkChild}".`,
-				sqlite3: `Invalid foreign key in collection "${collectionFkParent}".`,
+				sqlite3:
+					`Cannot delete collection "${collectionFkParent}": ` +
+					`it is still referenced.`,
 			};
 
 			// Assert

--- a/tests/blackbox/tests/db/routes/items/db-error-translation.test.ts
+++ b/tests/blackbox/tests/db/routes/items/db-error-translation.test.ts
@@ -116,12 +116,12 @@ describe('translateDatabaseError', () => {
 				.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
 
 			// The translated message is vendor-specific. pg/mysql read the direction
-			// from the driver error, so they name the operated-on parent as still
-			// referenced by the child. sqlite exposes nothing, so it only names the
-			// parent (threaded from the call site) under the default wording.
+			// from the driver error, so with the operation threaded they name the
+			// blocked delete on the operated-on parent. sqlite exposes no direction,
+			// so it only names the parent under the default wording.
 			const exactMessage: Record<string, string> = {
 				postgres:
-					`Record in collection "${collectionFkParent}" is still ` +
+					`Cannot delete collection "${collectionFkParent}": it is still ` +
 					`referenced by collection "${collectionFkChild}".`,
 				sqlite3: `Invalid foreign key in collection "${collectionFkParent}".`,
 			};
@@ -137,9 +137,10 @@ describe('translateDatabaseError', () => {
 			}
 
 			// pg carries the full enrichment: the still_referenced direction, the
-			// operated-on parent, and the referring child.
+			// delete operation, the operated-on parent, and the referring child.
 			if (vendor === 'postgres') {
 				expect(error.extensions.reason).toBe('still_referenced');
+				expect(error.extensions.operation).toBe('delete');
 				expect(error.extensions.collection).toBe(collectionFkParent);
 				expect(error.extensions.relatedCollection).toBe(collectionFkChild);
 				expect(error.extensions.constraint).toBeTruthy();

--- a/tests/blackbox/tests/db/routes/items/db-error-translation.test.ts
+++ b/tests/blackbox/tests/db/routes/items/db-error-translation.test.ts
@@ -120,8 +120,10 @@ describe('translateDatabaseError', () => {
 			// blocked delete on the operated-on parent. sqlite exposes no direction,
 			// so it only names the parent under the default wording.
 			const exactMessage: Record<string, string> = {
+				// pg reads the blocked row's key from the driver detail, so it names
+				// `collection:pk`; sqlite exposes no key or direction.
 				postgres:
-					`Cannot delete collection "${collectionFkParent}": it is still ` +
+					`Cannot delete "${collectionFkParent}:${parentId}": it is still ` +
 					`referenced by collection "${collectionFkChild}".`,
 				sqlite3: `Invalid foreign key in collection "${collectionFkParent}".`,
 			};


### PR DESCRIPTION
Closes #287. Follow-up to #281 (do **not** revert that translation — this is the clarity work on top of it).

## Why

Once #281 routed delete-path FK errors through the translator, the structured `InvalidForeignKeyError` turned out **less diagnostic** than the raw driver message it replaced, and for the delete/`RESTRICT` direction it was **mislabeled** (pointed at the child table, called a "still referenced" error an "invalid foreign key").

## What

- **Widened `InvalidForeignKeyError` extensions**: `constraint`, `relatedCollection`, `reason` (`'invalid_reference' | 'still_referenced'`), and `operation` (`'create' | 'update' | 'delete'`). `code` stays `INVALID_FOREIGN_KEY` (no client-contract break) — the direction/operation are machine-readable extensions.
- **Message branches on reason + operation.** A blocked delete names the exact row when the driver gives its key (pg does): *"Cannot delete "enrollment:5": it is still referenced by collection "student_enrollment"."*, an update likewise; mysql/sqlite have no key on this path so they fall back to *"Cannot delete collection "enrollment": …"*. Insert/update-with-bad-ref reads *"Invalid foreign key … in collection "…" (references "…")"*. The read path (no operation) stays operation-agnostic (*"Record in collection X is still referenced by Y"*).
- **Threaded call-site context** (`{ collection, operation }`) through `translateDatabaseError`/`extractError`. The driver names the child on a delete; the parent + operation are only known at the call site (`items.ts` create/update/delete), so they're passed in. Falls back to the driver table + agnostic wording on the read path.
- **Enriched extractors** for pg and mysql/mariadb (constraint, related table, direction from the driver error; mysql also handles the delete-side `ER_ROW_IS_REFERENCED_2`, and its unused `error.sql` paren-guard is dropped so deletes translate). sqlite exposes nothing, so it gains the threaded collection + operation only.
- **Raw driver message preserved**: logged server-side on every translation, and attached to the response `extensions.databaseError` **in development only** (mirroring `stack`). It carries SQL + values — exactly what #281 keeps out of prod — carried on the translated error as a non-enumerable property.

## Scope

pg / mysql+mariadb / sqlite, per our deploy matrix. **mssql and oracle unchanged** (out of scope).

## Design decisions (settled)

- **`reason` + `operation` fields, not new error types** — keeps the `INVALID_FOREIGN_KEY` code stable and machine-parseable.
- **Structured fields in prod, raw message dev-only** — constraint/relatedCollection/reason/operation are curated (safe, client-facing); the raw message is SQL+values (dev + logs only).
- **Thread `{ collection, operation }`** — the driver reports the child on delete and never the operation; both come from the call site.

## Tested

- Unit: `invalid-foreign-key.test.ts` (reason + delete/update operation messages), pg/mysql/sqlite extractors (insert + delete/still-referenced, operation + operated-collection), `translate.test.ts` (context forwarding, raw-message rider non-enumerable + logged), `error-handler.test.ts` (raw message exposed in development, absent in production — stubs `NODE_ENV`).
- Blackbox: `db-error-translation.test.ts` (run via the `Run Blackbox` label, pg + sqlite3) — the real delete-a-still-referenced-parent path asserts the *"Cannot delete collection …"* message + the pg enrichment (`reason`/`operation`/`collection`/`relatedCollection`/`constraint`); the insert path asserts the pg `invalid_reference` enrichment.

## Deep review — dispositions

Ran an adversarial review. No blockers. Applied:

- **pg direction is now operation-driven (was locale-dependent).** `detail.includes('is still referenced')` reads pg's `detail`, which is localized by `lc_messages` — on a non-English PG server a delete-RESTRICT was misclassified `invalid_reference`. Now `reason` comes from the threaded operation (create ⇒ invalid_reference, delete ⇒ still_referenced), falling back to the detail text only for `update` (ambiguous direction). mysql already keys off the error *code*, so it was fine.
- **Composite key** — skip the `collection:pk` naming when the key spans multiple columns (`collection:1, 2` reads wrong); fall back to the collection.
- **Zero PK** — `value != null` instead of a truthiness test, which dropped `0`.

Accepted (documented, not fixed):

- **mssql / oracle unchanged** (out of scope for this fork's matrix). They keep the pre-existing 3-field, direction-agnostic behavior; no regression. Threading the operation there is a follow-up if we ever support them.
- **mysql tick-position parsing** assumes the schema-qualified `` `db`.`table` `` prefix, and only `ER_ROW_IS_REFERENCED_2` (1451) is caught (not the detail-less 1217). Pre-existing fragility; noted, not widened.

Verified clean by the review: no raw-message prod leak (non-enumerable + dev-gated); operation coverage complete (all write leaves funnel through create/update/delete); no signature-change regressions (only `fields.ts` + the error-handler read path call the translator).

## Deep review — round 2

Second adversarial pass. Applied:

- **Read-path self-referential message fixed.** On the read path (error-handler / `fields.ts` translate with no context), a pg still-referenced delete set both `collection` and `relatedCollection` to the driver table (the child) → *"Record in collection X is still referenced by collection X"*. Now `collection` stays null when the parent is unknowable, so only the referring child is named.
- **sqlite direction.** sqlite now derives `reason` from the operation (delete ⇒ still_referenced) and emits the full extensions shape (matching pg/mysql) — a blocked delete reads *"Cannot delete collection X: it is still referenced"* instead of the wrong-direction *"Invalid foreign key …"*.
- **Empty parsed key** — the `collection:pk` naming now also gates on `value !== ''` (parity with the invalid_reference branch).

Documented (not fixed): a non-English **update** that is actually still-referenced can still be mislabeled (falls to detail text; narrow — Directus rarely mutates a referenced PK). Verified sound: composite-key guard, zero-value, no regex/state leak, dev-only raw exposure, test integrity (each fix has a test that fails on revert).
