### PR TITLE
fix(cache): skip caching the /utils/cache monitoring endpoints

### DIFF
--- a/api/src/utils/should-skip-cache.test.ts
+++ b/api/src/utils/should-skip-cache.test.ts
@@ -95,6 +95,32 @@ test.each([
 	},
 );
 
+test.each([
+	'/utils/cache',
+	'/utils/cache/timeseries?window=1h',
+	'/utils/cache/anomalies',
+])('should skip cache for the self-monitoring endpoint %s', (originalUrl) => {
+	vi.mocked(useEnv).mockReturnValue({ PUBLIC_URL: '/', CACHE_SKIP_ALLOWED: false });
+
+	const req = {
+		get: vi.fn(() => undefined),
+		originalUrl,
+	} as unknown as Request;
+
+	expect(shouldSkipCache(req)).toBe(true);
+});
+
+test('should not skip cache for a normal /items request', () => {
+	vi.mocked(useEnv).mockReturnValue({ PUBLIC_URL: '/', CACHE_SKIP_ALLOWED: false });
+
+	const req = {
+		get: vi.fn(() => undefined),
+		originalUrl: '/items/articles',
+	} as unknown as Request;
+
+	expect(shouldSkipCache(req)).toBe(false);
+});
+
 test('should not skip cache for requests coming outside of data studio', () => {
 	vi.mocked(useEnv).mockReturnValue({
 		PUBLIC_URL: 'http://admin.example.com',

--- a/api/src/utils/should-skip-cache.ts
+++ b/api/src/utils/should-skip-cache.ts
@@ -13,6 +13,13 @@ import { getEndpoint } from '@directus/utils';
 export function shouldSkipCache(req: Request): boolean {
 	const env = useEnv();
 
+	// The cache-monitoring endpoints (/utils/cache*) are dynamic admin telemetry —
+	// never cacheable, and letting them through the cache path logs a self-inflicted
+	// miss on every auto-refresh poll (the page watching itself). Skip them outright.
+	if (url.parse(req.originalUrl ?? '').pathname?.startsWith('/utils/cache')) {
+		return true;
+	}
+
 	// Always skip cache for requests coming from the data studio based on Referer header
 	const referer = req.get('Referer');
 


### PR DESCRIPTION
## Why

The cache page's own auto-refresh polls `/utils/cache`, `/utils/cache/anomalies`, `/utils/cache/timeseries`. Under `CACHE_AUTO_PURGE_MODE=scoped` those data-studio GETs aren't cache-skipped, so each poll runs the cache path, finds nothing (the responses are dynamic and never stored) and logs a **miss**. With the page open on a short refresh interval that's a steady self-inflicted miss floor on its own chart — the page measuring itself, unrelated to real traffic. It's what surfaced as "misses stay high with the TTL raised and no activity".

## What

One guard in `shouldSkipCache`: skip the cache path for any `/utils/cache*` request. No miss is recorded, and since `get-cache-headers` reads the same predicate the responses also get `no-store` — correct, since these must never be cached.

## Notes

- Chosen over a chart-side filter: a `system`/`response` store filter can't help (hit/miss telemetry is response-cache-only — `systemCache`/`lockCache` emit no events), and the noise is a URL distinction, not a store one. Fixing it at the source is simpler and helps every viewer with no new column or UI. Supersedes the drafted #315.
- `/utils/cache/clear` is POST — already skipped by the method gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
