### PR TITLE
refactor(cache): share the timeseries wire types via @directus/types

### DIFF
--- a/api/src/cache-events.ts
+++ b/api/src/cache-events.ts
@@ -10,6 +10,13 @@ import { useLogger } from './logger/index.js';
 import { redisConfigAvailable, useRedis } from './redis/index.js';
 import { getMilliseconds } from './utils/get-milliseconds.js';
 
+// The timeseries wire types live in @directus/types so the app chart shares them.
+export type {
+	CacheConfigEvent,
+	CacheTimeseries,
+	CacheTimeseriesBucket,
+} from '@directus/types';
+
 /**
  * Cache telemetry buffered in a Redis Stream and drained to three PG tables so a
  * hit/miss never touches the DB on the hot path:
@@ -111,35 +118,6 @@ export interface CacheEntryRecord {
 	createdAt: number;
 	expiresAt: number | null;
 	lastHitAt: number | null;
-}
-
-export interface CacheTimeseriesBucket {
-	t: number; // bucket-start epoch ms
-	hits: number;
-	misses: number;
-	anomalies: number;
-	ttlMs: number | null; // effective TTL in force during the bucket
-	// Response-latency percentiles (ms): hit = serve-from-cache, miss = compute/fill,
-	// both = the two pooled. null when the bucket had no sample of that kind.
-	hitP50: number | null;
-	hitP95: number | null;
-	missP50: number | null;
-	missP95: number | null;
-	bothP50: number | null;
-	bothP95: number | null;
-}
-
-export interface CacheConfigEvent {
-	time: number;
-	kind: 'ttl_change' | 'flush';
-	detail: string | null;
-}
-
-export interface CacheTimeseries {
-	buckets: CacheTimeseriesBucket[];
-	markers: CacheConfigEvent[];
-	// The TTL in force (override, else env default) — for the page's TTL input.
-	effectiveTtl: string | null;
 }
 
 export interface CacheStatsState {

--- a/app/src/modules/settings/routes/cache/cache.vue
+++ b/app/src/modules/settings/routes/cache/cache.vue
@@ -9,7 +9,13 @@ import ApexCharts, { type ApexOptions } from 'apexcharts';
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { abbreviateNumber } from '@directus/utils';
-import type { CacheFlushTarget, Filter, User } from '@directus/types';
+import type {
+	CacheFlushTarget,
+	CacheTimeseries,
+	CacheTimeseriesBucket,
+	Filter,
+	User,
+} from '@directus/types';
 import SettingsNavigation from '../../components/navigation.vue';
 import AutoRefresh from '@/views/private/components/refresh-sidebar-detail.vue';
 import SearchInput from '@/views/private/components/search-input.vue';
@@ -529,36 +535,7 @@ async function flush() {
 	}
 }
 
-interface TimeseriesBucket {
-	t: number;
-	hits: number;
-	misses: number;
-	anomalies: number;
-	ttlMs: number | null;
-	// Response-latency percentiles (ms): hit = serve, miss = compute, both = pooled.
-	hitP50: number | null;
-	hitP95: number | null;
-	missP50: number | null;
-	missP95: number | null;
-	bothP50: number | null;
-	bothP95: number | null;
-}
-
-interface ConfigMarker {
-	time: number;
-	kind: 'ttl_change' | 'flush';
-	detail: string | null;
-}
-
-interface TimeseriesData {
-	buckets: TimeseriesBucket[];
-	markers: ConfigMarker[];
-	// The TTL in force server-side (override, else env default) — shown as the TTL
-	// input's placeholder so an empty field reveals what it inherits.
-	effectiveTtl: string | null;
-}
-
-const timeseries = ref<TimeseriesData>({
+const timeseries = ref<CacheTimeseries>({
 	buckets: [],
 	markers: [],
 	effectiveTtl: null,
@@ -642,7 +619,7 @@ function themeVar(name: string, fallback: string): string {
 function chartConfig(): ApexOptions {
 	const buckets = timeseries.value.buckets;
 
-	function series(pick: (b: TimeseriesBucket) => number | null) {
+	function series(pick: (b: CacheTimeseriesBucket) => number | null) {
 		return buckets.map((b): [number, number | null] => [b.t, pick(b)]);
 	}
 
@@ -654,7 +631,7 @@ function chartConfig(): ApexOptions {
 		unit: 'count' | 'seconds';
 		curve: 'straight' | 'stepline';
 		color: string;
-		pick: (b: TimeseriesBucket) => number | null;
+		pick: (b: CacheTimeseriesBucket) => number | null;
 	}[] = [
 		{
 			name: t('hits', 'Hits'),
@@ -810,7 +787,7 @@ function renderChart() {
 function latencyChartConfig(): ApexOptions {
 	const buckets = timeseries.value.buckets;
 
-	function series(pick: (b: TimeseriesBucket) => number | null) {
+	function series(pick: (b: CacheTimeseriesBucket) => number | null) {
 		return buckets.map((b): [number, number | null] => [b.t, pick(b)]);
 	}
 
@@ -824,7 +801,7 @@ function latencyChartConfig(): ApexOptions {
 		name: string;
 		color: string;
 		dash: number;
-		pick: (b: TimeseriesBucket) => number | null;
+		pick: (b: CacheTimeseriesBucket) => number | null;
 	}[] = [
 		{
 			name: t('cache_lat_hit_p50', 'Hits p50'),

--- a/packages/types/src/cache.ts
+++ b/packages/types/src/cache.ts
@@ -5,3 +5,35 @@
  * `UtilsService.clearCache` type and the runtime stay a single source of truth.
  */
 export type CacheFlushTarget = 'response' | 'system' | 'locks';
+
+/** One bucket of the cache timeseries: outcome counts, the effective TTL, and
+ * response-latency percentiles (hit = serve, miss = compute/fill, both = pooled).
+ * Shared so the API producer and the app chart can't drift. */
+export interface CacheTimeseriesBucket {
+	t: number; // bucket-start epoch ms
+	hits: number;
+	misses: number;
+	anomalies: number;
+	ttlMs: number | null;
+	hitP50: number | null;
+	hitP95: number | null;
+	missP50: number | null;
+	missP95: number | null;
+	bothP50: number | null;
+	bothP95: number | null;
+}
+
+/** A plotted config change — a TTL edit or a flush — shown as a chart marker. */
+export interface CacheConfigEvent {
+	time: number;
+	kind: 'ttl_change' | 'flush';
+	detail: string | null;
+}
+
+/** The full cache timeseries payload: dense buckets, config markers, and the TTL in
+ * force (override, else env default) for the page's TTL input placeholder. */
+export interface CacheTimeseries {
+	buckets: CacheTimeseriesBucket[];
+	markers: CacheConfigEvent[];
+	effectiveTtl: string | null;
+}


### PR DESCRIPTION
## Why (review finding #3)

The deep review flagged type drift: `cache.vue` re-declares the API's timeseries shape as local `TimeseriesBucket`/`TimeseriesData` interfaces. #318 added the six latency percentile fields to *both* copies by hand — they agree today, but nothing enforces it. An API field change would silently drop in the app (structural TS is happy with a narrower local type over `any` JSON).

## What

Move `CacheTimeseriesBucket` / `CacheConfigEvent` / `CacheTimeseries` into `@directus/types` (beside `CacheFlushTarget`, already shared the same way), re-export them from `cache-events.ts` for internal API consumers (`services/utils.ts`), and import them in the app — deleting the local mirror. One owner, no drift.

## Verified

`@directus/types` builds; api (84) + app (64) cache tests pass; eslint + style-gate clean.

## Stacked on #318

Needs #318's latency fields on the shared type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
