### PR TITLE
feat(cache): filter the timeseries by endpoint prefix

### DIFF
--- a/api/src/cache-events.test.ts
+++ b/api/src/cache-events.test.ts
@@ -635,11 +635,12 @@ describe('drainCacheEvents', () => {
 	it('demuxes hits/misses to events and descriptors to the dimension', async () => {
 		streamBatch = [
 			streamEntry('1-0', {
-				kind: 'h', cacheKey: 'k1', ageMs: '5000', ttlMs: '300000',
-				durationMs: '12', ts: '1000',
+				kind: 'h', cacheKey: 'k1', prefix: '/items', ageMs: '5000',
+				ttlMs: '300000', durationMs: '12', ts: '1000',
 			}),
 			streamEntry('2-0', {
-				kind: 'm', cacheKey: 'k2', gapMs: '2000', ttlMs: '300000', ts: '2000',
+				kind: 'm', cacheKey: 'k2', prefix: '/users', gapMs: '2000',
+				ttlMs: '300000', ts: '2000',
 			}),
 			streamEntry('3-0', {
 				kind: 'd', cacheKey: 'k1', redisKey: '/items/a:u1', coarse: '1',
@@ -658,6 +659,7 @@ describe('drainCacheEvents', () => {
 				{
 					time: new Date(1000),
 					cache_key: 'k1',
+					prefix: '/items',
 					kind: 0,
 					age_ms: 5000,
 					gap_ms: null,
@@ -667,6 +669,7 @@ describe('drainCacheEvents', () => {
 				{
 					time: new Date(2000),
 					cache_key: 'k2',
+					prefix: '/users',
 					kind: 1,
 					age_ms: null,
 					gap_ms: 2000,

--- a/api/src/cache-events.test.ts
+++ b/api/src/cache-events.test.ts
@@ -784,7 +784,7 @@ describe('drainCacheEvents', () => {
 	it('inserts anomaly entries into the anomalies table', async () => {
 		streamBatch = [
 			streamEntry('1-0', {
-				kind: 'a', cacheKey: 'k9', reason: 'value_too_large',
+				kind: 'a', cacheKey: 'k9', prefix: '/items', reason: 'value_too_large',
 				detail: '2048B', ts: '4000',
 			}),
 		];
@@ -799,6 +799,7 @@ describe('drainCacheEvents', () => {
 				{
 					time: new Date(4000),
 					cache_key: 'k9',
+					prefix: '/items',
 					reason: 'value_too_large',
 					detail: '2048B',
 				},

--- a/api/src/cache-events.ts
+++ b/api/src/cache-events.ts
@@ -77,6 +77,7 @@ export type CacheAnomalyReason =
 
 export interface CacheAnomaly {
 	cacheKey: string;
+	prefix?: string;
 	reason: CacheAnomalyReason;
 	detail?: string | null; // byte size / error message
 }
@@ -414,6 +415,7 @@ export function queueCacheAnomaly(entry: CacheAnomaly): void {
 	xadd({
 		kind: 'a',
 		cacheKey: entry.cacheKey,
+		prefix: entry.prefix ?? '',
 		reason: entry.reason,
 		detail: entry.detail ?? '',
 		ts: String(Date.now()),
@@ -534,6 +536,7 @@ interface CacheDescriptorRow {
 interface CacheAnomalyRow {
 	time: Date;
 	cache_key: string;
+	prefix: string | null;
 	reason: string;
 	detail: string;
 }
@@ -711,6 +714,9 @@ async function persistStreamBatch(
 			anomalies.push({
 				time: at,
 				cache_key: f['cacheKey']!,
+				prefix: f['prefix']
+					? f['prefix']
+					: null,
 				reason: f['reason'] ?? '',
 				detail: f['detail'] ?? '',
 			});
@@ -1165,22 +1171,33 @@ export async function readCacheTimeseries(
 
 	const bucketExpr = 'floor(extract(epoch from (time - ?::timestamptz)) / ?)';
 
-	// Every prefix in the window — the filter's option list, built unfiltered so a
-	// narrowed selection never hides the other options.
-	const prefixRows = await db('directus_cache_events')
-		.where('time', '>', since)
-		.whereNotNull('prefix')
-		.distinct('prefix')
-		.orderBy('prefix');
+	async function distinctPrefixes(table: string): Promise<string[]> {
+		const rows = await db(table)
+			.where('time', '>', since)
+			.whereNotNull('prefix')
+			.distinct('prefix');
 
-	const availablePrefixes = (prefixRows as Record<string, unknown>[])
-		.map((row) => String(row['prefix']));
+		return (rows as Record<string, unknown>[]).map((row) => String(row['prefix']));
+	}
+
+	// Every prefix in the window across both plotted sources (events + anomalies) —
+	// the filter's option list, built unfiltered so a narrowed selection never hides
+	// the other options.
+	const availablePrefixes = [
+		...new Set([
+			...await distinctPrefixes('directus_cache_events'),
+			...await distinctPrefixes('directus_cache_anomalies'),
+		]),
+	].sort();
 
 	const eventQuery = db('directus_cache_events').where('time', '>', since);
+	const anomalyQuery = db('directus_cache_anomalies').where('time', '>', since);
 
-	// Empty/absent selection means all; a non-empty one narrows to those prefixes.
+	// Empty/absent selection means all; a non-empty one narrows both series to those
+	// prefixes so the whole chart tracks the same endpoint set.
 	if (prefixes && prefixes.length > 0) {
 		void eventQuery.whereIn('prefix', prefixes);
+		void anomalyQuery.whereIn('prefix', prefixes);
 	}
 
 	const eventRows = await eventQuery
@@ -1192,8 +1209,7 @@ export async function readCacheTimeseries(
 			db.raw('MAX(ttl_ms) AS ttl_ms'),
 		);
 
-	const anomalyRows = await db('directus_cache_anomalies')
-		.where('time', '>', since)
+	const anomalyRows = await anomalyQuery
 		.groupByRaw('1')
 		.select(
 			db.raw(`${bucketExpr} AS bucket`, [since, bucketSec]),

--- a/api/src/cache-events.ts
+++ b/api/src/cache-events.ts
@@ -30,6 +30,9 @@ import { getMilliseconds } from './utils/get-milliseconds.js';
 
 export interface CacheHit {
 	cacheKey: string;
+	// The request's endpoint prefix (`/items`, …). Emitted by the cache middleware,
+	// which always sets it; optional so telemetry callers/tests can omit it.
+	prefix?: string;
 	ageMs: number;
 	ttlMs: number | null;
 	durationMs: number | null;
@@ -37,6 +40,7 @@ export interface CacheHit {
 
 export interface CacheMiss {
 	cacheKey: string;
+	prefix?: string;
 	gapMs: number | null;
 	ttlMs: number | null;
 }
@@ -131,6 +135,9 @@ export interface CacheTimeseries {
 	markers: CacheConfigEvent[];
 	// The TTL in force (override, else env default) — for the page's TTL input.
 	effectiveTtl: string | null;
+	// Every endpoint prefix seen in the window — populates the page's prefix filter,
+	// independent of which subset is currently selected so options never vanish.
+	prefixes: string[];
 }
 
 export interface CacheStatsState {
@@ -345,6 +352,7 @@ export async function queueCacheHit(hit: CacheHit): Promise<void> {
 	xadd({
 		kind: 'h',
 		cacheKey: hit.cacheKey,
+		prefix: hit.prefix ?? '',
 		ageMs: String(hit.ageMs),
 		ttlMs: hit.ttlMs === null
 			? ''
@@ -364,6 +372,7 @@ export async function queueCacheMiss(miss: CacheMiss): Promise<void> {
 	xadd({
 		kind: 'm',
 		cacheKey: miss.cacheKey,
+		prefix: miss.prefix ?? '',
 		gapMs: miss.gapMs === null
 			? ''
 			: String(miss.gapMs),
@@ -499,6 +508,7 @@ export async function readCacheTombstone(key: string): Promise<number | null> {
 interface CacheEventRow {
 	time: Date;
 	cache_key: string;
+	prefix: string | null;
 	kind: number;
 	age_ms: number | null;
 	gap_ms: number | null;
@@ -743,6 +753,9 @@ async function persistStreamBatch(
 		events.push({
 			time: at,
 			cache_key: f['cacheKey']!,
+			prefix: f['prefix']
+				? f['prefix']
+				: null,
 			kind: f['kind'] === 'h'
 				? 0
 				: 1,
@@ -1093,6 +1106,7 @@ export async function recordCacheConfigEvent(
 export async function readCacheTimeseries(
 	windowMs?: number,
 	buckets = 60,
+	prefixes?: string[],
 ): Promise<CacheTimeseries> {
 	const db = getDatabase();
 	const windowLen = clampCacheStatsWindow(windowMs);
@@ -1146,13 +1160,30 @@ export async function readCacheTimeseries(
 	);
 
 	if (!cacheStatsConfigured() || db.client.config.client !== 'pg') {
-		return { buckets: dense, markers, effectiveTtl };
+		return { buckets: dense, markers, effectiveTtl, prefixes: [] };
 	}
 
 	const bucketExpr = 'floor(extract(epoch from (time - ?::timestamptz)) / ?)';
 
-	const eventRows = await db('directus_cache_events')
+	// Every prefix in the window — the filter's option list, built unfiltered so a
+	// narrowed selection never hides the other options.
+	const prefixRows = await db('directus_cache_events')
 		.where('time', '>', since)
+		.whereNotNull('prefix')
+		.distinct('prefix')
+		.orderBy('prefix');
+
+	const availablePrefixes = (prefixRows as Record<string, unknown>[])
+		.map((row) => String(row['prefix']));
+
+	const eventQuery = db('directus_cache_events').where('time', '>', since);
+
+	// Empty/absent selection means all; a non-empty one narrows to those prefixes.
+	if (prefixes && prefixes.length > 0) {
+		void eventQuery.whereIn('prefix', prefixes);
+	}
+
+	const eventRows = await eventQuery
 		.groupByRaw('1')
 		.select(
 			db.raw(`${bucketExpr} AS bucket`, [since, bucketSec]),
@@ -1189,7 +1220,7 @@ export async function readCacheTimeseries(
 		dense[slotOf(row['bucket'])]!.anomalies += Number(row['count'] ?? 0);
 	}
 
-	return { buckets: dense, markers, effectiveTtl };
+	return { buckets: dense, markers, effectiveTtl, prefixes: availablePrefixes };
 }
 
 // Prune config-event markers past the retention window. Ungated (they are recorded

--- a/api/src/cache-timeseries.test.ts
+++ b/api/src/cache-timeseries.test.ts
@@ -108,12 +108,17 @@ describe('readCacheTimeseries', () => {
 				{ prefix: '/items' },
 				{ prefix: '/utils' },
 			],
+			// A prefix seen only in anomalies still reaches the option list (union).
+			'directus_cache_anomalies:distinct': [
+				{ prefix: '/graphql' },
+				{ prefix: '/utils' },
+			],
 		};
 
 		const result = await readCacheTimeseries(windowMs, buckets);
 
 		expect(result.buckets).toHaveLength(3);
-		expect(result.prefixes).toEqual(['/items', '/utils']);
+		expect(result.prefixes).toEqual(['/graphql', '/items', '/utils']);
 
 		// bucket 0 → slot 0; gap at slot 1; bucket 2 → slot 2; the out-of-range bucket
 		// 3 folds into the last slot too (5+1 hits, 4+2 misses).
@@ -158,11 +163,17 @@ describe('readCacheTimeseries', () => {
 		env['CACHE_STATS_ENABLED'] = true;
 	});
 
-	it('narrows the event query to the selected prefixes', async () => {
+	it('narrows both the event and anomaly queries to the prefixes', async () => {
 		await readCacheTimeseries(180_000, 3, ['/items', '/users']);
 
 		expect(whereInSpy).toHaveBeenCalledWith(
 			'directus_cache_events',
+			'prefix',
+			['/items', '/users'],
+		);
+
+		expect(whereInSpy).toHaveBeenCalledWith(
+			'directus_cache_anomalies',
 			'prefix',
 			['/items', '/users'],
 		);

--- a/api/src/cache-timeseries.test.ts
+++ b/api/src/cache-timeseries.test.ts
@@ -24,17 +24,35 @@ import {
 let rowsByTable: Record<string, any[]>;
 let insertSpy: ReturnType<typeof vi.fn>;
 let deleteSpy: ReturnType<typeof vi.fn>;
+let whereInSpy: ReturnType<typeof vi.fn>;
 
 function makeBuilder(table: string) {
+	// The distinct-prefix query hits the same table as the event aggregation, so a
+	// `distinct()` call routes to a separate `<table>:distinct` reply.
+	let distinctCalled = false;
+
 	const builder: any = {
 		where: () => builder,
+		whereIn: (...args: unknown[]) => {
+			whereInSpy(table, ...args);
+			return builder;
+		},
+		whereNotNull: () => builder,
+		distinct: () => {
+			distinctCalled = true;
+			return builder;
+		},
 		orderBy: () => builder,
 		groupByRaw: () => builder,
 		select: () => builder,
 		insert: (row: unknown) => insertSpy(table, row),
 		delete: () => deleteSpy(table),
 		then: (resolve: any, reject: any) => {
-			return Promise.resolve(rowsByTable[table] ?? []).then(resolve, reject);
+			const key = distinctCalled
+				? `${table}:distinct`
+				: table;
+
+			return Promise.resolve(rowsByTable[key] ?? []).then(resolve, reject);
 		},
 	};
 
@@ -51,6 +69,7 @@ beforeEach(() => {
 	rowsByTable = {};
 	insertSpy = vi.fn(() => Promise.resolve([1]));
 	deleteSpy = vi.fn(() => Promise.resolve(3));
+	whereInSpy = vi.fn();
 
 	const db: any = vi.fn((table: string) => makeBuilder(table));
 	db.client = { config: { client: 'pg' } };
@@ -85,11 +104,16 @@ describe('readCacheTimeseries', () => {
 			directus_cache_config_events: [
 				{ time: new Date(NOW - 1000), kind: 'flush', detail: 'response' },
 			],
+			'directus_cache_events:distinct': [
+				{ prefix: '/items' },
+				{ prefix: '/utils' },
+			],
 		};
 
 		const result = await readCacheTimeseries(windowMs, buckets);
 
 		expect(result.buckets).toHaveLength(3);
+		expect(result.prefixes).toEqual(['/items', '/utils']);
 
 		// bucket 0 → slot 0; gap at slot 1; bucket 2 → slot 2; the out-of-range bucket
 		// 3 folds into the last slot too (5+1 hits, 4+2 misses).
@@ -132,6 +156,22 @@ describe('readCacheTimeseries', () => {
 		expect(result.buckets.every((b) => b.hits === 0 && b.misses === 0)).toBe(true);
 
 		env['CACHE_STATS_ENABLED'] = true;
+	});
+
+	it('narrows the event query to the selected prefixes', async () => {
+		await readCacheTimeseries(180_000, 3, ['/items', '/users']);
+
+		expect(whereInSpy).toHaveBeenCalledWith(
+			'directus_cache_events',
+			'prefix',
+			['/items', '/users'],
+		);
+	});
+
+	it('does not narrow when no prefixes are selected (all)', async () => {
+		await readCacheTimeseries(180_000, 3, []);
+
+		expect(whereInSpy).not.toHaveBeenCalled();
 	});
 });
 

--- a/api/src/controllers/utils.ts
+++ b/api/src/controllers/utils.ts
@@ -270,8 +270,13 @@ router.get(
 			? undefined
 			: Number(req.query['buckets']);
 
+		// Comma-joined endpoint prefixes to narrow the series to; absent = all.
+		const prefixes = typeof req.query['prefixes'] === 'string'
+			? req.query['prefixes'].split(',').filter(Boolean)
+			: undefined;
+
 		res.locals['payload'] = {
-			data: await service.getCacheTimeseries(windowMs, buckets),
+			data: await service.getCacheTimeseries(windowMs, buckets, prefixes),
 		};
 
 		return next();

--- a/api/src/database/migrations/20260728A-add-cache-event-prefix.ts
+++ b/api/src/database/migrations/20260728A-add-cache-event-prefix.ts
@@ -1,0 +1,21 @@
+import type { Knex } from 'knex';
+
+/**
+ * Adds `prefix` to `directus_cache_events` — the request's first path segment
+ * (`/items`, `/utils`, …) captured at hit/miss time. A miss never writes a
+ * descriptor, so the opaque `cache_key` is otherwise its only handle; the prefix
+ * lets the cache page filter the timeseries by endpoint group (and drop the
+ * self-polling `/utils` noise). Nullable so pre-existing rows stay valid; no
+ * index, matching the table's lean-fact stance (the query is time-sliced first).
+ */
+export async function up(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_cache_events', (table) => {
+		table.string('prefix', 64).nullable();
+	});
+}
+
+export async function down(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_cache_events', (table) => {
+		table.dropColumn('prefix');
+	});
+}

--- a/api/src/database/migrations/20260728B-add-cache-anomaly-prefix.ts
+++ b/api/src/database/migrations/20260728B-add-cache-anomaly-prefix.ts
@@ -1,0 +1,19 @@
+import type { Knex } from 'knex';
+
+/**
+ * Adds `prefix` to `directus_cache_anomalies` — the request's first path segment,
+ * captured at report time — so the cache page's prefix filter narrows the anomaly
+ * series alongside hits/misses (they're plotted together). Nullable so pre-existing
+ * rows stay valid; no index, matching the events table's lean-fact stance.
+ */
+export async function up(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_cache_anomalies', (table) => {
+		table.string('prefix', 64).nullable();
+	});
+}
+
+export async function down(knex: Knex): Promise<void> {
+	await knex.schema.alterTable('directus_cache_anomalies', (table) => {
+		table.dropColumn('prefix');
+	});
+}

--- a/api/src/middleware/cache.test.ts
+++ b/api/src/middleware/cache.test.ts
@@ -319,7 +319,11 @@ describe('checkCacheMiddleware', () => {
 		expect(readCacheMissGap).toHaveBeenCalledWith('cache-key', expect.any(Number));
 
 		expect(queueCacheMiss).toHaveBeenCalledWith(
-			expect.objectContaining({ cacheKey: 'cache-hash', gapMs: 4000 }),
+			expect.objectContaining({
+				cacheKey: 'cache-hash',
+				gapMs: 4000,
+				prefix: '/items',
+			}),
 		);
 
 		expect(next).toHaveBeenCalled();

--- a/api/src/middleware/cache.ts
+++ b/api/src/middleware/cache.ts
@@ -15,6 +15,7 @@ import asyncHandler from '../utils/async-handler.js';
 import { getCacheControlHeader } from '../utils/get-cache-headers.js';
 import { getMilliseconds } from '../utils/get-milliseconds.js';
 import { getCacheKey } from '../utils/get-cache-key.js';
+import { cacheEventPrefix } from '../utils/cache-event-prefix.js';
 import { shouldSkipCache } from '../utils/should-skip-cache.js';
 
 const checkCacheMiddleware: RequestHandler = asyncHandler(async (req, res, next) => {
@@ -98,6 +99,7 @@ const checkCacheMiddleware: RequestHandler = asyncHandler(async (req, res, next)
 		if (cacheStatsActive() && createdAt > 0) {
 			void queueCacheHit({
 				cacheKey: hash,
+				prefix: cacheEventPrefix(req.originalUrl),
 				ageMs: Math.max(Date.now() - createdAt, 0),
 				ttlMs: expiresMeta?.ttlMs ?? null,
 				durationMs: Math.max(Date.now() - Number(res.locals['requestStart']), 0),
@@ -136,6 +138,7 @@ const checkCacheMiddleware: RequestHandler = asyncHandler(async (req, res, next)
 				.then((gapMs) => {
 					return queueCacheMiss({
 						cacheKey: hash,
+						prefix: cacheEventPrefix(req.originalUrl),
 						gapMs,
 						ttlMs: getMilliseconds(resolvedCacheTtl()) ?? null,
 					});

--- a/api/src/services/utils.ts
+++ b/api/src/services/utils.ts
@@ -221,10 +221,11 @@ export class UtilsService {
 	async getCacheTimeseries(
 		windowMs?: number,
 		buckets?: number,
+		prefixes?: string[],
 	): Promise<CacheTimeseries> {
 		this.assertCacheAdmin('inspect the cache timeseries');
 
-		return readCacheTimeseries(windowMs, buckets);
+		return readCacheTimeseries(windowMs, buckets, prefixes);
 	}
 
 	// The live Redis state for a single key — the cached response plus its

--- a/api/src/utils/cache-event-prefix.test.ts
+++ b/api/src/utils/cache-event-prefix.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'vitest';
+import { cacheEventPrefix } from './cache-event-prefix.js';
+
+test('takes the first path segment, dropping the query string', () => {
+	expect(cacheEventPrefix('/items/articles?limit=5')).toBe('/items');
+});
+
+test('groups the self-polling cache endpoints under /utils', () => {
+	expect(cacheEventPrefix('/utils/cache/timeseries?window=1h')).toBe('/utils');
+});
+
+test('keeps a bare single-segment path', () => {
+	expect(cacheEventPrefix('/collections')).toBe('/collections');
+});
+
+test('falls back to / when there is no segment', () => {
+	expect(cacheEventPrefix('/')).toBe('/');
+	expect(cacheEventPrefix('')).toBe('/');
+});

--- a/api/src/utils/cache-event-prefix.ts
+++ b/api/src/utils/cache-event-prefix.ts
@@ -1,0 +1,16 @@
+import url from 'url';
+
+/**
+ * The request's first path segment (`/items/articles?x=1` → `/items`), captured on
+ * every hit/miss so the cache page can group the timeseries by endpoint. A miss
+ * never writes a descriptor, so this is the only path handle it carries. Falls back
+ * to `/` when there's no segment.
+ */
+export function cacheEventPrefix(originalUrl: string): string {
+	const path = url.parse(originalUrl).pathname ?? '';
+	const [segment] = path.split('/').filter(Boolean);
+
+	return segment
+		? `/${segment}`
+		: '/';
+}

--- a/api/src/utils/report-cache-anomaly.test.ts
+++ b/api/src/utils/report-cache-anomaly.test.ts
@@ -70,6 +70,7 @@ describe('reportCacheAnomaly', () => {
 
 		expect(mocks.queueCacheAnomaly).toHaveBeenCalledWith({
 			cacheKey: 'h1',
+			prefix: '/items',
 			reason: 'value_too_large',
 			detail: '2048B',
 		});
@@ -92,6 +93,7 @@ describe('reportCacheAnomaly', () => {
 
 		expect(mocks.queueCacheAnomaly).toHaveBeenCalledWith({
 			cacheKey: 'h2',
+			prefix: '/graphql',
 			reason: 'missing_scope',
 			detail: null,
 		});

--- a/api/src/utils/report-cache-anomaly.ts
+++ b/api/src/utils/report-cache-anomaly.ts
@@ -5,6 +5,7 @@ import {
 	queueCacheAnomaly,
 	type CacheAnomalyReason,
 } from '../cache-events.js';
+import { cacheEventPrefix } from './cache-event-prefix.js';
 import { getCacheKey } from './get-cache-key.js';
 import { getGraphqlQueryAndVariables } from './get-graphql-query-and-variables.js';
 
@@ -48,5 +49,10 @@ export async function reportCacheAnomaly(
 		lastFilled: null,
 	});
 
-	queueCacheAnomaly({ cacheKey: hash, reason, detail: detail ?? null });
+	queueCacheAnomaly({
+		cacheKey: hash,
+		prefix: cacheEventPrefix(req.originalUrl),
+		reason,
+		detail: detail ?? null,
+	});
 }

--- a/app/src/modules/settings/routes/cache/cache.test.ts
+++ b/app/src/modules/settings/routes/cache/cache.test.ts
@@ -160,7 +160,7 @@ const global = {
 // anomalies + stats to empty so an entries-only test doesn't leak them elsewhere.
 function mockCacheGet(
 	entries: unknown,
-	extra: { anomalies?: unknown; stats?: unknown } = {},
+	extra: { anomalies?: unknown; stats?: unknown; timeseries?: unknown } = {},
 ) {
 	vi.mocked(api.get).mockImplementation(((url: string) => {
 		if (url === '/utils/cache/anomalies') {
@@ -172,7 +172,9 @@ function mockCacheGet(
 		}
 
 		if (url === '/utils/cache/timeseries') {
-			return Promise.resolve({ data: { data: { buckets: [], markers: [] } } });
+			return Promise.resolve({
+				data: { data: extra.timeseries ?? { buckets: [], markers: [] } },
+			});
 		}
 
 		return Promise.resolve({ data: { data: entries } });
@@ -914,5 +916,33 @@ describe('CachePage', () => {
 		await flushPromises();
 
 		expect(localStorage.getItem('cache-refresh-anon')).toBe('5');
+	});
+
+	it('populates the prefix filter and reloads on selection', async () => {
+		localStorage.clear();
+
+		mockCacheGet(ENTRIES, {
+			timeseries: { buckets: [], markers: [], prefixes: ['/items', '/utils'] },
+		});
+
+		const wrapper = mount(CachePage, { global });
+		await flushPromises();
+
+		const prefixSelect = wrapper.findComponent('.prefix-select');
+
+		expect(prefixSelect.props('items')).toEqual([
+			{ text: '/items', value: '/items' },
+			{ text: '/utils', value: '/utils' },
+		]);
+
+		vi.mocked(api.get).mockClear();
+		prefixSelect.vm.$emit('update:modelValue', ['/items']);
+		await flushPromises();
+
+		expect(localStorage.getItem('cache-prefixes-anon')).toBe('["/items"]');
+
+		expect(api.get).toHaveBeenCalledWith('/utils/cache/timeseries', {
+			params: { window: '24h', buckets: 60, prefixes: '/items' },
+		});
 	});
 });

--- a/app/src/modules/settings/routes/cache/cache.vue
+++ b/app/src/modules/settings/routes/cache/cache.vue
@@ -109,6 +109,10 @@ const refreshInterval = useLocalStorage<number | null>(
 	},
 );
 
+// Which endpoint prefixes to plot on the chart; empty = all. Persisted per-user
+// like the window, so the self-polling /utils noise can stay filtered out.
+const selectedPrefixes = useLocalStorage<string[]>(`cache-prefixes-${userId}`, []);
+
 // Bumped per load; a superseded window's late response can't clobber a newer one.
 let loadToken = 0;
 
@@ -536,12 +540,15 @@ interface TimeseriesData {
 	// The TTL in force server-side (override, else env default) — shown as the TTL
 	// input's placeholder so an empty field reveals what it inherits.
 	effectiveTtl: string | null;
+	// Every endpoint prefix seen in the window — the filter's option list.
+	prefixes: string[];
 }
 
 const timeseries = ref<TimeseriesData>({
 	buckets: [],
 	markers: [],
 	effectiveTtl: null,
+	prefixes: [],
 });
 
 const ttlPlaceholder = computed(() => {
@@ -579,11 +586,18 @@ const hasTimeseries = computed(() => {
 async function loadTimeseries() {
 	try {
 		const response = await api.get('/utils/cache/timeseries', {
-			params: { window: selectedWindow.value, buckets: 60 },
+			params: {
+				window: selectedWindow.value,
+				buckets: 60,
+				// Only send the filter when it's a real subset; empty = all (omit it).
+				...(selectedPrefixes.value.length > 0
+					? { prefixes: selectedPrefixes.value.join(',') }
+					: {}),
+			},
 		});
 
-		// Normalise so buckets/markers are always arrays — the chart's series() and
-		// hasTimeseries read them directly and must never see an undefined.
+		// Normalise so the arrays the chart's series()/hasTimeseries read are never
+		// undefined; keep the prefix option list for the filter.
 		const data = response.data.data;
 
 		timeseries.value = {
@@ -594,12 +608,30 @@ async function loadTimeseries() {
 				? data.markers
 				: [],
 			effectiveTtl: data?.effectiveTtl ?? null,
+			prefixes: Array.isArray(data?.prefixes)
+				? data.prefixes
+				: [],
 		};
 	}
 	catch {
-		timeseries.value = { buckets: [], markers: [], effectiveTtl: null };
+		timeseries.value = {
+			buckets: [],
+			markers: [],
+			effectiveTtl: null,
+			prefixes: [],
+		};
 	}
 }
+
+const prefixOptions = computed(() => {
+	return timeseries.value.prefixes.map((prefix) => {
+		return { text: prefix, value: prefix };
+	});
+});
+
+// Re-plot when the prefix filter changes; only the chart tracks it, so a full load
+// isn't needed (the listing keeps its own search/filter).
+watch(selectedPrefixes, () => void loadTimeseries());
 
 function themeVar(name: string, fallback: string): string {
 	const value = getComputedStyle(document.documentElement)
@@ -927,6 +959,16 @@ onUnmounted(() => {
 				:items="windowOptions"
 				inline
 				@update:model-value="load"
+			/>
+
+			<v-select
+				v-if="prefixOptions.length"
+				v-model="selectedPrefixes"
+				class="prefix-select"
+				:items="prefixOptions"
+				:placeholder="t('cache_prefixes', 'Endpoints')"
+				multiple
+				inline
 			/>
 
 			<search-input


### PR DESCRIPTION
## Why

While chasing "why do misses stay high with the TTL raised and no activity?", we found the cache page **watches itself**: its auto-refresh polls `/utils/cache*`, and under `CACHE_AUTO_PURGE_MODE=scoped` those admin GETs aren't cache-skipped, so each poll logs a miss that never becomes a hit — a self-inflicted floor on the chart. And a miss carries **no path** (only the opaque `cache_key`; a never-cached miss writes no descriptor), so the chart couldn't group or exclude that traffic.

So: capture the request's endpoint prefix on every event and let the page filter by it. Deselecting `/utils` drops the self-poll noise; the same control doubles as a per-endpoint breakdown.

## What

- `directus_cache_events` gains a nullable `prefix`; the cache middleware sets it from `req.originalUrl` (first path segment — `/items`, `/utils`, …).
- `readCacheTimeseries` returns the window's **distinct prefixes** (the filter's options, built unfiltered so a narrowed selection never hides the rest) and narrows the series to a selected subset (empty = all).
- The cache page gets a per-user multiselect beside the window picker, persisted in localStorage like the window.

## Stacked on #314

Base is `v11.10.1-feat/cache-refresh-intervals-window`, not `hhh-dev` — it touches the same `cache.vue` chart region as #314, so it stacks to avoid a conflict. Rebase onto hhh-dev once #314 lands.

## Retrocompat

`prefix` is nullable; pre-existing rows stay valid (they just don't show in the filter until new traffic accrues). The column is added by a standard `ALTER … ADD COLUMN` migration.

## Out of scope / open questions

- **Anomalies stay unfiltered** — `directus_cache_anomalies` has no `prefix` column. Symmetric filtering would need the same column + write-path there. Worth doing?
- **Prefix granularity** — first path segment only, so all `/utils/*` collapse to `/utils` (enough to drop the self-poll). Want `/utils/cache` distinguishable, i.e. two segments?
- The events table is a deliberately lean Timescale fact (`compress_segmentby = 'kind'`); this adds one low-cardinality dimension. Flagging the design shift.
- **Not live-demoed**: the dev instance hit an unrelated Directus `getSchema` boot loop (dangling relation, auth path) when restarted, so I verified via tests only (130 green) — API + UI unit coverage for the write path, filter, distinct prefixes, and the multiselect's render/persist/param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
