### PR TITLE
fix(cache): broadcast the TTL override from any settings write, not just SettingsService

### DIFF
--- a/.agents/auto-memory/MEMORY.md
+++ b/.agents/auto-memory/MEMORY.md
@@ -21,6 +21,8 @@
   `git commit --amend` + `git push --force-with-lease` over layered fix-up commits
 - [Don't ask before pnpm install / build in this repo](feedback_no_ask_for_build_install.md) — project override of the
   global ask-before-install rule; routine install/build steps run silently, dep-modifying commands still ask
+- [Never run blackbox locally — run it in CI](feedback_directus_bb_tests_in_ci.md) — local is SLOWER (full dist deploy +
+  a server per env variant, no sharding) and re-seeds jean's docker stack; push, label `Run Blackbox`, loop on the run
 - [Fork integration branches](project_directus_fork_integration_branches.md) — ⚠️2026-07-27 pr-controle RETIRED (tag archive/pr-controle), `v11.10.1-hhh-dev` IS now default; control-plane curated-ported (#303/#305), compose+publish parked; main = clean upstream base; hhh-main = derived from the copy stack; supersedes old
   main-overlay model; blackbox/e2e label-gated; blackbox-pr.yml is name:Check; CI gates = build+eslint+stylelint (no
   tsc)

--- a/.agents/auto-memory/feedback_directus_bb_tests_in_ci.md
+++ b/.agents/auto-memory/feedback_directus_bb_tests_in_ci.md
@@ -1,0 +1,27 @@
+---
+name: feedback_directus_bb_tests_in_ci
+description: Never run the blackbox suite locally on this repo — it is slower than CI; push and run it in GitHub Actions, looping on the run until it is green.
+metadata:
+  type: feedback
+---
+
+**Do not run `pnpm test:blackbox` locally.** Run the blackbox suite in CI and loop on the
+run until green. Told twice — the second time after I had already been asked to stop.
+
+**Why:** locally it is *slower* than CI, not faster. Every local run pays a full
+`rimraf dist` + `pnpm --filter directus deploy --prod dist` before vitest even starts,
+then boots a Directus server per env variant per vendor on one machine. CI shards the
+same work 8 ways across parallel runners, and the runners are doing it anyway. The local
+run also mutates jean's own `blackbox-*` docker stack (it bootstraps and re-seeds the
+shared postgres), so it has a side effect on his environment that CI does not.
+
+**How to apply:**
+- Write the test, prove the red/green claim at the **unit** level locally if the fix has a
+  unit seam (that part is cheap and expected — see [[feedback_local_vitest_env_constrained]]).
+- For the blackbox layer: commit, push, open the PR, add the `Run Blackbox` label, and read
+  results from the run — mechanics in [[project_directus_blackbox_run_and_logs]].
+- "Ensure red then make it green" over blackbox = two CI runs on the branch (one with the
+  fix reverted, one with it applied), not two local runs. Use `ScheduleWakeup` / a monitor
+  to loop on the run rather than polling — see [[feedback_wakeup_for_long_ci]].
+- A local `pnpm build` + targeted `vitest` on `api/src/**.test.ts` is still fine; the rule
+  is about the blackbox suite specifically.

--- a/api/src/cache-config.test.ts
+++ b/api/src/cache-config.test.ts
@@ -17,9 +17,16 @@ vi.mock('./database/index.js', () => ({ default: vi.fn() }));
 const mockBus = { publish: vi.fn(), subscribe: vi.fn() };
 vi.mock('./bus/index.js', () => ({ useBus: () => mockBus }));
 
+const mockEmitter = { onAction: vi.fn() };
+vi.mock('./emitter.js', () => ({ default: mockEmitter }));
+
 // The last handler `subscribe` was registered with — invoked to simulate a peer's
 // `cacheConfigChanged` delivery.
 let busHandler: (payload: { ttl: string | null }) => void;
+
+// The last handler `onAction` was registered with — invoked to simulate a settings
+// write landing, whichever service performed it.
+let settingsUpdateHandler: (meta: Record<string, any>) => void;
 
 let settingsRow: { cache_ttl: string | null } | undefined;
 
@@ -40,6 +47,10 @@ beforeEach(() => {
 
 	mockBus.subscribe.mockImplementation((_channel: string, handler: any) => {
 		busHandler = handler;
+	});
+
+	mockEmitter.onAction.mockImplementation((_event: string, handler: any) => {
+		settingsUpdateHandler = handler;
 	});
 });
 
@@ -121,5 +132,48 @@ describe('initCacheConfig', () => {
 		// A cleared override on the bus falls back to env.
 		busHandler({ ttl: null });
 		expect(resolvedCacheTtl()).toBe('10m');
+	});
+
+	it('announces any settings write that carries cache_ttl', async () => {
+		await initCacheConfig();
+
+		expect(mockEmitter.onAction).toHaveBeenCalledWith(
+			'settings.update',
+			expect.any(Function),
+		);
+
+		// The write never went through SettingsService — this is the shape a config-sync
+		// import produces — yet the node must both apply and announce it.
+		settingsUpdateHandler({ payload: { cache_ttl: '90s' } });
+
+		expect(resolvedCacheTtl()).toBe('90s');
+
+		expect(mockBus.publish).toHaveBeenCalledWith('cacheConfigChanged', {
+			ttl: '90s',
+		});
+	});
+
+	it('announces a cleared cache_ttl so peers fall back to env', async () => {
+		settingsRow = { cache_ttl: '5m' };
+		await initCacheConfig();
+
+		settingsUpdateHandler({ payload: { cache_ttl: null } });
+
+		expect(resolvedCacheTtl()).toBe('10m');
+
+		expect(mockBus.publish).toHaveBeenCalledWith('cacheConfigChanged', {
+			ttl: null,
+		});
+	});
+
+	it('stays quiet on a settings write that leaves cache_ttl alone', async () => {
+		settingsRow = { cache_ttl: '5m' };
+		await initCacheConfig();
+		mockBus.publish.mockClear();
+
+		settingsUpdateHandler({ payload: { project_name: 'Acme' } });
+
+		expect(resolvedCacheTtl()).toBe('5m');
+		expect(mockBus.publish).not.toHaveBeenCalled();
 	});
 });

--- a/api/src/cache-config.ts
+++ b/api/src/cache-config.ts
@@ -81,4 +81,18 @@ export async function initCacheConfig(): Promise<void> {
 	useBus().subscribe<CacheConfigChange>(CONFIG_CHANGED_CHANNEL, ({ ttl }) => {
 		cacheTtlOverride = normaliseTtl(ttl);
 	});
+
+	// Announcing from the action rather than from `SettingsService` is what makes the
+	// broadcast unconditional: every write to the singleton emits it, whatever wrote
+	// it — the cache page's PATCH, a config-sync import, a seed script. Announcing
+	// from the service instead left a bypassing writer's new value durable but
+	// unannounced, so each node kept serving its stale TTL until it happened to
+	// restart. Imported lazily for the same reason as the database above.
+	const { default: emitter } = await import('./emitter.js');
+
+	emitter.onAction('settings.update', ({ payload }) => {
+		if (payload && 'cache_ttl' in payload) {
+			publishCacheConfigChanged(payload['cache_ttl']);
+		}
+	});
 }

--- a/api/src/services/settings.test.ts
+++ b/api/src/services/settings.test.ts
@@ -1,12 +1,9 @@
 import knex from 'knex';
 import { MockClient } from 'knex-mock-client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { publishCacheConfigChanged } from '../cache-config.js';
 import { recordCacheConfigEvent } from '../cache-events.js';
 import { ItemsService } from './items.js';
 import { SettingsService } from './settings.js';
-
-vi.mock('../cache-config.js', () => ({ publishCacheConfigChanged: vi.fn() }));
 
 vi.mock('../cache-events.js', () => {
 	return { recordCacheConfigEvent: vi.fn(() => Promise.resolve()) };
@@ -14,6 +11,9 @@ vi.mock('../cache-events.js', () => {
 
 const db = knex({ client: MockClient });
 
+// Broadcasting the new value is not this service's job — it rides the
+// `settings.update` action so it covers writers that never reach here (see
+// cache-config.test.ts). What remains here is the validation gate and the marker.
 describe('SettingsService.upsertSingleton', () => {
 	beforeEach(() => {
 		vi.restoreAllMocks();
@@ -29,17 +29,15 @@ describe('SettingsService.upsertSingleton', () => {
 		});
 	}
 
-	it('broadcasts + records the new cache_ttl on change', async () => {
+	it('records the new cache_ttl on change', async () => {
 		await service().upsertSingleton({ cache_ttl: '30s' });
 
-		expect(publishCacheConfigChanged).toHaveBeenCalledWith('30s');
 		expect(recordCacheConfigEvent).toHaveBeenCalledWith('ttl_change', '30s');
 	});
 
-	it('broadcasts a cleared cache_ttl (null) so peers fall back to env', async () => {
+	it('records a cleared cache_ttl so the timeseries shows the reset', async () => {
 		await service().upsertSingleton({ cache_ttl: null });
 
-		expect(publishCacheConfigChanged).toHaveBeenCalledWith(null);
 		expect(recordCacheConfigEvent).toHaveBeenCalledWith('ttl_change', null);
 	});
 
@@ -49,9 +47,8 @@ describe('SettingsService.upsertSingleton', () => {
 			await expect(service().upsertSingleton({ cache_ttl: bad }))
 				.rejects.toThrow(/Invalid cache_ttl/);
 
-			// Gate runs before the write + broadcast, so nothing is persisted.
+			// Gate runs before the write, so nothing is persisted and nothing is recorded.
 			expect(ItemsService.prototype.upsertSingleton).not.toHaveBeenCalled();
-			expect(publishCacheConfigChanged).not.toHaveBeenCalled();
 			expect(recordCacheConfigEvent).not.toHaveBeenCalled();
 		},
 	);
@@ -59,7 +56,6 @@ describe('SettingsService.upsertSingleton', () => {
 	it('stays silent when the payload does not touch cache_ttl', async () => {
 		await service().upsertSingleton({ project_name: 'Acme' });
 
-		expect(publishCacheConfigChanged).not.toHaveBeenCalled();
 		expect(recordCacheConfigEvent).not.toHaveBeenCalled();
 	});
 });

--- a/api/src/services/settings.ts
+++ b/api/src/services/settings.ts
@@ -5,7 +5,6 @@ import type {
 	PrimaryKey,
 } from '@directus/types';
 import { InvalidPayloadError } from '@directus/errors';
-import { publishCacheConfigChanged } from '../cache-config.js';
 import { recordCacheConfigEvent } from '../cache-events.js';
 import { isPositiveDuration } from '../utils/get-milliseconds.js';
 import { ItemsService } from './items.js';
@@ -15,9 +14,11 @@ export class SettingsService extends ItemsService {
 		super('directus_settings', options);
 	}
 
-	// The cache page edits `cache_ttl` through the settings singleton
-	// (PATCH /settings). Broadcast the new value so every node's live override flips
-	// at once, instead of waiting for a redeploy to re-seed it from the DB at boot.
+	// The cache page edits `cache_ttl` through the settings singleton (PATCH
+	// /settings). The broadcast that flips every node's live override rides the
+	// `settings.update` action instead (see `initCacheConfig`), so it also covers
+	// writers that never reach this service; what stays here is the validation the
+	// write must not skip, and the timeseries marker.
 	override async upsertSingleton(
 		data: Partial<Item>,
 		opts?: MutationOptions,
@@ -44,11 +45,11 @@ export class SettingsService extends ItemsService {
 		const result = await super.upsertSingleton(data, opts);
 
 		if ('cache_ttl' in data) {
-			const ttl = data['cache_ttl'] as string | null;
-			publishCacheConfigChanged(ttl);
-
 			// Best-effort marker for the cache-page timeseries; don't fail the save on it.
-			void recordCacheConfigEvent('ttl_change', ttl).catch(() => {});
+			void recordCacheConfigEvent(
+				'ttl_change',
+				data['cache_ttl'] as string | null,
+			).catch(() => {});
 		}
 
 		return result;

--- a/tests/blackbox/extensions/settings-import-write/index.mjs
+++ b/tests/blackbox/extensions/settings-import-write/index.mjs
@@ -1,0 +1,33 @@
+// Stands in for a config-sync tool importing the settings singleton
+// (cache-config-broadcast.test.ts). Such a tool writes through a plain
+// `ItemsService('directus_settings')`, never through `SettingsService`, so every
+// guarantee bolted onto that subclass is silently skipped — which is how a
+// `cache_ttl` reset reached the DB in production while the running nodes kept
+// serving the previous value.
+//
+// Over HTTP there is no other way to reach that path: `PATCH /settings` always
+// routes through `SettingsService`. Hence this endpoint.
+//   POST /   { "cache_ttl": "<duration>" | null }
+
+export default function registerEndpoint(router, { services, database, getSchema }) {
+	router.post('/', async (req, res) => {
+		// A bare route has no asyncHandler wrapper, so a throw here is an unhandled
+		// rejection and takes the whole test shard down with the server.
+		try {
+			const schema = await getSchema();
+
+			const settingsService = new services.ItemsService('directus_settings', {
+				schema,
+				knex: database,
+			});
+
+			const cacheTtl = req.body.cache_ttl ?? null;
+			await settingsService.upsertSingleton({ cache_ttl: cacheTtl });
+
+			res.json({ cache_ttl: cacheTtl });
+		}
+		catch (err) {
+			res.status(500).json({ error: String(err) });
+		}
+	});
+}

--- a/tests/blackbox/extensions/settings-import-write/package.json
+++ b/tests/blackbox/extensions/settings-import-write/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "settings-import-write",
+	"version": "0.0.0",
+	"private": true,
+	"directus:extension": {
+		"type": "endpoint",
+		"path": "index.mjs",
+		"source": "index.mjs",
+		"host": "^10.10.0"
+	}
+}

--- a/tests/blackbox/tests/db/app/cache-config-broadcast.test.ts
+++ b/tests/blackbox/tests/db/app/cache-config-broadcast.test.ts
@@ -1,0 +1,177 @@
+import config, { getUrl, paths, type Env } from '@common/config';
+import vendors, { type Vendor } from '@common/get-dbs-to-test';
+import { USER } from '@common/variables';
+import { awaitDirectusConnection } from '@utils/await-connection';
+import { ChildProcess, spawn } from 'child_process';
+import getPort from 'get-port';
+import { cloneDeep } from 'lodash-es';
+import request from 'supertest';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+// The live cache-TTL override is durable in `directus_settings.cache_ttl` and
+// mirrored in every node's memory off the `cacheConfigChanged` bus. Two nodes over
+// one Redis and one database are the smallest rig that can tell a real broadcast
+// from a node merely reading its own write, so the assertions below are made on the
+// node that did NOT write.
+//
+// `writer` and `peer` differ only by cache namespace: same DB, same Redis, so they
+// share the settings row and the bus while keeping their cache entries apart.
+describe('Cache config broadcast', () => {
+	const directusInstances = {} as { [vendor: string]: ChildProcess[] };
+	const envs = {} as Record<Vendor, { writer: Env; peer: Env }>;
+
+	beforeAll(async () => {
+		const promises = [];
+
+		for (const vendor of vendors) {
+			// Redis (localhost:6108) is shared across vendors, so the cache namespace
+			// must carry the vendor — same reasoning as cache.test.ts. The bus namespace
+			// is a fixed `directus:bus` and cannot be scoped, so a run covering several
+			// vendors at once has them publishing into each other's channel; CI runs one
+			// vendor per job, which is what keeps that from mattering.
+			const nsPrefix = `directus-cache-config-${vendor}`;
+
+			const writer = cloneDeep(config.envs);
+			writer[vendor]['CACHE_ENABLED'] = 'true';
+			writer[vendor]['CACHE_STORE'] = 'redis';
+			writer[vendor]['REDIS_HOST'] = 'localhost';
+			writer[vendor]['REDIS_PORT'] = '6108';
+			writer[vendor]['CACHE_NAMESPACE'] = `${nsPrefix}_writer`;
+			writer[vendor]['CACHE_TTL'] = '11m';
+
+			const peer = cloneDeep(writer);
+			peer[vendor]['CACHE_NAMESPACE'] = `${nsPrefix}_peer`;
+
+			const writerPort = await getPort();
+			const peerPort = await getPort();
+			writer[vendor].PORT = String(writerPort);
+			peer[vendor].PORT = String(peerPort);
+
+			directusInstances[vendor] = [
+				spawn('node', [paths.cli, 'start'], { cwd: paths.cwd, env: writer[vendor] }),
+				spawn('node', [paths.cli, 'start'], { cwd: paths.cwd, env: peer[vendor] }),
+			];
+
+			envs[vendor] = { writer, peer };
+
+			promises.push(
+				awaitDirectusConnection(writerPort),
+				awaitDirectusConnection(peerPort),
+			);
+		}
+
+		await Promise.all(promises);
+	}, 180_000);
+
+	afterAll(() => {
+		for (const vendor of vendors) {
+			for (const instance of directusInstances[vendor]!) {
+				instance.kill();
+			}
+		}
+	});
+
+	afterEach(async () => {
+		// The override lives in one settings row shared by both nodes and outlives the
+		// test, so clear it back to "inherit env" between cases.
+		for (const vendor of vendors) {
+			await request(getUrl(vendor, envs[vendor]!.writer))
+				.patch('/settings')
+				.send({ cache_ttl: null })
+				.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+		}
+	});
+
+	// The TTL in force on a node, as that node reports it. Read from the node under
+	// assertion, never from the writer. Polled because the bus is asynchronous: a
+	// single immediate read would be a race, and a fixed sleep would either flake or
+	// pad every case.
+	async function awaitEffectiveTtl(
+		vendor: Vendor,
+		env: Env,
+		expected: string | null,
+	): Promise<string | null> {
+		let effectiveTtl: string | null = null;
+
+		for (let attempt = 0; attempt < 50; attempt++) {
+			const response = await request(getUrl(vendor, env))
+				.get('/utils/cache/timeseries')
+				.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+			effectiveTtl = response.body.data.effectiveTtl;
+
+			if (effectiveTtl === expected) {
+				return effectiveTtl;
+			}
+
+			await new Promise((resolve) => setTimeout(resolve, 100));
+		}
+
+		return effectiveTtl;
+	}
+
+	describe.each(vendors)('%s', (vendor) => {
+		it('starts both nodes on env CACHE_TTL with no override set', async () => {
+			// Non-vacuity: without this the later assertions could pass against a value
+			// that was already in force before the write.
+			const { writer, peer } = envs[vendor]!;
+
+			expect(await awaitEffectiveTtl(vendor, writer, '11m')).toBe('11m');
+			expect(await awaitEffectiveTtl(vendor, peer, '11m')).toBe('11m');
+		});
+
+		it('flips the peer when the cache page writes the TTL', async () => {
+			// The control: PATCH /settings routes through SettingsService, the path that
+			// already announced. If this fails the rig is broken, not the feature.
+			const { writer, peer } = envs[vendor]!;
+
+			await request(getUrl(vendor, writer))
+				.patch('/settings')
+				.send({ cache_ttl: '3h' })
+				.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`)
+				.expect(200);
+
+			expect(await awaitEffectiveTtl(vendor, peer, '3h')).toBe('3h');
+		});
+
+		it('flips both nodes when an import writes past SettingsService', async () => {
+			// A config-sync import writes the singleton through a plain ItemsService, so
+			// nothing SettingsService does applies. Both nodes must still converge — the
+			// writer included, since it never learned of its own write either.
+			const { writer, peer } = envs[vendor]!;
+
+			await request(getUrl(vendor, writer))
+				.post('/settings-import-write')
+				.send({ cache_ttl: '6h' })
+				.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`)
+				.expect(200);
+
+			expect(await awaitEffectiveTtl(vendor, peer, '6h')).toBe('6h');
+			expect(await awaitEffectiveTtl(vendor, writer, '6h')).toBe('6h');
+		});
+
+		it('returns both nodes to env CACHE_TTL when an import clears it', async () => {
+			// The production shape exactly: an import re-asserting `cache_ttl: null`
+			// over a value an operator had set. Clearing has to announce as loudly as
+			// setting, or the fleet splits between the override and the env fallback.
+			const { writer, peer } = envs[vendor]!;
+
+			await request(getUrl(vendor, writer))
+				.patch('/settings')
+				.send({ cache_ttl: '24h' })
+				.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`)
+				.expect(200);
+
+			expect(await awaitEffectiveTtl(vendor, peer, '24h')).toBe('24h');
+
+			await request(getUrl(vendor, writer))
+				.post('/settings-import-write')
+				.send({ cache_ttl: null })
+				.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`)
+				.expect(200);
+
+			expect(await awaitEffectiveTtl(vendor, peer, '11m')).toBe('11m');
+			expect(await awaitEffectiveTtl(vendor, writer, '11m')).toBe('11m');
+		});
+	});
+});


### PR DESCRIPTION
## Scope

A settings write that never reaches `SettingsService` persists a new `cache_ttl` but
announces nothing, so every running node keeps serving the value it last heard about
until it happens to restart. `SettingsService.upsertSingleton` was the only place that
called `publishCacheConfigChanged`, which makes any other writer silent by construction.

This bit us in production. An operator set the TTL to 24h through the cache page; a
config-sync tool re-asserted `cache_ttl: null` 51 minutes later through a plain
`ItemsService('directus_settings')`. The DB said "no override" from that moment, but
entries kept being filled with a 24h lifetime for another **75 minutes** — one process
still held the old value in memory, while restarted workers used the env fallback. The
cache page showed 1h and 24h alternating minute by minute for hours.

What's changed:

- `api/src/cache-config.ts` — `initCacheConfig` now subscribes to the `settings.update`
  action and announces any write carrying `cache_ttl`. That action fires for every
  `ItemsService`-level write to the singleton, so the broadcast no longer depends on
  which service the caller picked.
- `api/src/services/settings.ts` — the `publishCacheConfigChanged` call moves out. The
  validation gate and the timeseries marker stay: those are genuinely this service's
  job, the broadcast never was.
- `tests/blackbox/extensions/settings-import-write` — a probe endpoint that writes the
  singleton through a plain `ItemsService`. Over HTTP there is no other way to reach
  that path, since `PATCH /settings` always routes through `SettingsService`.
- `tests/blackbox/tests/db/app/cache-config-broadcast.test.ts` — two Redis-backed
  instances over one database and one bus, differing only by cache namespace. Every
  assertion is made on the node that did **not** write, so a node reading back its own
  write cannot pass the test.
- `api/src/cache-config.test.ts` / `api/src/services/settings.test.ts` — the unit
  coverage follows the responsibility rather than being deleted: the broadcast
  assertions move to the action seam, the marker and validation assertions stay put.
- `.agents/auto-memory/` — records that this repo's blackbox suite runs in CI, never
  locally.

Kept the publish awaited rather than fire-and-forget: `ItemsService` routes mutation
actions through `emitActionEvents`, which awaits unless a caller passes
`awaitActionHooks: false`, so the node handling the write is up to date before it
answers.

## Potential Risks / Drawbacks

- Any `settings.update` now costs one extra `in` check, and a bus publish when
  `cache_ttl` is present. Settings writes are rare enough that this is noise.
- A caller passing `awaitActionHooks: false` gets the broadcast asynchronously. It still
  happens; it is just no longer ordered before the response on that path.
- The `directus:bus` namespace is a fixed constant, not derived from `CACHE_NAMESPACE`.
  Instances sharing a Redis therefore share the channel — which is what makes the test
  possible, and also means a local multi-vendor blackbox run has vendors publishing into
  each other's channel. CI runs one vendor per job, so it does not bite there; noted in
  the test's header comment.

## Tested Scenarios

Two blackbox runs on this branch, deliberately — the tests landed first, on their own,
so the red is on the record rather than asserted:

- **Red** — commit `42187aaf4f`, tests only, no fix:
  [run 31163842039](https://github.com/jclaveau/directus/actions/runs/31163842039).
  `postgres (shard 6)` fails, `Unit Tests (api)` fails, every other shard and job passes.

  ```
  FAIL  cache-config-broadcast > postgres > flips both nodes when an import writes past SettingsService
          expected '11m' to be '6h'
  FAIL  cache-config-broadcast > postgres > returns both nodes to env CACHE_TTL when an import clears it
          expected '24h' to be '11m'
  Tests  2 failed | 3001 passed | 2 skipped (3005)
  ```

  The peer sat on `11m` — env `CACHE_TTL` — never told about the `6h` write, then sat on
  the stale `24h` after the import cleared it. The production split-brain, reproduced.

- **Green** — commit `d0a62d3ac2`, fix applied:
  [run 31164852461](https://github.com/jclaveau/directus/actions/runs/31164852461).

  ```
  ✓ |db| tests/db/app/cache-config-broadcast.test.ts  (4 tests) 10560ms
    Test Files  12 passed (12)
  ```

Note that only the two bypass cases went red. The baseline and the `PATCH /settings`
control passed in both runs, so the rig was sound and the failure isolated the bypassing
path rather than the harness. And the green run shows the file running 4 tests, not
skipping — a silently skipped file would have looked green too.

Four blackbox cases:

1. **Baseline / non-vacuity** — both nodes report env `CACHE_TTL` before anything is
   written, so a later assertion cannot pass against a value that was already in force.
2. **Control** — `PATCH /settings` on the writer flips the peer. This path already
   worked; if it ever fails, the rig is broken rather than the feature.
3. **The bug** — a write through the probe endpoint must flip **both** nodes, the writer
   included, since under the old code it never learned of its own write either.
4. **The production shape** — an import clearing a previously-set override must return
   both nodes to the env fallback. Clearing has to announce as loudly as setting, or the
   fleet splits between the stale override and env.

Unit, locally: red without the fix (`3 failed | 7 passed`), green with it
(`17 passed` across both files). `pnpm lint:style:changes` against
`origin/v11.10.1-hhh-dev` is clean, as is `eslint` on the touched files.

## Review Notes / Questions

- **A raw knex write still won't broadcast**, and I left it that way. The action seam
  covers every writer that goes through a service, which is what schema-sync-style tools
  do; covering raw SQL too would mean polling or a DB trigger, and neither seemed worth
  it for a value only the app writes. Push back if you'd rather have belt and braces —
  it changes what the probe extension should do.
- **I read the new value off the action payload rather than re-reading the row.**
  Re-reading is more authoritative, but the action can fire inside the transaction, and
  a fresh `getDatabase()` read would then see the pre-write value and silently publish
  the wrong thing. The payload is what was written; that seemed the safer of the two.
- **The marker has the same problem and I parked it** as
  https://github.com/jclaveau/directus/issues/342 rather than widen this diff.
  `recordCacheConfigEvent('ttl_change', …)` is still in `SettingsService`, so an import
  resets the TTL and leaves no annotation on the cache page's timeseries — which is
  exactly why the production reset stayed invisible until I read `directus_revisions`.
  It could ride the same hook. The open question there is whether the marker should
  record *every* writer or stay a deliberate record of operator intent, which is a
  different judgement from the broadcast's.

## Out of scope

- **The consumer-side half.** The tool that reset the value should not have been
  exporting `cache_ttl` in the first place; that is fixed separately in the consuming
  project by excluding the field from its config export. This PR is the half that makes
  the fleet converge regardless of who writes.
- **The cache page's TTL series.** It plots `MAX(ttl_ms)` per bucket, and a hit's
  `ttl_ms` is the TTL stamped on the entry when it was filled, not the TTL in force —
  so long-lived entries keep pushing the maximum up long after the config changed. That
  is a display question (`effectiveTtl` is already returned and is the honest source),
  not a config bug, and it wants its own PR.