### PR TITLE
test(blackbox): move server ports below the OS ephemeral range

### DIFF
--- a/tests/blackbox/common/config.ts
+++ b/tests/blackbox/common/config.ts
@@ -218,6 +218,9 @@ const config: Config = {
 		cockroachdb: 'CockroachDB',
 		sqlite3: 'SQLite 3',
 	},
+	// Server ports sit at 201xx (no-cache instance at PORT + 50 -> 202xx), kept below
+	// the Linux ephemeral range (32768-60999) so an outbound socket can't grab one as
+	// its source port and cause EADDRINUSE when a server calls listen (#309).
 	envs: {
 		postgres: {
 			...directusConfig,
@@ -227,7 +230,7 @@ const config: Config = {
 			DB_PASSWORD: 'secret',
 			DB_PORT: '6100',
 			DB_DATABASE: 'directus',
-			PORT: '59152',
+			PORT: '20152',
 		},
 		postgres10: {
 			...directusConfig,
@@ -237,7 +240,7 @@ const config: Config = {
 			DB_PASSWORD: 'secret',
 			DB_PORT: '6101',
 			DB_DATABASE: 'directus',
-			PORT: '59153',
+			PORT: '20153',
 		},
 		mysql: {
 			...directusConfig,
@@ -247,7 +250,7 @@ const config: Config = {
 			DB_USER: 'root',
 			DB_PASSWORD: 'secret',
 			DB_DATABASE: 'directus',
-			PORT: '59154',
+			PORT: '20154',
 		},
 		mysql5: {
 			...directusConfig,
@@ -257,7 +260,7 @@ const config: Config = {
 			DB_USER: 'root',
 			DB_PASSWORD: 'secret',
 			DB_DATABASE: 'directus',
-			PORT: '59155',
+			PORT: '20155',
 		},
 		maria: {
 			...directusConfig,
@@ -267,7 +270,7 @@ const config: Config = {
 			DB_USER: 'root',
 			DB_PASSWORD: 'secret',
 			DB_DATABASE: 'directus',
-			PORT: '59156',
+			PORT: '20156',
 		},
 		mssql: {
 			...directusConfig,
@@ -277,7 +280,7 @@ const config: Config = {
 			DB_USER: 'sa',
 			DB_PASSWORD: 'Test@123',
 			DB_DATABASE: 'model',
-			PORT: '59157',
+			PORT: '20157',
 		},
 		oracle: {
 			...directusConfig,
@@ -285,7 +288,7 @@ const config: Config = {
 			DB_USER: 'secretsysuser',
 			DB_PASSWORD: 'secretpassword',
 			DB_CONNECT_STRING: `127.0.0.1:6106/XE`,
-			PORT: '59158',
+			PORT: '20158',
 		},
 		cockroachdb: {
 			...directusConfig,
@@ -295,13 +298,13 @@ const config: Config = {
 			DB_PASSWORD: '',
 			DB_PORT: '6107',
 			DB_DATABASE: 'defaultdb',
-			PORT: '59159',
+			PORT: '20159',
 		},
 		sqlite3: {
 			...directusConfig,
 			DB_CLIENT: 'sqlite3',
 			DB_FILENAME: './test.db',
-			PORT: '59160',
+			PORT: '20160',
 		},
 	},
 };


### PR DESCRIPTION
## Why

Blackbox shards intermittently die during **global setup** (before any test runs) with:

```
Unhandled Rejection
Error: Directus-<vendor>-no-cache server failed (1):
 ERROR: Port 59202 is already in use
 ❯ ChildProcess.<anonymous> setup/setup.ts:93:29
```

The `on('exit')` handler throws → unhandled rejection → the **whole shard** fails, not just one test. Seen on `postgres (shard 5)` (59202) and `sqlite3 (shard 4)` (59210) in one run; the affected shard/vendor shifts run-to-run. Rare (base is green) and worse as the suite grows.

**Root cause:** the harness binds fixed server ports **59152–59210** (`config.ts` base 59152–59160, plus the no-cache instance at `PORT + 50` = 59202–59210). That range sits **inside** Linux's default ephemeral port range (`net.ipv4.ip_local_port_range` = 32768–60999). So an *outbound* socket the harness opens during setup (DB connections, `awaitDirectusConnection` probes, supertest clients) can be assigned one of these as its ephemeral **source** port — and if that happens before the server `listen()`s on the same port, the bind fails with `EADDRINUSE`. Nothing is really double-binding a listener; it's a source-port vs listen-port collision, which is why it's load-dependent and random.

## What

Move the base server ports to **201xx** (no-cache `+ 50` → 202xx), below 32768, out of the ephemeral range. The `PORT + 50` no-cache convention (`config.ts` + `setup.ts`) is relative, so it follows automatically. Added a comment so nobody tidies them back into the ephemeral range.

The other fixed harness ports (DB 6100–6107, SAML IdP 8880, minio 8881, local 8055) are already below 32768 — only the 591xx server ports were exposed.

## Notes

- Split out of #308 (seed-403 fix); this port flake was orthogonal and pre-existing.
- Alternative considered: reserve the range on the runner via `net.ipv4.ip_local_reserved_ports` — rejected as a less self-contained CI/sudo change; moving the ports fixes it in one file.

Fixes #309

Assisted-by: Claude:claude-opus-4-8
