### PR TITLE
fix(api): make the programmatic filter path agree with REST (three silent wrong-row bugs)

### DIFF
--- a/api/src/database/run-ast/lib/apply-query/filter/index.test.ts
+++ b/api/src/database/run-ast/lib/apply-query/filter/index.test.ts
@@ -454,7 +454,14 @@ test(`filtering a2o relation`, async () => {
 	const rawQuery = queryBuilder.toSQL();
 
 	expect(rawQuery.sql).toEqual(
-		`select * left join "image" as "alias123" on "article"."collection" = ? and "article"."header" = CAST("alias123"."id" AS CHAR(255)) left join "video" as "alias456" on "article"."collection" = ? and "article"."header" = CAST("alias456"."id" AS CHAR(255)) where "alias123"."id" = ? and "alias456"."id" = ?`,
+		// The two sibling keys arrive as one `_and` group (normalizeFilter no longer
+		// merges them flat, see #325), hence the parentheses.
+		'select * ' +
+			'left join "image" as "alias123" on "article"."collection" = ? ' +
+			'and "article"."header" = CAST("alias123"."id" AS CHAR(255)) ' +
+			'left join "video" as "alias456" on "article"."collection" = ? ' +
+			'and "article"."header" = CAST("alias456"."id" AS CHAR(255)) ' +
+			'where ("alias123"."id" = ? and "alias456"."id" = ?)',
 	);
 
 	expect(rawQuery.bindings).toEqual(['image', 'video', 1, 2]);

--- a/api/src/database/run-ast/lib/apply-query/normalize-filter.test.ts
+++ b/api/src/database/run-ast/lib/apply-query/normalize-filter.test.ts
@@ -187,14 +187,63 @@ describe('normalizeFilter', () => {
 		});
 	});
 
-	test('preserves flat structure when top-level keys are unique', () => {
+	test('wraps unique top-level keys in _and rather than merging them flat', () => {
 		const filter = {
 			field_a: { _eq: 1 },
 			field_b: { _eq: 2 },
 			rel: { sub: { _eq: 3 } },
 		};
 
-		expect(normalizeFilter(filter)).toEqual(filter);
+		expect(normalizeFilter(filter)).toEqual({
+			_and: [
+				{ field_a: { _eq: 1 } },
+				{ field_b: { _eq: 2 } },
+				{ rel: { sub: { _eq: 3 } } },
+			],
+		});
+	});
+
+	test('wraps a multi-key _or element so its siblings stay ANDed', () => {
+		// The element's keys are distinct top-level fields with operator-only children,
+		// so nothing above forces a split — but `addWhereClauses` recurses an `_or`
+		// element with `logical = 'or'`, and would OR these three against each other.
+		const filter = {
+			_or: [
+				{
+					course_part: { _eq: 1 },
+					day: { _eq: '2023-09-19' },
+					method_range: { _in: ['a', 'b'] },
+				},
+			],
+		};
+
+		expect(normalizeFilter(filter)).toEqual({
+			_or: [
+				{
+					_and: [
+						{ course_part: { _eq: 1 } },
+						{ day: { _eq: '2023-09-19' } },
+						{ method_range: { _in: ['a', 'b'] } },
+					],
+				},
+			],
+		});
+	});
+
+	test('wraps every multi-key _or element, and leaves single-key ones alone', () => {
+		const filter = {
+			_or: [
+				{ status: { _eq: 'published' } },
+				{ author: { _eq: 7 }, status: { _eq: 'draft' } },
+			],
+		};
+
+		expect(normalizeFilter(filter)).toEqual({
+			_or: [
+				{ status: { _eq: 'published' } },
+				{ _and: [{ author: { _eq: 7 } }, { status: { _eq: 'draft' } }] },
+			],
+		});
 	});
 
 	test('handles non-object filter values', () => {

--- a/api/src/database/run-ast/lib/apply-query/normalize-filter.test.ts
+++ b/api/src/database/run-ast/lib/apply-query/normalize-filter.test.ts
@@ -156,9 +156,15 @@ describe('normalizeFilter', () => {
 		});
 	});
 
-	test('keeps multiple operator keys on same field together', () => {
+	test('splits multiple operator keys on the same field', () => {
+		// They cannot share one part: `getOperation` reads `Object.keys(value)[0]` and
+		// returns that operator alone, so `{ _gte, _lte }` compiled to `field >= 1` with
+		// the `_lte` silently dropped. This test previously asserted the merged shape.
 		const filter = { field: { _gte: 1, _lte: 10 } };
-		expect(normalizeFilter(filter)).toEqual(filter);
+
+		expect(normalizeFilter(filter)).toEqual({
+			_and: [{ field: { _gte: 1 } }, { field: { _lte: 10 } }],
+		});
 	});
 
 	test('handles _some as relational key', () => {

--- a/api/src/database/run-ast/lib/apply-query/normalize-filter.ts
+++ b/api/src/database/run-ast/lib/apply-query/normalize-filter.ts
@@ -32,7 +32,26 @@ export function normalizeFilter(filter: Filter): Filter {
 		const val = value as Record<string, any>;
 		const childKeys = Object.keys(val);
 		const relKeys = childKeys.filter((k) => !k.startsWith('_') || k === '_none' || k === '_some');
-		const opKeys = childKeys.filter((k) => k.startsWith('_') && k !== '_none' && k !== '_some');
+		const logicalKeys = childKeys.filter((k) => k === '_and' || k === '_or');
+
+		const opKeys = childKeys.filter((k) => {
+			return k.startsWith('_') && !['_none', '_some', '_and', '_or'].includes(k);
+		});
+
+		// A logical operator under a relational key is lifted above it, so
+		// `{ rel: { _or: [a, b] } }` becomes `{ _or: [{ rel: a }, { rel: b }] }`. Left
+		// in place it is not merely mis-combined, it is DROPPED: `getFilterPath` stops
+		// at the `_or`, `getOperation` recurses in and returns null, and the clause
+		// is skipped — the filter compiles to a bare `select *`. `parseFilter`
+		// does this same lift (`shiftLogicalOperatorsUp`), which is why REST never
+		// sees it and only the programmatic path could.
+		for (const lk of logicalKeys) {
+			const lifted = (val[lk] as Filter[]).map((sub) => {
+				return normalizeFilter({ [key]: sub } as Filter);
+			});
+
+			parts.push({ [lk]: lifted } as Filter);
+		}
 
 		if (relKeys.length > 1 || (relKeys.length >= 1 && opKeys.length >= 1)) {
 			// Multiple relational children or mix of relational + operator keys: split each
@@ -41,18 +60,23 @@ export function normalizeFilter(filter: Filter): Filter {
 				liftAndPush(parts, key, normalized);
 			}
 
-			if (opKeys.length > 0) {
-				const ops: Record<string, any> = {};
-				for (const ok of opKeys) ops[ok] = val[ok];
-				parts.push({ [key]: ops } as Filter);
+			for (const ok of opKeys) {
+				parts.push({ [key]: { [ok]: val[ok] } } as Filter);
 			}
-		} else if (relKeys.length === 1) {
+		}
+		else if (relKeys.length === 1) {
 			// Single relational child, recurse to normalize deeper levels
-			const normalized = normalizeFilter(val as Filter);
-			liftAndPush(parts, key, normalized);
-		} else {
-			// Only operator keys (leaf node)
-			parts.push({ [key]: val } as Filter);
+			const relKey = relKeys[0]!;
+			liftAndPush(parts, key, normalizeFilter({ [relKey]: val[relKey] } as Filter));
+		}
+		else if (opKeys.length > 0) {
+			// One part per operator. Several on one field cannot share a part:
+			// `getOperation` reads `Object.keys(value)[0]` and returns that operator
+			// alone, so `{ id: { _gte: 1, _lte: 10 } }` compiled to `id >= 1` and the
+			// `_lte` was dropped. `parseFilter` splits them the same way.
+			for (const ok of opKeys) {
+				parts.push({ [key]: { [ok]: val[ok] } } as Filter);
+			}
 		}
 	}
 
@@ -68,10 +92,14 @@ export function normalizeFilter(filter: Filter): Filter {
 }
 
 /**
- * If the normalized result is a pure `_and` wrapper, lift each sub-filter
- * and wrap it with the parent key individually. This prevents `_and` from
- * appearing inside a relational value object where `getFilterPath` can't
- * handle it.
+ * Keep a logical wrapper from ending up inside a relational value, where
+ * `getFilterPath` stops at it and `getOperation` returns null — which makes
+ * `addWhereClauses` skip the clause entirely.
+ *
+ * `_and` distributes: each sub-filter becomes its own part under `key`, since the
+ * parts are themselves `_and`-combined. `_or` cannot — its alternatives have to stay
+ * one clause — so it is lifted whole with `key` pushed inside each alternative,
+ * exactly as `shiftLogicalOperatorsUp` does in `parseFilter`.
  */
 function liftAndPush(parts: Filter[], key: string, normalized: Filter): void {
 	const normKeys = Object.keys(normalized);
@@ -80,6 +108,11 @@ function liftAndPush(parts: Filter[], key: string, normalized: Filter): void {
 		for (const sub of (normalized as any)._and) {
 			parts.push({ [key]: sub } as Filter);
 		}
+	}
+	else if (normKeys.length === 1 && normKeys[0] === '_or') {
+		parts.push({
+			_or: ((normalized as any)._or as Filter[]).map((sub) => ({ [key]: sub })),
+		} as Filter);
 	} else {
 		parts.push({ [key]: normalized } as Filter);
 	}

--- a/api/src/database/run-ast/lib/apply-query/normalize-filter.ts
+++ b/api/src/database/run-ast/lib/apply-query/normalize-filter.ts
@@ -9,6 +9,10 @@ import { isObject } from '@directus/utils';
  *
  * This is necessary because `getFilterPath` only follows `Object.keys(value)[0]`,
  * silently dropping any sibling keys at the same nesting level.
+ *
+ * Any object left with several sibling conditions comes back as `{ _and: [...] }`
+ * — the same shape `parseFilter` produces for REST input — so the two paths agree
+ * on what siblings mean wherever the result lands, `_or` elements included.
  */
 export function normalizeFilter(filter: Filter): Filter {
 	const entries = Object.entries(filter);
@@ -55,13 +59,11 @@ export function normalizeFilter(filter: Filter): Filter {
 	if (parts.length === 0) return {} as Filter;
 	if (parts.length === 1) return parts[0]!;
 
-	// Merge into a flat object when all keys are unique (preserves original structure)
-	const allKeys = parts.flatMap((p) => Object.keys(p));
-
-	if (new Set(allKeys).size === allKeys.length) {
-		return Object.assign({}, ...parts) as Filter;
-	}
-
+	// Always `_and`, mirroring `parseFilter`. Merging unique keys back into one flat
+	// object reads as harmless — sibling keys are ANDed — but `addWhereClauses`
+	// recurses `_or` elements with `logical = 'or'`, so a flat element's siblings
+	// would be OR-combined. REST is safe because `parseFilter` wrapped it already;
+	// this is the programmatic `readByQuery` path (#325).
 	return { _and: parts } as Filter;
 }
 

--- a/api/src/database/run-ast/lib/apply-query/programmatic-filter-rest-parity.test.ts
+++ b/api/src/database/run-ast/lib/apply-query/programmatic-filter-rest-parity.test.ts
@@ -1,0 +1,188 @@
+/**
+ * `ItemsService.readByQuery` takes its filter raw: it never passes through
+ * `sanitizeQuery`/`parseFilter`, so `normalizeFilter` is the only thing standing
+ * between an extension's filter and the query builder. This file pins the property
+ * that matters — for any shape, the SQL the programmatic path emits is the SQL
+ * REST would have emitted for the same filter.
+ *
+ * Divergences found this way, each of which returned wrong rows with no error:
+ * - a logical operator under a relational key compiled to a bare `select *`
+ * - a multi-key `_or` element had siblings OR-combined instead of ANDed (#325)
+ * - a second operator on one field (`{ _gte, _lte }`) was dropped
+ */
+import { SchemaBuilder } from '@directus/schema-builder';
+import { parseFilter } from '@directus/utils';
+import knex from 'knex';
+import { expect, test, vi } from 'vitest';
+import { Client_SQLite3 } from './mock.js';
+
+const aliasFn = vi.fn(() => 'alias1');
+
+vi.doMock('nanoid/non-secure', () => {
+	return { customAlphabet: () => aliasFn };
+});
+
+const { applyFilter } = await import('./filter/index.js');
+
+const schema = new SchemaBuilder()
+	.collection('article', (c) => {
+		c.field('id').id();
+		c.field('status').string();
+		c.field('author').m2o('users');
+		c.field('links').o2m('links_list', 'article_id');
+	})
+	.collection('links_list', (c) => {
+		c.field('id').id();
+		c.field('article_id').m2o('article');
+		c.field('label').string();
+	})
+	.collection('users', (c) => {
+		c.field('id').id();
+		c.field('name').string();
+		c.field('email').string();
+		c.field('team').m2o('teams');
+	})
+	.collection('teams', (c) => {
+		c.field('id').id();
+		c.field('label').string();
+	})
+	.build();
+
+function sqlFor(filter: any) {
+	const db = vi.mocked(knex.default({ client: Client_SQLite3 }));
+	const queryBuilder = db.queryBuilder();
+	applyFilter(db, schema, queryBuilder, filter, 'article', {}, [], []);
+	const raw = queryBuilder.toSQL();
+	return `${raw.sql} -- ${JSON.stringify(raw.bindings)}`;
+}
+
+const SHAPES: [string, any][] = [
+	['logical under a relation', {
+		author: { _or: [{ name: { _eq: 'a' } }, { email: { _eq: 'b' } }] },
+	}],
+	['_and under a relation', {
+		author: { _and: [{ name: { _eq: 'a' } }, { email: { _eq: 'b' } }] },
+	}],
+	['logical two levels down', {
+		author: { team: { _or: [{ label: { _eq: 'x' } }] } },
+	}],
+	['multi-key element in a nested logical', {
+		author: { _or: [{ name: { _eq: 'a' }, email: { _eq: 'b' } }] },
+	}],
+	['logical beside a sibling field', {
+		author: { _or: [{ name: { _eq: 'a' } }], email: { _eq: 'b' } },
+	}],
+	['multi-key _or element', { _or: [{ status: { _eq: 'p' }, id: { _eq: 1 } }] }],
+	['plain siblings', { status: { _eq: 'p' }, id: { _eq: 1 } }],
+	['relation siblings', { author: { name: { _eq: 'a' }, email: { _eq: 'b' } } }],
+	['operator pair on one field', { id: { _gte: 1, _lte: 10 } }],
+	['_some', { links: { _some: { label: { _eq: 'a' } } } }],
+	['_some with a nested logical', {
+		links: { _some: { _or: [{ label: { _eq: 'a' } }] } },
+	}],
+	['_none', { links: { _none: { label: { _eq: 'a' } } } }],
+	['_or with an empty element', { _or: [{}, { status: { _eq: 'p' } }] }],
+	['nested _or inside _or', {
+		_or: [{ _or: [{ status: { _eq: 'p' }, id: { _eq: 1 } }] }],
+	}],
+];
+
+test.each(SHAPES)('programmatic SQL matches REST SQL — %s', (_name, raw) => {
+	const programmatic = sqlFor(structuredClone(raw));
+	const rest = sqlFor(parseFilter(structuredClone(raw), null));
+
+	expect(programmatic).toBe(rest);
+});
+
+// A seeded generator, so a failure names a reproducible case rather than a mood.
+function makeRandom(seed: number) {
+	let state = seed;
+
+	return () => {
+		state = (state * 1103515245 + 12345) % 2147483648;
+		return state / 2147483648;
+	};
+}
+
+const SCALARS = [
+	['status', 'p'],
+	['id', 1],
+] as const;
+
+const RELATION_SCALARS = [
+	['name', 'a'],
+	['email', 'b'],
+] as const;
+
+function randomFilter(random: () => number, depth: number): any {
+	const roll = random();
+
+	if (depth <= 0 || roll < 0.35) {
+		const [field, value] = SCALARS[Math.floor(random() * SCALARS.length)]!;
+		return { [field]: { _eq: value } };
+	}
+
+	if (roll < 0.5) {
+		const index = Math.floor(random() * RELATION_SCALARS.length);
+		const [field, value] = RELATION_SCALARS[index]!;
+		return { author: { [field]: { _eq: value } } };
+	}
+
+	if (roll < 0.6) {
+		return { id: { _gte: 1, _lte: 10 } };
+	}
+
+	if (roll < 0.7) {
+		return { author: { team: randomFilter(random, depth - 1) } };
+	}
+
+	if (roll < 0.8) {
+		return { links: { _some: randomFilter(random, depth - 1) } };
+	}
+
+	const operator = random() < 0.5
+		? '_and'
+		: '_or';
+
+	const width = 1 + Math.floor(random() * 2);
+
+	// Under a relational key half the time — the shape REST can never produce,
+	// and the one that used to vanish.
+	const branch = {
+		[operator]: Array.from({ length: width }, () => randomFilter(random, depth - 1)),
+	};
+
+	return random() < 0.5
+		? branch
+		: { author: branch };
+}
+
+test('programmatic SQL matches REST SQL over generated filters', () => {
+	const random = makeRandom(20260805);
+	const mismatches: string[] = [];
+
+	for (let i = 0; i < 400; i++) {
+		const raw = randomFilter(random, 3);
+
+		let programmatic: string;
+		let rest: string;
+
+		try {
+			programmatic = sqlFor(structuredClone(raw));
+			rest = sqlFor(parseFilter(structuredClone(raw), null));
+		}
+		catch {
+			// A shape the query builder rejects outright (e.g. `_some` under a
+			// non-alias) is not what this test is about.
+			continue;
+		}
+
+		if (programmatic !== rest) {
+			mismatches.push(
+				`${JSON.stringify(raw)}\n  prog: ${programmatic}\n  rest: ${rest}`,
+			);
+		}
+	}
+
+	expect(mismatches).toEqual([]);
+});


### PR DESCRIPTION
I went after #325 because the failure mode is the nasty kind: no error, no warning, just
the wrong rows. Then you asked me to dig, so I built a differential harness — compile the
same filter through the programmatic path and through `parseFilter`, compare the emitted
SQL — and it turned up two more, both worse than the one I started with.

## The three divergences

All programmatic-path only. `ItemsService.readByQuery` takes its filter raw; it never
passes through `sanitizeQuery`/`parseFilter`, so `normalizeFilter` is the only thing
between an extension's filter and the query builder.

**1. A logical operator under a relational key was DROPPED entirely.**

```
{ author: { _or: [{ name: { _eq: 'a' } }, { email: { _eq: 'b' } }] } }
  →  select *
```

No join, no predicate, every row returned. `getFilterPath` stops at the `_or`,
`getOperation` recurses into it and returns `null`, `addWhereClauses` does
`if (!operation) continue`. An ownership or tenancy filter written that way leaks the
whole table, silently. This is the one I'd lose sleep over.

**2. A second operator on the same field was DROPPED.**

```
{ id: { _gte: 1, _lte: 10 } }  →  where id >= 1
```

`getOperation` reads `Object.keys(value)[0]` and returns that operator alone. A test
asserted the merged shape, so the behaviour was pinned rather than caught — I re-pointed
it rather than deleting it.

**3. A multi-key `_or` element had its siblings OR-combined** — the original #325.

## Why REST was always safe

`parseFilter` already does both transforms: `shiftLogicalOperatorsUp` lifts a logical out
of a relational value, and multi-key objects get `_and`-wrapped. That is also what makes
this fix low-risk — it is not a new invention, it is `normalizeFilter` being taught what
`parseFilter` has been doing in production all along. Where the two disagreed, `parseFilter`
was right.

## How sure I am

`programmatic-filter-rest-parity.test.ts` compiles **14 hand-picked shapes plus 400
generated ones** through both paths and asserts the SQL matches byte for byte, bindings
included. Shapes covered: logicals under relations and two levels down, logicals beside
sibling fields, multi-key elements inside logicals, `_some`/`_none` (including a logical
inside `_some`), the permissions `_or: [{}]` full-access short-circuit, nested `_or` in
`_or`, and operator pairs.

Falsification, because a test that passes either way proves nothing:

| version | parity tests failing |
|---|---|
| pristine base | **10 of 15** |
| after the #325 fix alone | **7 of 15** |
| this branch | 0 |

Coverage of `normalize-filter.ts` is 100% on statements, branches, functions and lines —
though I'd note that is the weaker claim of the two. It was already 100% before I found
any of this; what the coverage number cannot see is a shape that takes a covered line down
the wrong path. The parity harness is what actually pins the behaviour.

## Retrocompat

- Top-level multi-key filters now emit `WHERE (a = 1 AND b = 2)` — same predicate, extra
  parentheses. That is why the a2o join test's expected SQL moves here.
- Operator pairs now emit `(id >= 1 and id <= 10)` where they emitted `id >= 1`. Anything
  relying on the old output was relying on a dropped condition.

If something downstream string-matches generated SQL it would notice both. I don't think
anything does, but I'd rather say it than have you find it.

## Questions for you

- **The planner's `filterTreeToAnd`** (`apps/domain/src/utils/back/directus/directus-lib-to-split.ts`)
  becomes unnecessary once this ships — I ran its four spec cases through `normalizeFilter`
  and case 1 is handled identically, while its `_and` case avoids the redundant level its
  own TODO flags. **But do not port its `_in` behaviour**: splitting `_in: [2,4]` into
  `_in:[2] AND _in:[4]` is unsatisfiable, so that filter matches zero rows. `_nin` splits
  harmlessly, which is presumably why it went unnoticed. Worth checking the two aggregate
  hooks for an `_in` that reaches it.
- Should `getOperation`/`addWhereClauses` be hardened too? Right now they depend on
  `normalizeFilter` having tidied the shape first; a filter reaching them un-normalized
  still silently drops conditions. I left that alone here — it is a wider change and this
  PR is already load-bearing — but it is the real root cause.

Fixes #325