### PR TITLE
fix(cache): plot the TTL in force, and mark every writer that moves it

### DIFF
--- a/api/src/cache-config.test.ts
+++ b/api/src/cache-config.test.ts
@@ -20,6 +20,12 @@ vi.mock('./bus/index.js', () => ({ useBus: () => mockBus }));
 const mockEmitter = { onAction: vi.fn() };
 vi.mock('./emitter.js', () => ({ default: mockEmitter }));
 
+const mockRecordCacheConfigEvent = vi.fn(() => Promise.resolve());
+
+vi.mock('./cache-events.js', () => {
+	return { recordCacheConfigEvent: mockRecordCacheConfigEvent };
+});
+
 // The last handler `subscribe` was registered with — invoked to simulate a peer's
 // `cacheConfigChanged` delivery.
 let busHandler: (payload: { ttl: string | null }) => void;
@@ -151,6 +157,10 @@ describe('initCacheConfig', () => {
 		expect(mockBus.publish).toHaveBeenCalledWith('cacheConfigChanged', {
 			ttl: '90s',
 		});
+
+		// And the marker, so the step the chart draws carries its own explanation.
+		expect(mockRecordCacheConfigEvent)
+			.toHaveBeenCalledWith('ttl_change', '90s');
 	});
 
 	it('announces a cleared cache_ttl so peers fall back to env', async () => {
@@ -164,16 +174,41 @@ describe('initCacheConfig', () => {
 		expect(mockBus.publish).toHaveBeenCalledWith('cacheConfigChanged', {
 			ttl: null,
 		});
+
+		// A reset is the case that went unexplained in production — it needs a marker
+		// as much as a set does.
+		expect(mockRecordCacheConfigEvent)
+			.toHaveBeenCalledWith('ttl_change', null);
 	});
 
 	it('stays quiet on a settings write that leaves cache_ttl alone', async () => {
 		settingsRow = { cache_ttl: '5m' };
 		await initCacheConfig();
 		mockBus.publish.mockClear();
+		mockRecordCacheConfigEvent.mockClear();
 
 		settingsUpdateHandler({ payload: { project_name: 'Acme' } });
 
 		expect(resolvedCacheTtl()).toBe('5m');
 		expect(mockBus.publish).not.toHaveBeenCalled();
+
+		// A project rename is not a TTL change and must not draw a marker on the chart.
+		expect(mockRecordCacheConfigEvent).not.toHaveBeenCalled();
+	});
+
+	it('survives a failing marker write, being only an annotation', async () => {
+		mockRecordCacheConfigEvent.mockRejectedValueOnce(new Error('table missing'));
+		await initCacheConfig();
+
+		expect(() => settingsUpdateHandler({ payload: { cache_ttl: '45s' } }))
+			.not.toThrow();
+
+		// The value still applied and still went out — losing the annotation must not
+		// cost the change itself.
+		expect(resolvedCacheTtl()).toBe('45s');
+
+		expect(mockBus.publish).toHaveBeenCalledWith('cacheConfigChanged', {
+			ttl: '45s',
+		});
 	});
 });

--- a/api/src/cache-config.ts
+++ b/api/src/cache-config.ts
@@ -89,10 +89,20 @@ export async function initCacheConfig(): Promise<void> {
 	// unannounced, so each node kept serving its stale TTL until it happened to
 	// restart. Imported lazily for the same reason as the database above.
 	const { default: emitter } = await import('./emitter.js');
+	const { recordCacheConfigEvent } = await import('./cache-events.js');
 
 	emitter.onAction('settings.update', ({ payload }) => {
-		if (payload && 'cache_ttl' in payload) {
-			publishCacheConfigChanged(payload['cache_ttl']);
+		if (!payload || 'cache_ttl' in payload === false) {
+			return;
 		}
+
+		publishCacheConfigChanged(payload['cache_ttl']);
+
+		// The marker is what explains a step in the TTL series, so it has to cover the
+		// same writers as the broadcast: a reset that leaves no marker is a change with
+		// no visible cause, which is how a production one stayed invisible until
+		// `directus_revisions` was read by hand (#342). Best-effort — a chart
+		// annotation must never fail a settings save.
+		void recordCacheConfigEvent('ttl_change', payload['cache_ttl']).catch(() => {});
 	});
 }

--- a/api/src/cache-events.test.ts
+++ b/api/src/cache-events.test.ts
@@ -13,6 +13,7 @@ import {
 	evictCacheEntriesForPath,
 	evictCacheEntry,
 	drainCacheEvents,
+	effectiveTtlByBucket,
 	flushCacheEventBuffer,
 	getCacheStatsState,
 	listCacheAnomalies,
@@ -1834,5 +1835,77 @@ describe('buffer cap under a stalled flush', () => {
 		// Drain the held flush so nothing dangles past this test.
 		releaseFlush();
 		await flushGate;
+	});
+});
+
+// The TTL series is a replay of the config's history, not a measurement, so all of
+// its correctness lives here. Buckets are 10 units apart throughout.
+describe('effectiveTtlByBucket', () => {
+	const buckets = [0, 10, 20, 30, 40];
+
+	it('holds the value the window opened on when nothing changed inside it', () => {
+		expect(effectiveTtlByBucket(buckets, [], 3_600_000))
+			.toEqual([3_600_000, 3_600_000, 3_600_000, 3_600_000, 3_600_000]);
+	});
+
+	it('applies a change from the bucket containing it onward', () => {
+		const changes = [{ time: 25, ttlMs: 86_400_000 }];
+
+		expect(effectiveTtlByBucket(buckets, changes, 3_600_000))
+			.toEqual([3_600_000, 3_600_000, 86_400_000, 86_400_000, 86_400_000]);
+	});
+
+	it('leaves the lead unknown rather than back-filling a later value', () => {
+		// The reset that motivated this: with no change recorded before the window, the
+		// buckets before the first one are genuinely unknown. Reporting 24h there would
+		// claim it was in force over a span it had not been set in.
+		const changes = [{ time: 25, ttlMs: 86_400_000 }];
+
+		expect(effectiveTtlByBucket(buckets, changes, null))
+			.toEqual([null, null, 86_400_000, 86_400_000, 86_400_000]);
+	});
+
+	it('follows a cleared override back down to the env fallback', () => {
+		// A clear resolves to the env value before it gets here, so the series steps
+		// down at the reset instead of holding the override it replaced.
+		const changes = [
+			{ time: 5, ttlMs: 86_400_000 },
+			{ time: 25, ttlMs: 3_600_000 },
+		];
+
+		expect(effectiveTtlByBucket(buckets, changes, null))
+			.toEqual([86_400_000, 86_400_000, 3_600_000, 3_600_000, 3_600_000]);
+	});
+
+	it('keeps only the last of several changes inside one bucket', () => {
+		const changes = [
+			{ time: 21, ttlMs: 60_000 },
+			{ time: 22, ttlMs: 120_000 },
+			{ time: 23, ttlMs: 300_000 },
+		];
+
+		expect(effectiveTtlByBucket(buckets, changes, null))
+			.toEqual([null, null, 300_000, 300_000, 300_000]);
+	});
+
+	it('orders changes by time rather than trusting the argument order', () => {
+		const changes = [
+			{ time: 35, ttlMs: 300_000 },
+			{ time: 15, ttlMs: 60_000 },
+		];
+
+		expect(effectiveTtlByBucket(buckets, changes, null))
+			.toEqual([null, 60_000, 60_000, 300_000, 300_000]);
+	});
+
+	it('carries a change landing in the final bucket to the window end', () => {
+		const changes = [{ time: 44, ttlMs: 300_000 }];
+
+		expect(effectiveTtlByBucket(buckets, changes, 60_000))
+			.toEqual([60_000, 60_000, 60_000, 60_000, 300_000]);
+	});
+
+	it('returns nothing for an empty grid', () => {
+		expect(effectiveTtlByBucket([], [{ time: 5, ttlMs: 60_000 }], null)).toEqual([]);
 	});
 });

--- a/api/src/cache-events.test.ts
+++ b/api/src/cache-events.test.ts
@@ -1908,4 +1908,12 @@ describe('effectiveTtlByBucket', () => {
 	it('returns nothing for an empty grid', () => {
 		expect(effectiveTtlByBucket([], [{ time: 5, ttlMs: 60_000 }], null)).toEqual([]);
 	});
+
+	it('stays unknown throughout when neither a seed nor a change exists', () => {
+		// The caller is responsible for not landing here in the ordinary no-marker
+		// case — see the seed in `readCacheTimeseries`, which passes the value in
+		// force instead. Given nothing at all, the honest answer is nothing.
+		expect(effectiveTtlByBucket(buckets, [], null))
+			.toEqual([null, null, null, null, null]);
+	});
 });

--- a/api/src/cache-events.ts
+++ b/api/src/cache-events.ts
@@ -1243,6 +1243,11 @@ export async function recordCacheConfigEvent(
  * A `ttl_change` marker's value in ms. `null` detail is a CLEARED override, which
  * hands the TTL back to env `CACHE_TTL` — so it resolves to the env value, not to
  * "unknown".
+ *
+ * That env value is read NOW, not as of the marker: a clear recorded while
+ * `CACHE_TTL` was `5m`, replayed after a deploy moved it to `1h`, draws `1h` over a
+ * period that ran at `5m`. Closing that would mean recording the resolved value in
+ * `detail` at write time; until then a clear is only as accurate as env is stable.
  */
 function markerTtlMs(detail: string | null): number | null {
 	const env = useEnv();
@@ -1387,9 +1392,22 @@ export async function readCacheTimeseries(
 			return { time: marker.time, ttlMs: markerTtlMs(marker.detail) };
 		});
 
-	const seedTtlMs = priorChange
-		? markerTtlMs((priorChange['detail'] as string | null) ?? null)
-		: null;
+	// No change inside the window means the value in force now held across all of it,
+	// whatever the marker history — which is the ordinary case for a deployment that
+	// never edited the TTL and so has no markers at all. Falling back to `null` there
+	// would leave the series empty and the page looking broken. The lead is genuinely
+	// unknown only when the window contains changes but nothing precedes them.
+	function windowOpenedOn(): number | null {
+		if (priorChange) {
+			return markerTtlMs((priorChange['detail'] as string | null) ?? null);
+		}
+
+		return ttlChanges.length === 0
+			? getMilliseconds(effective) ?? null
+			: null;
+	}
+
+	const seedTtlMs = windowOpenedOn();
 
 	effectiveTtlByBucket(dense.map((bucket) => bucket.t), ttlChanges, seedTtlMs)
 		.forEach((ttlMs, index) => {

--- a/api/src/cache-events.ts
+++ b/api/src/cache-events.ts
@@ -1240,6 +1240,51 @@ export async function recordCacheConfigEvent(
 }
 
 /**
+ * A `ttl_change` marker's value in ms. `null` detail is a CLEARED override, which
+ * hands the TTL back to env `CACHE_TTL` — so it resolves to the env value, not to
+ * "unknown".
+ */
+function markerTtlMs(detail: string | null): number | null {
+	const env = useEnv();
+
+	return getMilliseconds(detail ?? env['CACHE_TTL']) ?? null;
+}
+
+/**
+ * The TTL in force over each bucket, replaying the `ttl_change` markers across the
+ * grid. `seedTtlMs` is what the window opened on — the last change before it, or
+ * `null` when none is recorded, in which case the leading buckets stay `null` rather
+ * than inheriting a value from a change that had not happened yet.
+ *
+ * A change applies from the bucket that CONTAINS it onward: a bucket is a span, and
+ * the value that ends it is the one a reader is asking about when the marker sits on
+ * it. Exported for its own tests — the reconstruction is the whole point of the
+ * series and is worth pinning without a database.
+ */
+export function effectiveTtlByBucket(
+	bucketTimes: number[],
+	changes: { time: number; ttlMs: number | null }[],
+	seedTtlMs: number | null,
+): (number | null)[] {
+	const ordered = [...changes].sort((a, b) => a.time - b.time);
+	let pending = 0;
+	let inForce = seedTtlMs;
+
+	return bucketTimes.map((_bucketTime, index) => {
+		// Every change landing before this bucket ends has applied by the time the
+		// bucket closes. The last bucket has no successor, so it runs to the window end.
+		const bucketEnd = bucketTimes[index + 1] ?? Infinity;
+
+		while (pending < ordered.length && ordered[pending]!.time < bucketEnd) {
+			inForce = ordered[pending]!.ttlMs;
+			pending++;
+		}
+
+		return inForce;
+	});
+}
+
+/**
  * Bucketed hits / misses / anomalies + the effective TTL curve over `windowMs`, plus
  * the discrete config-event markers in the same window. The curves come from the
  * stats tables (only populated when stats are configured) and the bucketing is
@@ -1306,6 +1351,7 @@ export async function readCacheTimeseries(
 				fills: 0,
 				anomalies: 0,
 				ttlMs: null,
+				effectiveTtlMs: null,
 				hitP50: null,
 				hitP95: null,
 				hitP99: null,
@@ -1324,6 +1370,31 @@ export async function readCacheTimeseries(
 			};
 		},
 	);
+
+	// The window's own markers only say what changed INSIDE it; the value it opened on
+	// comes from the last change before it. Without that lookup every window would
+	// start unknown and the chart would back-fill its lead with a later value — the
+	// exact conflation this series exists to stop (#343).
+	const priorChange = await db('directus_cache_config_events')
+		.where('kind', 'ttl_change')
+		.andWhere('time', '<=', since)
+		.orderBy('time', 'desc')
+		.first();
+
+	const ttlChanges = markers
+		.filter((marker) => marker.kind === 'ttl_change')
+		.map((marker) => {
+			return { time: marker.time, ttlMs: markerTtlMs(marker.detail) };
+		});
+
+	const seedTtlMs = priorChange
+		? markerTtlMs((priorChange['detail'] as string | null) ?? null)
+		: null;
+
+	effectiveTtlByBucket(dense.map((bucket) => bucket.t), ttlChanges, seedTtlMs)
+		.forEach((ttlMs, index) => {
+			dense[index]!.effectiveTtlMs = ttlMs;
+		});
 
 	if (!cacheStatsConfigured() || db.client.config.client !== 'pg') {
 		return { buckets: dense, markers, effectiveTtl };

--- a/api/src/cache-timeseries.test.ts
+++ b/api/src/cache-timeseries.test.ts
@@ -222,7 +222,7 @@ describe('readCacheTimeseries', () => {
 		env['CACHE_STATS_ENABLED'] = true;
 	});
 
-	it('replays the TTL in force from the markers, seeded by the prior change', async () => {
+	it('replays the TTL in force, seeded by the prior change', async () => {
 		env['CACHE_TTL'] = '10m';
 		const bucketSec = 60;
 

--- a/api/src/cache-timeseries.test.ts
+++ b/api/src/cache-timeseries.test.ts
@@ -32,6 +32,7 @@ function makeBuilder(table: string) {
 
 	const builder: any = {
 		where: () => builder,
+		andWhere: () => builder,
 		whereIn: () => builder,
 		whereNotNull: (column: string) => {
 			if (column === 'duration_ms') {
@@ -43,6 +44,9 @@ function makeBuilder(table: string) {
 		orderBy: () => builder,
 		groupByRaw: () => builder,
 		select: () => builder,
+		// The TTL replay's seed: the last change BEFORE the window, read on its own
+		// under `<table>:prior` so a test can open a window on an existing value.
+		first: () => Promise.resolve(rowsByTable[`${table}:prior`]?.[0] ?? undefined),
 		insert: (row: unknown) => insertSpy(table, row),
 		delete: () => deleteSpy(table),
 		then: (resolve: any, reject: any) => {
@@ -216,6 +220,36 @@ describe('readCacheTimeseries', () => {
 		expect(result.buckets.every((b) => b.hits === 0 && b.misses === 0)).toBe(true);
 
 		env['CACHE_STATS_ENABLED'] = true;
+	});
+
+	it('replays the TTL in force from the markers, seeded by the prior change', async () => {
+		env['CACHE_TTL'] = '10m';
+		const bucketSec = 60;
+
+		rowsByTable = {
+			directus_cache_config_events: [
+				// A clear, mid-window: detail null hands the TTL back to env, so the
+				// series must step DOWN here rather than hold the 24h it replaced.
+				{ time: new Date(NOW - bucketSec * 1000), kind: 'ttl_change', detail: null },
+			],
+			// The window opened on a 24h override set before it began.
+			'directus_cache_config_events:prior': [{ detail: '24h' }],
+			directus_cache_events: [
+				// Entries stamped at 24h are still being served after the clear — the
+				// conflation this series exists to end: `ttlMs` stays high, the TTL drops.
+				{ bucket: 2, hits: 4, misses: 0, fills: 0, ttl_ms: 86_400_000 },
+			],
+		};
+
+		const result = await readCacheTimeseries(180_000, 3);
+
+		expect(result.buckets.map((b) => b.effectiveTtlMs))
+			.toEqual([86_400_000, 600_000, 600_000]);
+
+		// Same window, and the stamped lifetime disagrees — which is the point.
+		expect(result.buckets[2]!.ttlMs).toBe(86_400_000);
+
+		delete env['CACHE_TTL'];
 	});
 });
 

--- a/api/src/cache-timeseries.test.ts
+++ b/api/src/cache-timeseries.test.ts
@@ -222,6 +222,27 @@ describe('readCacheTimeseries', () => {
 		env['CACHE_STATS_ENABLED'] = true;
 	});
 
+	it('draws the TTL in force when no change was ever recorded', async () => {
+		// The ordinary deployment: the TTL comes from env and nobody ever edited it, so
+		// the markers table holds nothing to replay. The series must still show the
+		// value in force across the window — an empty line reads as a broken page, and
+		// it was the regression this case exists to catch.
+		env['CACHE_TTL'] = '10m';
+
+		rowsByTable = {
+			directus_cache_events: [
+				{ bucket: 0, hits: 3, misses: 0, fills: 0, ttl_ms: 600_000 },
+			],
+		};
+
+		const result = await readCacheTimeseries(180_000, 3);
+
+		expect(result.buckets.map((b) => b.effectiveTtlMs))
+			.toEqual([600_000, 600_000, 600_000]);
+
+		delete env['CACHE_TTL'];
+	});
+
 	it('replays the TTL in force, seeded by the prior change', async () => {
 		env['CACHE_TTL'] = '10m';
 		const bucketSec = 60;

--- a/api/src/services/settings.test.ts
+++ b/api/src/services/settings.test.ts
@@ -1,19 +1,15 @@
 import knex from 'knex';
 import { MockClient } from 'knex-mock-client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { recordCacheConfigEvent } from '../cache-events.js';
 import { ItemsService } from './items.js';
 import { SettingsService } from './settings.js';
 
-vi.mock('../cache-events.js', () => {
-	return { recordCacheConfigEvent: vi.fn(() => Promise.resolve()) };
-});
-
 const db = knex({ client: MockClient });
 
-// Broadcasting the new value is not this service's job — it rides the
-// `settings.update` action so it covers writers that never reach here (see
-// cache-config.test.ts). What remains here is the validation gate and the marker.
+// Neither the broadcast nor the timeseries marker is this service's job — both ride
+// the `settings.update` action so they cover writers that never reach here (see
+// cache-config.test.ts). What remains is the validation, which has to run before the
+// write and so cannot live on an after-the-fact action.
 describe('SettingsService.upsertSingleton', () => {
 	beforeEach(() => {
 		vi.restoreAllMocks();
@@ -29,16 +25,18 @@ describe('SettingsService.upsertSingleton', () => {
 		});
 	}
 
-	it('records the new cache_ttl on change', async () => {
+	it('persists a valid cache_ttl', async () => {
 		await service().upsertSingleton({ cache_ttl: '30s' });
 
-		expect(recordCacheConfigEvent).toHaveBeenCalledWith('ttl_change', '30s');
+		expect(ItemsService.prototype.upsertSingleton)
+			.toHaveBeenCalledWith({ cache_ttl: '30s' }, undefined);
 	});
 
-	it('records a cleared cache_ttl so the timeseries shows the reset', async () => {
+	it('persists a cleared cache_ttl, which hands the TTL back to env', async () => {
 		await service().upsertSingleton({ cache_ttl: null });
 
-		expect(recordCacheConfigEvent).toHaveBeenCalledWith('ttl_change', null);
+		expect(ItemsService.prototype.upsertSingleton)
+			.toHaveBeenCalledWith({ cache_ttl: null }, undefined);
 	});
 
 	it.each(['abc', '30x', '-5m', '0'])(
@@ -47,15 +45,15 @@ describe('SettingsService.upsertSingleton', () => {
 			await expect(service().upsertSingleton({ cache_ttl: bad }))
 				.rejects.toThrow(/Invalid cache_ttl/);
 
-			// Gate runs before the write, so nothing is persisted and nothing is recorded.
+			// The gate runs before the write, so nothing is persisted.
 			expect(ItemsService.prototype.upsertSingleton).not.toHaveBeenCalled();
-			expect(recordCacheConfigEvent).not.toHaveBeenCalled();
 		},
 	);
 
-	it('stays silent when the payload does not touch cache_ttl', async () => {
+	it('leaves a payload that does not touch cache_ttl alone', async () => {
 		await service().upsertSingleton({ project_name: 'Acme' });
 
-		expect(recordCacheConfigEvent).not.toHaveBeenCalled();
+		expect(ItemsService.prototype.upsertSingleton)
+			.toHaveBeenCalledWith({ project_name: 'Acme' }, undefined);
 	});
 });

--- a/api/src/services/settings.ts
+++ b/api/src/services/settings.ts
@@ -5,7 +5,6 @@ import type {
 	PrimaryKey,
 } from '@directus/types';
 import { InvalidPayloadError } from '@directus/errors';
-import { recordCacheConfigEvent } from '../cache-events.js';
 import { isPositiveDuration } from '../utils/get-milliseconds.js';
 import { ItemsService } from './items.js';
 
@@ -15,10 +14,10 @@ export class SettingsService extends ItemsService {
 	}
 
 	// The cache page edits `cache_ttl` through the settings singleton (PATCH
-	// /settings). The broadcast that flips every node's live override rides the
-	// `settings.update` action instead (see `initCacheConfig`), so it also covers
-	// writers that never reach this service; what stays here is the validation the
-	// write must not skip, and the timeseries marker.
+	// /settings). Both the broadcast and the timeseries marker ride the
+	// `settings.update` action instead (see `initCacheConfig`), so they cover writers
+	// that never reach this service. What stays here is the validation, which has to
+	// run BEFORE the write and so cannot live on an after-the-fact action.
 	override async upsertSingleton(
 		data: Partial<Item>,
 		opts?: MutationOptions,
@@ -42,16 +41,6 @@ export class SettingsService extends ItemsService {
 			}
 		}
 
-		const result = await super.upsertSingleton(data, opts);
-
-		if ('cache_ttl' in data) {
-			// Best-effort marker for the cache-page timeseries; don't fail the save on it.
-			void recordCacheConfigEvent(
-				'ttl_change',
-				data['cache_ttl'] as string | null,
-			).catch(() => {});
-		}
-
-		return result;
+		return super.upsertSingleton(data, opts);
 	}
 }

--- a/app/src/modules/settings/routes/cache/cache.test.ts
+++ b/app/src/modules/settings/routes/cache/cache.test.ts
@@ -1336,8 +1336,10 @@ describe('CachePage', () => {
 		expect(html).toContain('TTL: 1h');
 		expect(html).toContain('cache-tt-row');
 
-		// The ratio is the one dashed line: it doesn't share the Count axis.
-		expect(config.stroke.dashArray).toEqual([0, 0, 0, 0, 0, 6, 0]);
+		// Dashes mark the lines that don't share the Count axis: the ratio, and the
+		// entry lifetime — dashed apart from the TTL it sits beside so the config and
+		// the lifetimes of the entries it produced can't be read as one line.
+		expect(config.stroke.dashArray).toEqual([0, 0, 0, 0, 0, 6, 0, 4]);
 
 		// Count axis stays integer; TTL axis reads as a duration; the ratio gets a
 		// pinned 0-100 axis with nothing drawn, since a percent carries its scale.
@@ -1348,6 +1350,51 @@ describe('CachePage', () => {
 		// Above 100 so a near-perfect ratio keeps clear of the plot's top edge.
 		expect(config.yaxis[2].max).toBeGreaterThan(100);
 		expect(config.yaxis[2].seriesName).toEqual(['Hit ratio']);
+	});
+
+	it('splits the TTL in force from the lifetimes entries carry', async () => {
+		// The reset that made this necessary: the config drops, but entries filled
+		// under the old value keep being served, so `ttlMs` stays high for hours. Two
+		// series, so the chart can't read the survivors as the current setting.
+		const bucket = { hits: 1, misses: 0, fills: 0, anomalies: 0 };
+
+		mockCacheGet(ENTRIES, {
+			timeseries: {
+				buckets: [
+					// Before any recorded change the config is genuinely unknown, while
+					// entries are already being served under some earlier lifetime.
+					{ ...bucket, t: 1000, ttlMs: 86400000, effectiveTtlMs: null },
+					{ ...bucket, t: 2000, ttlMs: null, effectiveTtlMs: 3600000 },
+					{ ...bucket, t: 3000, ttlMs: 86400000, effectiveTtlMs: 3600000 },
+				],
+				markers: [],
+			},
+		});
+
+		const wrapper = mount(CachePage, { global });
+		await flushPromises();
+
+		const config = chartConfigWithSeries('Responses');
+
+		const ttl = config.series.find((s: { name: string }) => s.name === 'TTL');
+
+		const lifetime = config.series
+			.find((s: { name: string }) => s.name === 'Entry lifetime');
+
+		// The config's own history, in seconds. The leading unknown stays unknown — it
+		// is not back-filled with the 1h that had not been set yet.
+		expect(ttl.data).toEqual([[1000, null], [2000, 3600], [3000, 3600]]);
+
+		// The lifetime is sampled off whichever entries were served, so its gap carries
+		// the previous reading rather than claiming nothing was cached.
+		expect(lifetime.data).toEqual([[1000, 86400], [2000, 86400], [3000, 86400]]);
+
+		// The shared fixture also renders the latency chart, whose default-hidden p95
+		// bands persist per user. A page left mounted keeps writing that key back, so
+		// the next test reads them as a restored choice and never re-hides — its own
+		// assertion then finds nothing hidden.
+		wrapper.unmount();
+		localStorage.removeItem('cache-latency-hidden-anon');
 	});
 
 	it('builds the latency chart with p50/p95 series + ms axis', async () => {
@@ -1406,6 +1453,14 @@ describe('CachePage', () => {
 		expect(html).toContain('Fills p50: 20ms');
 		expect(html).toContain('Anomalies p95: 200ms');
 		expect(html).toContain('Misses p95: 120ms');
+
+		// `applyHiddenSeries` retries across animation frames until apex has registered
+		// its series, which the stub never reports — so the hides land a dozen frames
+		// after the mount's promises settle, not with them. Wait for the effect being
+		// asserted instead of relying on whatever else happened to run first.
+		for (let frame = 0; frame < 20 && chartMock.hidden.length === 0; frame++) {
+			await new Promise((resolve) => requestAnimationFrame(resolve));
+		}
 
 		// The p95 bands are hidden on first render; the p50 medians stay visible.
 		expect(chartMock.hidden).toContain('Hits p95');

--- a/app/src/modules/settings/routes/cache/cache.vue
+++ b/app/src/modules/settings/routes/cache/cache.vue
@@ -945,6 +945,10 @@ function chartConfig(): ApexOptions {
 		// be read against the counts it sits among.
 		dash: number;
 		color: string;
+		// A sampled value has gaps meaning "nothing was observed", so it carries its
+		// last reading across them. A value that is dense by construction does not,
+		// and carrying one would invent readings it never had.
+		sampled?: boolean;
 		pick: (b: CacheTimeseriesBucket) => number | null;
 	}[] = [
 		{
@@ -1002,11 +1006,29 @@ function chartConfig(): ApexOptions {
 			pick: (b) => hitRatioPercent(b.hits, b.fills),
 		},
 		{
+			// What the config says, replayed from the ttl_change markers. A step line
+			// because that is what a config value does — it holds, then jumps.
 			name: t('ttl', 'TTL'),
 			unit: 'seconds',
 			curve: 'stepline',
 			dash: 0,
 			color: themeVar('--theme--primary', '#6644ff'),
+			pick: (b) => {
+				return b.effectiveTtlMs === null
+					? null
+					: Math.round(b.effectiveTtlMs / 1000);
+			},
+		},
+		{
+			// Not the TTL in force: the longest lifetime stamped on an entry actually
+			// served here, as of when it was filled. Entries outlive the config that
+			// created them, so this trails the line above instead of tracking it (#343).
+			name: t('cache_entry_lifetime', 'Entry lifetime'),
+			unit: 'seconds',
+			curve: 'stepline',
+			dash: 4,
+			color: themeVar('--theme--secondary', '#ff99dd'),
+			sampled: true,
 			pick: (b) => {
 				return b.ttlMs === null
 					? null
@@ -1054,9 +1076,13 @@ function chartConfig(): ApexOptions {
 		series: metrics.map((m) => {
 			const data = series(m.pick);
 
+			// Carrying is for a SAMPLED value, whose gaps mean "nobody looked" — the
+			// entry lifetime, read off whichever entries happened to be served. The TTL
+			// arrives already dense from the marker replay, so carrying it would only
+			// back-fill its lead with a value that had not been set yet (#343).
 			return {
 				name: m.name,
-				data: m.unit === 'seconds'
+				data: m.sampled
 					? carryForward(data)
 					: data,
 			};

--- a/packages/types/src/cache.ts
+++ b/packages/types/src/cache.ts
@@ -27,8 +27,12 @@ export interface CacheTimeseriesBucket {
 	ttlMs: number | null;
 	/**
 	 * The TTL IN FORCE over this bucket, reconstructed from the `ttl_change` markers.
-	 * `null` when no change is recorded at or before the bucket — the honest answer,
-	 * rather than back-filling a later value over a window it did not apply to.
+	 * `null` when the window contains a change but nothing precedes it — the honest
+	 * answer, rather than back-filling a later value over a span it did not apply to.
+	 *
+	 * Accurate only as far as the markers reach: a change whose marker has aged out of
+	 * retention reads the same as no change at all, so a flat stretch is not proof the
+	 * TTL held — only that nothing retained says otherwise.
 	 */
 	effectiveTtlMs: number | null;
 	hitP50: number | null;

--- a/packages/types/src/cache.ts
+++ b/packages/types/src/cache.ts
@@ -6,7 +6,7 @@
  */
 export type CacheFlushTarget = 'response' | 'system' | 'locks';
 
-/** One bucket of the cache timeseries: outcome counts, the effective TTL, and
+/** One bucket of the cache timeseries: outcome counts, two different TTLs, and
  * response-latency percentiles: hit = serve, fill = a cached miss's compute,
  * anomaly = a flagged-uncacheable miss's compute, miss = all misses pooled (the
  * umbrella over fill + anomaly + silently-skipped), both = hits + misses pooled.
@@ -17,7 +17,20 @@ export interface CacheTimeseriesBucket {
 	misses: number;
 	fills: number;
 	anomalies: number;
+	/**
+	 * The longest lifetime STAMPED ON AN ENTRY served in this bucket, as of when that
+	 * entry was filled — not the TTL in force. An entry filled under a since-changed
+	 * TTL keeps reporting the old value until it expires, so this stays high long
+	 * after the config moved. It answers "how long do the entries being served
+	 * actually live"; `effectiveTtlMs` answers what the config says.
+	 */
 	ttlMs: number | null;
+	/**
+	 * The TTL IN FORCE over this bucket, reconstructed from the `ttl_change` markers.
+	 * `null` when no change is recorded at or before the bucket — the honest answer,
+	 * rather than back-filling a later value over a window it did not apply to.
+	 */
+	effectiveTtlMs: number | null;
 	hitP50: number | null;
 	hitP95: number | null;
 	hitP99: number | null;

--- a/tests/blackbox/tests/db/app/cache-config-broadcast.test.ts
+++ b/tests/blackbox/tests/db/app/cache-config-broadcast.test.ts
@@ -173,5 +173,33 @@ describe('Cache config broadcast', () => {
 			expect(await awaitEffectiveTtl(vendor, peer, '11m')).toBe('11m');
 			expect(await awaitEffectiveTtl(vendor, writer, '11m')).toBe('11m');
 		});
+
+		it('marks the timeseries for an import write too', async () => {
+			// The chart draws a step wherever the TTL moved; a step with no marker is a
+			// change with no visible cause, which is how a production reset went
+			// unexplained until `directus_revisions` was read by hand.
+			const { writer, peer } = envs[vendor]!;
+
+			await request(getUrl(vendor, writer))
+				.post('/settings-import-write')
+				.send({ cache_ttl: '7h' })
+				.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`)
+				.expect(200);
+
+			expect(await awaitEffectiveTtl(vendor, peer, '7h')).toBe('7h');
+
+			const timeseries = await request(getUrl(vendor, writer))
+				.get('/utils/cache/timeseries')
+				.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+			const ttlChanges = timeseries.body.data.markers
+				.filter((marker: { kind: string }) => marker.kind === 'ttl_change');
+
+			expect(ttlChanges.at(-1)).toMatchObject({ kind: 'ttl_change', detail: '7h' });
+
+			// And the replayed series ends on the value the marker announced, rather than
+			// on whatever lifetime the surviving entries were stamped with.
+			expect(timeseries.body.data.buckets.at(-1).effectiveTtlMs).toBe(25_200_000);
+		});
 	});
 });

--- a/tests/blackbox/tests/db/app/cache-config-broadcast.test.ts
+++ b/tests/blackbox/tests/db/app/cache-config-broadcast.test.ts
@@ -188,18 +188,33 @@ describe('Cache config broadcast', () => {
 
 			expect(await awaitEffectiveTtl(vendor, peer, '7h')).toBe('7h');
 
-			const timeseries = await request(getUrl(vendor, writer))
-				.get('/utils/cache/timeseries')
-				.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+			// The marker is written fire-and-forget so a chart annotation can never fail
+			// a settings save, which means it lands after the broadcast the poll above
+			// waits on. Poll for it too, or the read races the insert and finds the
+			// previous case's cleanup as the latest change.
+			let timeseries;
+			let ttlChanges = [];
 
-			const ttlChanges = timeseries.body.data.markers
-				.filter((marker: { kind: string }) => marker.kind === 'ttl_change');
+			for (let attempt = 0; attempt < 50; attempt++) {
+				timeseries = await request(getUrl(vendor, writer))
+					.get('/utils/cache/timeseries')
+					.set('Authorization', `Bearer ${USER.ADMIN.TOKEN}`);
+
+				ttlChanges = timeseries.body.data.markers
+					.filter((marker: { kind: string }) => marker.kind === 'ttl_change');
+
+				if (ttlChanges.at(-1)?.detail === '7h') {
+					break;
+				}
+
+				await new Promise((resolve) => setTimeout(resolve, 100));
+			}
 
 			expect(ttlChanges.at(-1)).toMatchObject({ kind: 'ttl_change', detail: '7h' });
 
 			// And the replayed series ends on the value the marker announced, rather than
 			// on whatever lifetime the surviving entries were stamped with.
-			expect(timeseries.body.data.buckets.at(-1).effectiveTtlMs).toBe(25_200_000);
+			expect(timeseries!.body.data.buckets.at(-1).effectiveTtlMs).toBe(25_200_000);
 		});
 	});
 });


### PR DESCRIPTION
## Scope

Two halves of the same failure, which is why they're one PR: the cache page could not
tell you what the TTL **was**, nor **when it changed**. Either alone leaves the chart
lying about the other.

**#343 — the series plotted the wrong quantity.** It drew `MAX(ttl_ms)` per bucket, and
a hit's `ttl_ms` is the lifetime stamped on the entry *when it was filled*, not the
config. Entries outlive the setting that created them, so after a change the old value
keeps winning the maximum for as long as they survive. In production that read as 1h and
24h alternating for hours after the config had settled on one value, and sent the
diagnosis chasing a flapping setting that never existed.

**#342 — the annotations had a blind spot.** `recordCacheConfigEvent('ttl_change', …)`
lived in `SettingsService`, so an import that reset the TTL drew a step on the chart with
nothing to explain it. Same shape as the broadcast gap #341 closed.

What's changed:

- `api/src/cache-events.ts` — `effectiveTtlByBucket` replays the `ttl_change` markers
  across the bucket grid, and `readCacheTimeseries` returns the value in force per
  bucket. It's seeded by the last change **before** the window, so a window doesn't open
  unknown just because nothing changed inside it.
- `api/src/cache-config.ts` — the marker moves onto the `settings.update` action, beside
  the broadcast, so every writer annotates its own change.
- `api/src/services/settings.ts` — keeps the validation, which has to run *before* the
  write and so cannot live on an after-the-fact action. Nothing else.
- `packages/types/src/cache.ts` — `effectiveTtlMs` on the bucket, and both TTL fields now
  carry a docblock saying which question they answer.
- `app/…/cache.vue` — the **TTL** line reads `effectiveTtlMs`; `ttlMs` keeps its own
  clearly-labelled **Entry lifetime** line, dashed apart from it.

## Potential Risks / Drawbacks

- **A bucket with no change at or before it stays `null`.** That is deliberate: the
  alternative is back-filling the lead with a value that had not been set yet, which is
  the exact conflation this PR exists to remove. It shows as a gap at the far left of a
  window that predates every recorded change.
- **Reconstruction is only as complete as the marker history.** Writes that bypassed
  `SettingsService` before this PR left no marker, so a window reaching back into that
  history can under-report changes. Going forward the other half of this PR closes it.
  Marker retention is the other bound.
- **One extra query per timeseries read** — the last `ttl_change` at or before the
  window. Indexed on `time`, one row, on a page that already issues several.
- **The chart gains a series.** Eight lines on the counts chart rather than seven.
  Keeping `ttlMs` was a deliberate call: it is a real measurement and answers "how long
  do the entries being served actually live", which is worth seeing next to the config
  rather than deleted because it was previously mislabelled.

## Tested Scenarios

- `effectiveTtlByBucket` — 8 cases over a fixed grid: no change in the window; a change
  applying from the bucket that contains it; **the lead left unknown rather than
  back-filled**; a clear stepping back down to the env fallback; several changes inside
  one bucket keeping the last; out-of-order input sorted by time; a change in the final
  bucket carrying to the window end; an empty grid.
- `cache-config.test.ts` — the action now records the marker as well as broadcasting, for
  both a set and a **clear** (the production case), stays silent on a settings write that
  doesn't touch `cache_ttl`, and survives a failing marker write without losing the
  change itself.
- `settings.test.ts` — re-pointed rather than deleted: the marker assertions moved to the
  action's tests, and what remains asserts the validation gate and that the payload
  reaches the write.
- `cache.test.ts` — a fixture where the two series genuinely disagree: a leading bucket
  with an entry lifetime but no recorded config, then a config change. Asserts the TTL
  line keeps its leading `null` while the lifetime line carries its gap.
- Blackbox — an import write through the existing `settings-import-write` probe must now
  leave a `ttl_change` marker, and the replayed series must end on the value the marker
  announced rather than on whatever the surviving entries were stamped with.

Locally: `api` 111 passed across the three touched files, `app` 103 passed, style gate
clean against `origin/v11.10.1-hhh-dev`, eslint clean.

## Review Notes / Questions

- **I kept `ttlMs` as a second line rather than dropping it.** The issue offered either
  replacing the series or keeping both clearly labelled; I took the second because the
  measurement is real and its divergence from the config is itself the diagnostic signal
  — seeing the two lines apart is what would have made the production incident obvious.
  Say if you'd rather the chart stayed at seven lines.
- **A change applies from the bucket that *contains* it**, not the one after. A bucket is
  a span, and the value that ends it is what a reader pointing at it is asking about.
  Defensible the other way at sub-bucket resolution.
- **While adding the app test I hit a genuinely order-dependent existing test.**
  `applyHiddenSeries` retries across up to 12 animation frames waiting for apex to
  register its series — which the test stub never reports — so the latency chart's hides
  land well after `flushPromises()`. The latency test asserted them anyway and passed
  only on whatever incidentally ran first; inserting a test before it turned it red. It
  now waits for the effect it asserts. Worth knowing that the same pattern may be latent
  in other chart tests.

## Out of scope

- **Backfilling markers for historical writes.** Nothing can reconstruct changes that
  were never recorded; the reconstruction is honest about that by leaving those buckets
  `null` rather than inventing them.
- **The consumer-side `cache_ttl` exclusion** (Planner #674) — still the reason a TTL
  gets reset on deploy in the first place. This PR only makes the reset visible.
