### PR TITLE
fix(types): align UtilsService.clearCache type with the { targets } runtime

### DIFF
--- a/api/src/cache.ts
+++ b/api/src/cache.ts
@@ -1,5 +1,5 @@
 import { useEnv } from '@directus/env';
-import type { SchemaOverview } from '@directus/types';
+import type { CacheFlushTarget, SchemaOverview } from '@directus/types';
 import Keyv, { type KeyvOptions } from 'keyv';
 import { useBus } from './bus/index.js';
 import { useLogger } from './logger/index.js';
@@ -42,8 +42,6 @@ interface CacheMessage {
 // The subset a flush drops, chosen per-target on the cache page. `system` rides the
 // existing `schemaChanged` broadcast; `response`/`locks` are per-node memory tiers a
 // dedicated channel has to reach (see `clearCacheTargets`).
-export type CacheFlushTarget = 'response' | 'system' | 'locks';
-
 interface CacheClearMessage {
 	targets: CacheFlushTarget[];
 }

--- a/api/src/controllers/utils.ts
+++ b/api/src/controllers/utils.ts
@@ -1,9 +1,9 @@
 import { InvalidPayloadError, InvalidQueryError, UnsupportedMediaTypeError } from '@directus/errors';
+import type { CacheFlushTarget } from '@directus/types';
 import argon2 from 'argon2';
 import Busboy from 'busboy';
 import { Router } from 'express';
 import Joi from 'joi';
-import type { CacheFlushTarget } from '../cache.js';
 import collectionExists from '../middleware/collection-exists.js';
 import { respond } from '../middleware/respond.js';
 import { ExportService, ImportService } from '../services/import-export.js';

--- a/api/src/services/utils.test.ts
+++ b/api/src/services/utils.test.ts
@@ -5,7 +5,7 @@ import type { Accountability } from '@directus/types';
 import knex, { type Knex } from 'knex';
 import { MockClient, Tracker, createTracker } from 'knex-mock-client';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
-import { getCache, getCacheValue } from '../cache.js';
+import { clearCacheTargets, getCache, getCacheValue } from '../cache.js';
 import {
 	evictCacheEntriesForPath,
 	evictCacheEntry as registryEvictCacheEntry,
@@ -13,6 +13,7 @@ import {
 	listCacheAnomalies,
 	listCacheEntries,
 	readCacheTombstone,
+	recordCacheConfigEvent,
 	setCacheStatsEnabled,
 	truncateCacheEvents,
 } from '../cache-events.js';
@@ -93,6 +94,24 @@ describe('Services / Utils', () => {
 			).rejects.toThrowError(
 				`'test-user' does not have permission to clear the cache as not being an admin`,
 			);
+		});
+
+		it('flushes exactly the requested targets for an admin', async () => {
+			const service = new UtilsService({
+				knex: db,
+				schema,
+				accountability: { user: 'admin-user', admin: true } as Accountability,
+			});
+
+			vi.mocked(recordCacheConfigEvent).mockResolvedValue();
+
+			// Pins the runtime `{ targets }` contract that the published type mirrors:
+			// a revert to the pre-11.10.1 `{ system }` shape passes `targets: undefined`
+			// here and crashes on `undefined.includes` (issue #299). `system` is the
+			// decoy — it must NOT leak in when only response/locks were asked for.
+			await service.clearCache({ targets: ['response', 'locks'] });
+
+			expect(clearCacheTargets).toHaveBeenCalledWith(['response', 'locks']);
 		});
 	});
 

--- a/api/src/services/utils.ts
+++ b/api/src/services/utils.ts
@@ -1,13 +1,14 @@
 import { ForbiddenError, InvalidPayloadError } from '@directus/errors';
 import { systemCollectionRows } from '@directus/system-data';
-import type { AbstractServiceOptions, Accountability, PrimaryKey, SchemaOverview } from '@directus/types';
+import type {
+	AbstractServiceOptions,
+	Accountability,
+	CacheFlushTarget,
+	PrimaryKey,
+	SchemaOverview,
+} from '@directus/types';
 import type { Knex } from 'knex';
-import {
-	type CacheFlushTarget,
-	clearCacheTargets,
-	getCache,
-	getCacheValue,
-} from '../cache.js';
+import { clearCacheTargets, getCache, getCacheValue } from '../cache.js';
 import {
 	type CacheAnomalyRecord,
 	type CacheEntryRecord,

--- a/app/src/modules/settings/routes/cache/cache.vue
+++ b/app/src/modules/settings/routes/cache/cache.vue
@@ -9,7 +9,7 @@ import ApexCharts, { type ApexOptions } from 'apexcharts';
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { abbreviateNumber } from '@directus/utils';
-import type { Filter, User } from '@directus/types';
+import type { CacheFlushTarget, Filter, User } from '@directus/types';
 import SettingsNavigation from '../../components/navigation.vue';
 import AutoRefresh from '@/views/private/components/refresh-sidebar-detail.vue';
 import SearchInput from '@/views/private/components/search-input.vue';
@@ -453,10 +453,6 @@ async function saveTtl() {
 	}
 }
 
-// The flush target subset is a pure UI preference → per-user localStorage, so
-// chained purges keep the last selection without re-picking it each time.
-type CacheFlushTarget = 'response' | 'system' | 'locks';
-
 const flushTargetOptions = [
 	{ text: t('cache_flush_response', 'Response'), value: 'response' },
 	{ text: t('cache_flush_system', 'System'), value: 'system' },
@@ -465,6 +461,8 @@ const flushTargetOptions = [
 
 const userId = (userStore.currentUser as User | null)?.id ?? 'anon';
 
+// The flush target subset is a pure UI preference → per-user localStorage, so
+// chained purges keep the last selection without re-picking it each time.
 const flushTargets = useLocalStorage<CacheFlushTarget[]>(
 	`cache-flush-targets-${userId}`,
 	['response'],

--- a/packages/types/src/cache.ts
+++ b/packages/types/src/cache.ts
@@ -1,0 +1,7 @@
+/**
+ * A subset of the cache the API can flush independently. `response` is the public
+ * query cache; `system` is auto-invalidated on schema change and costly to rebuild;
+ * `locks` holds the build-identity fingerprint. Shared here so the published
+ * `UtilsService.clearCache` type and the runtime stay a single source of truth.
+ */
+export type CacheFlushTarget = 'response' | 'system' | 'locks';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,6 +1,7 @@
 export * from './accountability.js';
 export * from './assets.js';
 export * from './authentication.js';
+export * from './cache.js';
 export * from './collection.js';
 export * from './comments.js';
 export * from './database.js';

--- a/packages/types/src/services.ts
+++ b/packages/types/src/services.ts
@@ -7,6 +7,7 @@ import type { Transporter } from 'nodemailer';
 import type { Accountability } from './accountability.js';
 import type { TransformationSet } from './assets.js';
 import type { LoginResult } from './authentication.js';
+import type { CacheFlushTarget } from './cache.js';
 import type { ApiCollection, RawCollection } from './collection.js';
 import type { ActionHandler } from './events.js';
 import type { ApiOutput, ExtensionManager, ExtensionSettings } from './extensions/index.js';
@@ -448,7 +449,7 @@ interface UsersService {
  */
 interface UtilsService {
 	sort(collection: string, { item, to }: { item: PrimaryKey; to: PrimaryKey }): Promise<void>;
-	clearCache({ system }: { system: boolean }): Promise<void>;
+	clearCache({ targets }: { targets: CacheFlushTarget[] }): Promise<void>;
 }
 
 /**


### PR DESCRIPTION
Closes #299. Re-targets to `hhh-dev` — see routing note below.

While chasing the `SocketError: other side closed` class of crash I traced it to a type that lies. The scoped-cache rewrite moved `UtilsService.clearCache`'s runtime to `{ targets: CacheFlushTarget[] }` but left the published type declaring the pre-11.10.1 `{ system: boolean }`. Anything that trusts `@directus/types` and calls `clearCache({ system })` hands the runtime `targets: undefined`, which then does `undefined.includes('system')` — and because that sits in an async tail after `res.send()`, it surfaces as an unhandled rejection that takes the worker down rather than a catchable error. Internally we're safe (the controller already passes `{ targets }`); the victims are extensions consuming the type.

Rather than patch the one declaration, I went after the root shape of the bug: the same three-value union was hand-copied in **four** places (api `cache.ts`, the controller's joi schema, the service, and the app's `cache.vue`), so nothing stopped them drifting — which is exactly what happened. I moved `CacheFlushTarget` into `@directus/types` as the one authority and pointed every site at it, so the published type and the runtime can no longer disagree.

The `{ targets }` param shape in the `UtilsService` interface is still a hand-mirror of the class (the type package can't import the api class without a cycle), so I added an admin happy-path test that pins the runtime contract with a decoy target — a revert to `{ system }` passes `undefined` and fails on `.includes` again.

**Routing:** this originally landed as #300 into `v11.10.1-feat/cache-ttl-flush`, but that branch's merge into `hhh-dev` predated #300 — so `hhh-dev` currently has the `{ targets }` runtime WITHOUT this type fix, i.e. the #299 bug is live there. This PR rebases the same commit straight onto `hhh-dev` to close that gap.

**Retrocompat:** the HTTP `?system` query flag is untouched (the controller still maps it onto targets). Only the programmatic `clearCache({ system })` shape changes — it was already crashing at runtime, so no working caller regresses.

**Questions:**
- Happy with `CacheFlushTarget` living in `@directus/types`, or keep it api-local and inline the literal in the interface (smaller diff, drift stays possible)?
- I folded the app's `cache.vue` copy into the shared type too — in scope, or should that ride separately?

🤖 Generated with [Claude Code](https://claude.com/claude-code)