### PR TITLE
test(blackbox): move the postgres service to pg18

### DIFF
--- a/tests/blackbox/docker-compose.yml
+++ b/tests/blackbox/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     # timescaledb-ha bundles timescaledb (+ toolkit) AND postgis, so the
     # directus_cache_events hypertable path is exercised while the geometry
     # suite keeps postgis. init.sql creates both extensions on first boot.
-    image: timescale/timescaledb-ha:pg17
+    image: timescale/timescaledb-ha:pg18
     environment:
       POSTGRES_PASSWORD: secret
       POSTGRES_DB: directus


### PR DESCRIPTION
## Scope

The blackbox postgres service was still pinned to `timescale/timescaledb-ha:pg17`,
one major behind. The image now publishes a `pg18` line, so I would rather have the
suite tell us about PostgreSQL 18 today than discover the breakage later, when a
bump is entangled with whatever else is in flight.

What's changed:

- `tests/blackbox/docker-compose.yml`: the `postgres` service image tag moves from
  `pg17` to `pg18`. Nothing else in the file changes.

I booted the new tag locally before pushing, and the three things the pin exists
for are all there:

- PostgreSQL 18.4 (`Ubuntu 18.4-1.pgdg22.04+1`)
- `timescaledb` 2.29.1 + `timescaledb_toolkit` 1.24.0 — the `directus_cache_events`
  hypertable path
- `postgis` 3.6.4 — the geometry suite

`postgres-init/init.sql` still creates both extensions on first boot, and the
existing healthcheck already gates `compose up --wait` on real readiness.

## Potential Risks / Drawbacks

- This only moves the **test** container. Nothing here claims the fork supports
  PostgreSQL 18 in production — that would need the same treatment on
  `docker-compose.yml` at the root and on the `postgres:16-alpine` services in
  `acceptance.yml` / `preview-admin.yml`, which I deliberately left alone.
- `pg18` is a moving tag, same as `pg17` was. If we want reproducibility we should
  pin `pg18.4-ts2.29.1` or a digest — see the question below.
- `pgbouncer` fronts this service and is digest-pinned to 1.25.2. It talks the v3
  protocol and I expect no interaction with the server major, but the pool-exhaustion
  tests are the place that would show it.

## Tested Scenarios

Ran the full vendor matrix on this branch (`sqlite3` + `postgres` + `maria`, 8 shards
each) rather than the postgres-only smoke set, so the other two vendors also confirm
the change is inert for them —
[run 31131255022](https://github.com/jclaveau/directus/actions/runs/31131255022).

- `common`: green
- `postgres` — **8/8 green on pg18**, the result this PR is about
- `sqlite3`: 8/8 green
- `maria`: 6/8, shards 4 and 8 red

The two maria failures are maria-only and cannot be reached by a postgres image tag:

- shard 4 — `tests/db/app/cache.test.ts > Recommends a TTL from the re-request age
  p95 (Postgres only) > maria`:
  `ER_NO_DEFAULT_FOR_FIELD (1364): Field 'redis_key' doesn't have a default value` on
  an insert into `directus_cache_descriptors`. The title says "(Postgres only)" but
  the test is not actually skipped for maria.
- shard 8 — `tests/db/routes/items/cache-takeover-scope.test.ts (#292) > maria`:
  `ER_TOO_LONG_IDENT (1059): Identifier name
  'test_items_article_author_test_items_article_id_test_items_author_id_unique' is too
  long` — maria's 64-character identifier cap on a generated unique-constraint name.

Rather than assert that, I re-ran the maria vendor on `ci-dialect-maria` — still
`pg17`, cut from a `v11.10.1-hhh-dev` tip —
[run 31132719828](https://github.com/jclaveau/directus/actions/runs/31132719828).
It comes back 6/8 with the same two shards red and byte-identical errors on the same
two tests, so both predate this PR. Fixing them is out of scope here; they want their
own PR.

## Review Notes / Questions

- Do you want the tag pinned harder (`pg18.4-ts2.29.1`, or a digest like we did for
  pgbouncer)? A floating `pg18` means a green CI today can go red tomorrow with no
  commit of ours in between. I kept the existing floating style to stay minimal, but
  I lean toward pinning.
- Should the root `docker-compose.yml` (`postgis/postgis:13-3.4-alpine`) and the
  `postgres:16-alpine` service in `acceptance.yml` / `preview-admin.yml` follow in a
  separate PR, or do you prefer them all in one move?
- The `postgres10` service is untouched — it is there precisely to keep the oldest
  supported floor covered, and widening the span is arguably the point.