### PR TITLE
fix(cache): make the cache-stats tables system collections (#323)

### DIFF
--- a/api/src/database/migrations/20260731A-unmanage-cache-stats-collections.ts
+++ b/api/src/database/migrations/20260731A-unmanage-cache-stats-collections.ts
@@ -1,0 +1,51 @@
+import type { Knex } from 'knex';
+
+const HIDDEN = [
+	'directus_cache_events',
+	'directus_cache_anomalies',
+	'directus_cache_config_events',
+];
+
+const VISIBLE = ['directus_cache_descriptors'];
+
+const ALL = [...HIDDEN, ...VISIBLE];
+
+/**
+ * Supersedes `20260730A`. The four cache-stats tables are now registered in
+ * `@directus/system-data`, so `isSystemCollection` returns true and they drop out
+ * of the schema snapshot/apply scope — the proper fix for the reconcile that dropped
+ * them while their migration rows survived (#323).
+ *
+ * The `directus_collections` rows `20260730A` inserted are now both redundant and
+ * harmful: `CollectionsService.readByQuery` appends the system-data rows without
+ * deduping by name, so a DB row of the same name yields a SECOND collection entry
+ * whose `meta.system` is falsy — it slips back past the snapshot's `excludeSystem`
+ * filter and re-enters the drop scope. Delete them so the system-data registration
+ * alone governs them (hidden/visible comes from `collections.yaml` now).
+ */
+export async function up(knex: Knex): Promise<void> {
+	await knex('directus_fields')
+		.whereIn('collection', ALL)
+		.delete();
+
+	await knex('directus_collections')
+		.whereIn('collection', ALL)
+		.delete();
+}
+
+export async function down(knex: Knex): Promise<void> {
+	const rows = ALL.map((collection) => {
+		return {
+			collection,
+			hidden: HIDDEN.includes(collection),
+			singleton: false,
+			accountability: null,
+			note: 'Internal cache statistics — written by the response-cache pipeline.',
+		};
+	});
+
+	await knex('directus_collections')
+		.insert(rows)
+		.onConflict('collection')
+		.merge(['hidden', 'accountability', 'note']);
+}

--- a/app/src/lang/translations/en-US.yaml
+++ b/app/src/lang/translations/en-US.yaml
@@ -1277,6 +1277,9 @@ directus_collection:
   directus_access: Policy attachments
   directus_activity: Accountability logs for all events
   directus_cache_descriptors: Per-key cache-entry descriptors (telemetry)
+  directus_cache_events: Cache hit/miss/latency events (telemetry)
+  directus_cache_anomalies: Uncacheable / not-cached anomalies (telemetry)
+  directus_cache_config_events: Cache TTL-change and flush events (telemetry)
   directus_collections: Additional collection configuration and metadata
   directus_comments: Comments for items
   directus_dashboards: Dashboards within the Insights module

--- a/packages/system-data/src/collections/collections.yaml
+++ b/packages/system-data/src/collections/collections.yaml
@@ -119,3 +119,21 @@ data:
     icon: memory
     note: $t:directus_collection.directus_cache_descriptors
     accountability: null
+
+  - collection: directus_cache_events
+    hidden: true
+    icon: memory
+    note: $t:directus_collection.directus_cache_events
+    accountability: null
+
+  - collection: directus_cache_anomalies
+    hidden: true
+    icon: memory
+    note: $t:directus_collection.directus_cache_anomalies
+    accountability: null
+
+  - collection: directus_cache_config_events
+    hidden: true
+    icon: memory
+    note: $t:directus_collection.directus_cache_config_events
+    accountability: null


### PR DESCRIPTION
Fixes #323.

## Why

The cache-stats tables (`directus_cache_events`, `_descriptors`, `_anomalies`,
`_config_events`) are `directus_`-prefixed but weren't all system collections, so
`isSystemCollection()` returned false and they fell into the schema-snapshot / schema-apply
scope. A consumer applying an older snapshot then **drops the tables while the
`directus_migrations` rows survive** — the DB ends "migration recorded, table missing",
and every cache-stats query fails with `relation "..." does not exist`. That actually bit a
planner PR-preview env.

My own `20260730A` (from the dashboard PR) made this worse: it registered the four in
`directus_collections` to surface them in Data Model — which is exactly what pulled them
into the managed scope. Its own doc comment flagged the gap.

## What

- Register the three telemetry tables in `@directus/system-data`
  (`collections.yaml`, `hidden: true`, `accountability: null`) — `directus_cache_descriptors`
  was already a system collection there. Now `isSystemCollection()` is true for all four, so
  they're excluded from snapshot/apply and behave like every other `directus_*` table.
- `20260731A-unmanage-cache-stats-collections` **deletes** the `directus_collections` rows
  `20260730A` inserted. This is not just cleanup: `CollectionsService.readByQuery` appends the
  system-data rows without deduping by name, so a leftover DB row of the same name yields a
  *second* collection entry whose `meta.system` is falsy — it slips past the snapshot's
  `excludeSystem` filter and re-enters the drop scope. The DB rows have to go for the fix to
  hold.
- Three `directus_collection.*` note strings in `en-US.yaml`.

## Retrocompat / effects (verified against 11.10.1 source + a local boot)

- **`/items/directus_cache_*` → 403.** The items controller throws `ForbiddenError` for any
  system collection. This is hardening, not a regression: real access is the custom
  `/utils/cache/*` controllers (raw knex), which bypass the items controller.
- **Activity / revisions: unchanged (still none).** Writes are raw knex (no `ItemsService`),
  and `accountability: null` gates out activity even on a hypothetical UI edit.
- **Data Model:** the four move under the System group; the three telemetry ones stay hidden,
  descriptors stays visible/browsable.
- **`directus_cache_events` has no primary key** (Timescale hypertable). It stays "ignored"
  at schema build with the same benign boot warning as before — registering it as a system
  collection doesn't change that (verified on a local boot: no crash, snapshot excludes all
  four, `isSystemCollection` true for all four).

## Out of scope

- The issue's Q3 (boot init `set -e` + a post-init table-existence assertion so record/table
  drift fails a deploy loudly) lives in the **planner deploy/init script**, a different repo —
  not fixable here. Worth a follow-up there.
- Q1's alternative (a `directus-extension-schema-sync` exclude list) isn't actionable in this
  repo — that extension is a third-party consumer, and core `schema-apply` had the same drop
  path anyway, which the system-data route fixes at the source.

## Question for the reviewer

`20260731A` leaves `20260730A` in history (already released), so a fresh DB runs
insert-then-delete on those four rows. I kept it honest over rewriting an applied migration —
prefer that, or should `20260730A` be neutralized to a no-op for fresh installs?
