### PR TITLE
test(blackbox): retry CreateItem seed to survive shared-instance contention

### DIFF
--- a/tests/blackbox/common/config.ts
+++ b/tests/blackbox/common/config.ts
@@ -325,4 +325,18 @@ export function getUrl(vendor: Vendor, overrideEnv?: Env) {
 	return `http://127.0.0.1:${port}`;
 }
 
+// The seed conduit: the CACHE_SCHEMA=false instance setup.ts spawns at PORT + 50. It
+// recomputes the schema from the DB every request, so a collection created moments
+// earlier is always visible — the cache server can serve a stale schema snapshot and
+// 403 a brand-new collection under concurrent seed load.
+export function getNoCacheUrl(vendor: Vendor) {
+	if (process.env['TEST_LOCAL']) {
+		return getUrl(vendor);
+	}
+
+	const port = parseInt(config.envs[vendor].PORT) + 50;
+
+	return `http://127.0.0.1:${port}`;
+}
+
 export default config;

--- a/tests/blackbox/common/functions.ts
+++ b/tests/blackbox/common/functions.ts
@@ -3,7 +3,7 @@ import { omit } from 'lodash-es';
 import { randomUUID } from 'node:crypto';
 import request from 'supertest';
 import { afterAll, beforeEach, describe, expect, it } from 'vitest';
-import { getUrl, type Env } from './config';
+import { getNoCacheUrl, getUrl, type Env } from './config';
 import vendors, { type Vendor } from './get-dbs-to-test';
 import type { PrimaryKeyType } from './types';
 import { ROLE, USER } from './variables';
@@ -693,14 +693,30 @@ export type OptionsCreateItem = {
 };
 
 export async function CreateItem(vendor: Vendor, options: OptionsCreateItem) {
-	// Action
-	const response = await request(getUrl(vendor))
+	// Seed on the cache server (fast, cached schema). Right after CreateCollections it
+	// can serve a stale schema snapshot and 403 the brand-new collection under
+	// concurrent seed load (TESTS_FLOW is admin_access, so it's schema lag, not a
+	// permission gap). Fall back to the no-cache instance, which recomputes the schema
+	// from the DB every request, so the just-created collection is always visible.
+	const auth = `Bearer ${options.token ?? USER.TESTS_FLOW.TOKEN}`;
+
+	let response = await request(getUrl(vendor))
 		.post(`/items/${options.collection}`)
-		.set('Authorization', `Bearer ${options.token ?? USER.TESTS_FLOW.TOKEN}`)
+		.set('Authorization', auth)
 		.send(options.item);
 
+	if (response.status === 403) {
+		response = await request(getNoCacheUrl(vendor))
+			.post(`/items/${options.collection}`)
+			.set('Authorization', auth)
+			.send(options.item);
+	}
+
 	if (!response.ok) {
-		throw new Error('Could not create item', response.body);
+		throw new Error(
+			`Could not create item in ${options.collection}: `
+			+ `${response.status} ${JSON.stringify(response.body)}`,
+		);
 	}
 
 	return response.body.data;


### PR DESCRIPTION
## Why

Blackbox seeds run many collections' `beforeAll` **concurrently against the single shared cache server** (`getUrl` → default instance, `CACHE_SCHEMA` on). Right after `CreateCollections`, a concurrent `getSchema` recompute can re-cache a schema snapshot taken *before* the new collection committed — so the server returns **`403 FORBIDDEN`** for a collection it doesn't know yet. `TESTS_FLOW` has `admin_access`, so permissions are bypassed: the 403 is **schema-cache lag, not a permission gap**. One blip red a whole shard (postgres shards 2/3/5, the failing shard shifting run-to-run — a load race, not a test bug). Surfaced while adding blackbox coverage in #306 "feat(cache): expose context.scopedCache.purgeForMutatedRows".

## What

Seed on the cache server as before (fast, cached schema); **only on the `403`, fall back to the no-cache instance** the harness already spawns in `setup.ts` (`CACHE_SCHEMA=false`, same DB, `PORT + 50`). It recomputes the schema from the DB on every request, so a collection committed moments earlier on the cache server is **always visible** → the fallback create is deterministic. Common seeds pay nothing extra; only the rare stale-schema race takes one extra request. No retry loop, no backoff.

- add `getNoCacheUrl(vendor)` to `config.ts` — the fallback conduit.
- `CreateItem`: cache server, then no-cache on 403; throw with real `status` + `body` on failure (the old throw hid the status in `Error`'s `cause` slot — that's how the 403 stayed opaque and got mis-called "pool pressure").

### Why the fallback is gated on 403 (not "always no-cache")

I first routed *every* seed through the no-cache instance. Measured on the "Run tests" step (build excluded), that added **~+35–90s on 3/4 seed-heavy shards** (pg1 flat, pg2 +90, sq1 +35, sq3 +50) — a full schema recompute per `CreateItem`. Gating the fallback on the 403 keeps the steady-state cost at zero while staying deterministic.

Scoped to `CreateItem` (the observed culprit). `CreateField`/nested creates could race the same way; out of scope unless it recurs — same fallback if so.

## Out of scope — separate infra flake

The failing run also red **postgres shard 5** + **sqlite3 shard 4** with `ERROR: Port 59202/59210 is already in use` (the no-cache server failing to bind at global setup → unhandled rejection → whole shard dies). Root cause: server ports **59152–59210 sit inside Linux's ephemeral range (32768–60999)**, so an outbound socket (DB conn / supertest client) can grab a server's port as its *source* port before the server `listen`s. Rare, random shard, aggravated by more test files. Pre-existing (base `v11.10.1-hhh-dev` is green) and orthogonal to the seed race — tracked as #309 (fix: move the test server ports below 32768). Not addressed here.

Assisted-by: Claude:claude-opus-4-8