### PR TITLE
fix(items): reset mutation tracker on transaction retry (#312)

### DIFF
--- a/api/src/services/items.test.ts
+++ b/api/src/services/items.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi, type Mocked
 import { getDatabaseClient } from '../database/index.js';
 import emitter from '../emitter.js';
 import { readMeta } from '../utils/read-meta.js';
+import { transaction } from '../utils/transaction.js';
 import { validateUserCountIntegrity } from '../utils/validate-user-count-integrity.js';
 import { ItemsService } from './items.js';
 
@@ -733,6 +734,113 @@ describe('Integration Tests', () => {
 					emitter.offAction('test.items.delete', handler);
 				}
 			});
+		});
+	});
+
+	describe('mutation tracker retry safety (#312)', () => {
+		// #312: transaction() retries the handler on SQLITE_BUSY / cockroach 40001. The
+		// mutation tracker lives outside the retried handler, so without a reset a retry
+		// re-counts the nested M2O mutations onto the outer count -> over-count.
+		// The fake knex below only needs isTransaction + a transaction() that runs the
+		// handler; transaction() passes knex to the mocked getDatabaseClient only.
+		const retryingKnex = {
+			isTransaction: false,
+			transaction: (handler: (trx: Knex) => Promise<unknown>) => {
+				return handler({ isTransaction: true } as unknown as Knex);
+			},
+		} as unknown as Knex;
+
+		function busyOnFirstAttempt(
+			mutationTracker: ReturnType<ItemsService['createMutationTracker']>,
+		) {
+			let attempts = 0;
+
+			return async function handler() {
+				// The nested M2O count added inside the retried handler.
+				mutationTracker.trackMutations(2);
+
+				if (attempts++ === 0) {
+					throw Object.assign(new Error('database is locked'), {
+						code: 'SQLITE_BUSY',
+					});
+				}
+			};
+		}
+
+		it('restores outer count on retry, nested not double-counted', async () => {
+			vi.mocked(getDatabaseClient).mockReturnValueOnce('sqlite');
+			const service = new ItemsService('test', { knex: db, schema });
+			const mutationTracker = service.createMutationTracker();
+
+			// The outer count (e.g. data.length), added once outside the transaction.
+			mutationTracker.trackMutations(3);
+
+			await transaction(
+				retryingKnex,
+				busyOnFirstAttempt(mutationTracker),
+				mutationTracker.snapshot(),
+			);
+
+			// 3 outer + 2 nested, NOT 3 + 2 + 2 (the nested count re-added on retry).
+			expect(mutationTracker.getCount()).toBe(5);
+		});
+
+		it('over-counts without the snapshot restore (control witness)', async () => {
+			vi.mocked(getDatabaseClient).mockReturnValueOnce('sqlite');
+			const service = new ItemsService('test', { knex: db, schema });
+			const mutationTracker = service.createMutationTracker();
+
+			mutationTracker.trackMutations(3);
+
+			// No onRetry restore passed, so the bug reproduces.
+			await transaction(retryingKnex, busyOnFirstAttempt(mutationTracker));
+
+			expect(mutationTracker.getCount()).toBe(7);
+		});
+
+		it('does not wrongly exceed MAX_BATCH_MUTATION after a retry', async () => {
+			const savedMax = env['MAX_BATCH_MUTATION'];
+			// 3 outer + 2 nested = 5 <= 6, but the double-counted 7 would exceed it.
+			env['MAX_BATCH_MUTATION'] = 6;
+
+			try {
+				vi.mocked(getDatabaseClient).mockReturnValueOnce('sqlite');
+				const service = new ItemsService('test', { knex: db, schema });
+				const mutationTracker = service.createMutationTracker();
+
+				mutationTracker.trackMutations(3);
+
+				await expect(
+					transaction(
+						retryingKnex,
+						busyOnFirstAttempt(mutationTracker),
+						mutationTracker.snapshot(),
+					),
+				).resolves.toBeUndefined();
+			}
+			finally {
+				env['MAX_BATCH_MUTATION'] = savedMax;
+			}
+		});
+
+		it('wrongly rejects at the limit without restore (control)', async () => {
+			const savedMax = env['MAX_BATCH_MUTATION'];
+			env['MAX_BATCH_MUTATION'] = 6;
+
+			try {
+				vi.mocked(getDatabaseClient).mockReturnValueOnce('sqlite');
+				const service = new ItemsService('test', { knex: db, schema });
+				const mutationTracker = service.createMutationTracker();
+
+				mutationTracker.trackMutations(3);
+
+				await expect(
+					transaction(retryingKnex, busyOnFirstAttempt(mutationTracker)),
+				).rejects.toThrow('Exceeded max batch mutation limit');
+			}
+			finally {
+				env['MAX_BATCH_MUTATION'] = savedMax;
+			}
 		});
 	});
 });

--- a/api/src/services/items.ts
+++ b/api/src/services/items.ts
@@ -482,6 +482,13 @@ implements AbstractService<Item> {
 			getCount() {
 				return mutationCount;
 			},
+			snapshot() {
+				const savedCount = mutationCount;
+
+				return () => {
+					mutationCount = savedCount;
+				};
+			},
 		};
 	}
 
@@ -923,7 +930,7 @@ implements AbstractService<Item> {
 					(p): ActionPayload => ({ primaryKey: p.primaryKey, actionHookPayload: p.actionHookPayload }),
 				),
 			};
-		});
+		}, opts.mutationTracker.snapshot());
 
 		if (opts.emitEvents !== false) {
 			const eventName =
@@ -1313,7 +1320,7 @@ implements AbstractService<Item> {
 						await validateUserCountIntegrity({ flags: userIntegrityCheckFlags, knex });
 					}
 				}
-			});
+			}, opts.mutationTracker.snapshot());
 		}
 		finally {
 			if (shouldClearCache(this.cache, opts, this.collection)) {
@@ -1658,7 +1665,7 @@ implements AbstractService<Item> {
 					}
 				}
 			}
-		});
+		}, opts.mutationTracker.snapshot());
 
 		if (shouldClearCache(this.cache, opts, this.collection)) {
 			// Old slices from the pre-update capture, plus the new value re-read from the
@@ -1770,7 +1777,7 @@ implements AbstractService<Item> {
 			}
 
 			return primaryKeys;
-		});
+		}, opts.mutationTracker.snapshot());
 
 		if (shouldClearCache(this.cache, opts, this.collection)) {
 			// Re-snapshot the committed rows for their new scope values (covers both the
@@ -1971,7 +1978,7 @@ implements AbstractService<Item> {
 					{ bypassLimits: true },
 				);
 			}
-		});
+		}, opts.mutationTracker.snapshot());
 
 		if (shouldClearCache(this.cache, opts, this.collection)) {
 			await this.purgeScopedCache(oldScopedCacheTags, scopedCacheCollector);

--- a/api/src/utils/transaction.ts
+++ b/api/src/utils/transaction.ts
@@ -11,7 +11,11 @@ import type { DatabaseClient } from '@directus/types';
  * Can be used to ensure the handler is run within a transaction,
  * while preventing nested transactions.
  */
-export const transaction = async <T = unknown>(knex: Knex, handler: (knex: Knex) => Promise<T>): Promise<T> => {
+export const transaction = async <T = unknown>(
+	knex: Knex,
+	handler: (knex: Knex) => Promise<T>,
+	onRetry?: () => void,
+): Promise<T> => {
 	if (knex.isTransaction) {
 		return handler(knex);
 	} else {
@@ -20,6 +24,12 @@ export const transaction = async <T = unknown>(knex: Knex, handler: (knex: Knex)
 		} catch (error) {
 			const client = getDatabaseClient(knex);
 
+			// Only sqlite / cockroach reach the retry loop: both hand an aborted
+			// transaction back and require the CLIENT to re-run it (no server-side
+			// recovery). cockroach's optimistic SERIALIZABLE aborts a txn that lost
+			// a write race at commit (40001); sqlite's single writer rejects a
+			// concurrent write with SQLITE_BUSY. postgres blocks on locks instead
+			// of returning a retry code, so it never lands here.
 			if (!shouldRetryTransaction(client, error)) throw error;
 
 			const MAX_ATTEMPTS = 3;
@@ -33,6 +43,10 @@ export const transaction = async <T = unknown>(knex: Knex, handler: (knex: Knex)
 				await new Promise((resolve) => setTimeout(resolve, delay));
 
 				logger.trace(`Restarting failed transaction (attempt ${attempt + 1}/${MAX_ATTEMPTS})`);
+
+				// Roll back caller state (e.g. the mutation counter) so a re-run of the
+				// handler doesn't accumulate its side effects onto the previous attempt.
+				onRetry?.();
 
 				try {
 					return await knex.transaction((trx) => handler(trx));

--- a/packages/types/src/items.ts
+++ b/packages/types/src/items.ts
@@ -23,6 +23,12 @@ export type ActionEventParams = {
 export type MutationTracker = {
 	trackMutations: (count: number) => void;
 	getCount: () => number;
+	/**
+	 * Capture the current count and return a restore function. A retried
+	 * transaction calls it before each re-run so nested mutation counts aren't
+	 * accumulated onto the surviving outer count.
+	 */
+	snapshot: () => () => void;
 };
 
 export type QueryOptions = {


### PR DESCRIPTION
Closes #312.

## Why

While de-flaking the m2o MAX_BATCH_MUTATION WebSocket flake (#311) I split out this tracker bug rather than fold it into a test-only PR — it touches the production mutation hot-path and wanted its own change + regression test.

`transaction()` retries the handler on `SQLITE_BUSY` (sqlite) / `40001` (cockroach). But the mutation tracker and the *outer* mutation count are created **outside** the retried handler, while the nested M2O counts (`payload.ts` `processM2O` → `createOne`/`updateOne`) happen **inside** it. So on a retry the nested mutations get re-counted onto the never-reset tracker and the total over-counts. A create/update whose payload sits near `MAX_BATCH_MUTATION` can then be wrongly rejected with *"Exceeded max batch mutation limit"* after a perfectly legitimate retry.

## What

I went with option 1 from the issue (snapshot + restore) over option 2 (move the tracker creation inside the handler), because the outer count must **survive** the retry while only the nested counts reset — a plain reset-to-zero would drop the outer count too.

- `transaction()` gains an optional `onRetry` hook, called before each re-run. It stays tracker-agnostic — it just rolls back whatever caller state was handed to it.
- `MutationTracker` gains `snapshot()`, returning a restore closure that pins the count back to its pre-attempt value.
- Wired at the five tracker-owning transaction sites: `createMany`, `updateBatch`, `updateMany`, `upsertMany`, `deleteMany`.

Nested service calls run inside the parent transaction (`knex.isTransaction === true`), so they never open their own retrying transaction — the hook is inert there, and only the outermost tracker-owner resets.

## Tests

Four tests in `items.test.ts` drive the real `transaction()` + a real `MutationTracker` through a fake knex that throws `SQLITE_BUSY` on the first attempt:
- with the snapshot restore → count is `outer + nested` (5), and a near-limit payload is **not** rejected;
- paired control witnesses with the restore omitted → count is `outer + 2·nested` (7) and the near-limit payload **is** wrongly rejected.

I confirmed the pair is load-bearing: reverting the `onRetry?.()` call flips the two "with restore" tests red while the controls stay green.

## Out of scope

Postgres isn't in the retry set, so it was never affected. I didn't touch the retry policy itself (attempts/backoff) — only the tracker's behaviour across a retry.

## Question

`onRetry` is deliberately generic — do you want it named something more explicit (`resetOnRetry` / `rollback`), or is the tracker-agnostic `onRetry` the right level of abstraction for a util that shouldn't know about mutation counting?

🤖 Generated with [Claude Code](https://claude.com/claude-code)