### PR TITLE
fix(cache): anchor the timeseries grid to a fixed bucket boundary

### DIFF
--- a/api/src/cache-events.ts
+++ b/api/src/cache-events.ts
@@ -1097,13 +1097,23 @@ export async function readCacheTimeseries(
 	const db = getDatabase();
 	const windowLen = clampCacheStatsWindow(windowMs);
 	const now = Date.now();
-	const sinceMs = now - windowLen;
-	const since = new Date(sinceMs);
 
 	const bucketCount = Math.min(
 		Math.max(Math.trunc(buckets), 1),
 		CACHE_TIMESERIES_MAX_BUCKETS,
 	);
+
+	const bucketSec = Math.max(1, Math.ceil(windowLen / bucketCount / 1000));
+	const bucketMs = bucketSec * 1000;
+
+	// Anchor the grid to a fixed bucketSec boundary so a fast (1s) refresh doesn't
+	// re-quantize every bucket — otherwise the whole curve crawls on each tick. Only
+	// the newest bucket fills as `now` advances; the grid steps by one whole bucket
+	// when `now` crosses a boundary. The last slot is the bucket CONTAINING now, so
+	// the most recent traffic is never dropped off the edge.
+	const anchorMs = Math.floor(now / bucketMs) * bucketMs;
+	const sinceMs = anchorMs - (bucketCount - 1) * bucketMs;
+	const since = new Date(sinceMs);
 
 	const markerRows = await db('directus_cache_config_events')
 		.where('time', '>', since)
@@ -1126,12 +1136,10 @@ export async function readCacheTimeseries(
 		? effective
 		: null;
 
-	// Bucket by whole seconds ELAPSED since `since` (an interval difference), so the
-	// index is 0-based (0 = oldest, bucketCount-1 = newest) and immune to the column's
-	// storage timezone. An absolute `floor(epoch/bucketSec)` grid instead pushed the
-	// `now` edge one slot past the array, silently dropping the most recent traffic.
-	const bucketSec = Math.max(1, Math.ceil(windowLen / bucketCount / 1000));
-
+	// Bucket by whole seconds ELAPSED since the anchored `since` (an interval
+	// difference): index is 0-based (0 = oldest, bucketCount-1 = the bucket holding
+	// now) and immune to the column's storage timezone. `since` itself is bucket-
+	// aligned above so the grid is stable across refreshes.
 	const dense: CacheTimeseriesBucket[] = Array.from(
 		{ length: bucketCount },
 		(_unused, index) => {

--- a/api/src/cache-events.ts
+++ b/api/src/cache-events.ts
@@ -1177,9 +1177,9 @@ export async function readCacheTimeseries(
 			db.raw('COUNT(*) AS count'),
 		);
 
-	// Defensive clamp: a row at/after the next boundary (e.g. clock skew) would land
-	// past the last slot; fold it into the last real bucket rather than drop it. `+=`
-	// in the count loop below because the fold can still collapse two DB buckets into one.
+	// Defensive clamp: a row at/after the next boundary (clock skew) would exceed the
+	// last slot; fold it into the last bucket rather than drop it. `+=` in the count
+	// loop because the fold can still collapse two DB buckets into one.
 	function slotOf(bucket: unknown): number {
 		return Math.min(Math.max(Number(bucket), 0), bucketCount - 1);
 	}

--- a/api/src/cache-events.ts
+++ b/api/src/cache-events.ts
@@ -1177,8 +1177,9 @@ export async function readCacheTimeseries(
 			db.raw('COUNT(*) AS count'),
 		);
 
-	// `now` lands one bucket past the last slot — fold it into the last real bucket.
-	// `+=` below because the fold can collapse two DB buckets into one slot.
+	// Defensive clamp: a row at/after the next boundary (e.g. clock skew) would land
+	// past the last slot; fold it into the last real bucket rather than drop it. `+=`
+	// in the count loop below because the fold can still collapse two DB buckets into one.
 	function slotOf(bucket: unknown): number {
 		return Math.min(Math.max(Number(bucket), 0), bucketCount - 1);
 	}

--- a/api/src/cache-timeseries.test.ts
+++ b/api/src/cache-timeseries.test.ts
@@ -105,13 +105,32 @@ describe('readCacheTimeseries', () => {
 			hits: 10, misses: 6, anomalies: 2, ttlMs: 60000,
 		});
 
-		// Dense timestamps are anchored at `since`, one bucketSec apart.
-		expect(result.buckets[0]!.t).toBe(NOW - windowMs);
-		expect(result.buckets[1]!.t).toBe(NOW - windowMs + bucketSec * 1000);
+		// The grid is bucket-anchored: newest slot = now's bucket, the rest step back
+		// by bucketSec (NOW is divisible by the 60s bucket, so it sits on a boundary).
+		expect(result.buckets[2]!.t).toBe(NOW);
+		expect(result.buckets[1]!.t).toBe(NOW - bucketSec * 1000);
+		expect(result.buckets[0]!.t).toBe(NOW - 2 * bucketSec * 1000);
 
 		expect(result.markers).toEqual([
 			{ time: NOW - 1000, kind: 'flush', detail: 'response' },
 		]);
+	});
+
+	it('anchors the grid so a sub-bucket refresh does not shift it', async () => {
+		const first = await readCacheTimeseries(180_000, 3); // bucketSec 60
+
+		// Advance now by less than one bucket — the grid must stay put (no crawl).
+		vi.setSystemTime(NOW + 40_000);
+		const within = await readCacheTimeseries(180_000, 3);
+
+		expect(within.buckets.map((b) => b.t)).toEqual(first.buckets.map((b) => b.t));
+
+		// Cross the boundary — the grid steps forward by exactly one bucket.
+		vi.setSystemTime(NOW + 60_000);
+		const crossed = await readCacheTimeseries(180_000, 3);
+
+		expect(crossed.buckets[2]!.t).toBe(NOW + 60_000);
+		expect(crossed.buckets[0]!.t).toBe(first.buckets[0]!.t + 60_000);
 	});
 
 	it('returns markers but empty curves when stats are not configured', async () => {


### PR DESCRIPTION
## Why

The cache timeseries anchored its buckets at `now - windowLen`, recomputed every read. With the new short auto-refresh (1s) on a narrow window, that re-quantized the whole grid on every tick — events hopped bucket boundaries and the curves visibly crawled, worst on small buckets (a 3m window = 3s buckets, so a 1s shift is a third of a bucket).

## What

Anchor `since` to a fixed `bucketSec` boundary (`floor(now / bucketMs) * bucketMs`). The grid now only steps by a whole bucket when `now` crosses one; between crossings it's frozen and only the newest bucket fills. The last slot is the bucket *containing* `now`, so the most recent traffic is never dropped off the edge — the exact failure the old code comment warned about for a naive absolute-epoch grid.

Confirmed live: two reads ~1s apart on a 3m window now return timestamps that differ by exactly one bucketSec (3s), not the raw elapsed ms.

## Test

`cache-timeseries.test.ts` gains an anchor regression: a sub-bucket `now` advance leaves the grid identical; crossing a boundary steps it by exactly one bucket.

## Tradeoff

The window's left edge snaps to a bucket boundary and the newest bucket is partial. Negligible at the default 60 buckets (≤1/60 of the window); only visible on tiny bucket counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
