### PR TITLE
fix(cli): tolerate excess argv on `directus start` (pm2 cluster mode)

### DIFF
--- a/api/src/cli/index.test.ts
+++ b/api/src/cli/index.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+import { startServer } from '../server.js';
+import { createCli } from './index.js';
+
+vi.mock('directus/version', () => ({ version: '0.0.0' }));
+vi.mock('./load-extensions.js', () => ({ loadExtensions: vi.fn() }));
+vi.mock('../emitter.js', () => ({ default: { emitInit: vi.fn() } }));
+vi.mock('../server.js', () => ({ startServer: vi.fn() }));
+
+describe('createCli', () => {
+	// pm2 cluster mode appends the ecosystem path and a duplicated `start` to the
+	// worker argv; the start command must swallow those excess positionals instead of
+	// letting commander 14 reject them and crash the boot.
+	it('start tolerates the excess argv pm2 cluster injects', async () => {
+		const program = await createCli();
+		program.exitOverride();
+
+		await program.parseAsync(['start', '/x/ecosystem.config.cjs', 'start'], {
+			from: 'user',
+		});
+
+		expect(vi.mocked(startServer)).toHaveBeenCalledOnce();
+	});
+});

--- a/api/src/cli/index.ts
+++ b/api/src/cli/index.ts
@@ -26,7 +26,14 @@ export async function createCli(): Promise<Command> {
 	program.name('directus').usage('[command] [options]');
 	program.version(version, '-v, --version');
 
-	program.command('start').description('Start the Directus API').action(startServer);
+	// Under pm2 cluster mode, ProcessContainer leaks the ecosystem config path and a
+	// stray "start" into argv; tolerate them so commander doesn't reject start's boot.
+	program
+		.command('start')
+		.description('Start the Directus API')
+		.allowExcessArguments()
+		.action(startServer);
+
 	program.command('init').description('Create a new Directus Project').action(init);
 
 	// Security

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3057,6 +3057,9 @@ importers:
       lodash-es:
         specifier: 'catalog:'
         version: 4.18.1
+      pm2:
+        specifier: 'catalog:'
+        version: 7.0.1
       seedrandom:
         specifier: 3.0.5
         version: 3.0.5

--- a/tests/blackbox/package.json
+++ b/tests/blackbox/package.json
@@ -32,6 +32,7 @@
 		"knex": "3.1.0",
 		"listr2": "10.1.2",
 		"lodash-es": "catalog:",
+		"pm2": "catalog:",
 		"seedrandom": "3.0.5",
 		"supertest": "7.2.2",
 		"typescript": "catalog:",

--- a/tests/blackbox/tests/db/app/cli-start-excess-args.test.ts
+++ b/tests/blackbox/tests/db/app/cli-start-excess-args.test.ts
@@ -1,0 +1,88 @@
+import config, { getUrl, paths } from '@common/config';
+import vendors from '@common/get-dbs-to-test';
+import { awaitDirectusConnection } from '@utils/await-connection';
+import { ChildProcess, spawn } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import getPort from 'get-port';
+import { cloneDeep } from 'lodash-es';
+import { createRequire } from 'module';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+// Boots directus the way prod does: pm2-runtime in cluster mode, not a bare `node
+// cli.js start`. In cluster mode pm2/lib/ProcessContainer.js re-invokes the worker
+// with the ecosystem args followed by the config path and another copy of the args,
+// so `directus start` effectively runs as `start <ecosystem path> start` — two
+// excess positionals. Without allowExcessArguments() on the start command, commander
+// 14 rejects them, the worker exits 1, pm2 restart-loops, and the port never opens.
+const require = createRequire(import.meta.url);
+const pm2Runtime = require.resolve('pm2/bin/pm2-runtime');
+
+// pm2 checks fs.existsSync(script), so it needs the real file — `paths.cli` is
+// extensionless and only `node` would resolve it to cli.js.
+const cliScript = require.resolve(paths.cli);
+
+describe('CLI start boots under pm2-runtime cluster mode', () => {
+	const env = cloneDeep(config.envs);
+	const runtimes = {} as Record<string, ChildProcess>;
+	const pm2Homes: string[] = [];
+
+	beforeAll(async () => {
+		const promises = [];
+
+		for (const vendor of vendors) {
+			const port = await getPort();
+			env[vendor].PORT = String(port);
+
+			const pm2Home = mkdtempSync(join(tmpdir(), `pm2-${vendor}-`));
+			pm2Homes.push(pm2Home);
+
+			const ecosystem = join(pm2Home, 'ecosystem.config.cjs');
+
+			writeFileSync(
+				ecosystem,
+				`module.exports = ${JSON.stringify({
+					apps: [
+						{
+							name: 'directus',
+							script: cliScript,
+							args: 'start',
+							exec_mode: 'cluster',
+							instances: 1,
+							env: env[vendor],
+						},
+					],
+				})};\n`,
+			);
+
+			runtimes[vendor] = spawn('node', [pm2Runtime, 'start', ecosystem], {
+				cwd: paths.cwd,
+				env: { ...process.env, PM2_HOME: pm2Home },
+			});
+
+			promises.push(awaitDirectusConnection(port));
+		}
+
+		await Promise.all(promises);
+	}, 60_000);
+
+	afterAll(() => {
+		for (const vendor of vendors) {
+			runtimes[vendor]?.kill('SIGINT');
+		}
+
+		for (const pm2Home of pm2Homes) {
+			rmSync(pm2Home, { recursive: true, force: true });
+		}
+	});
+
+	it.each(vendors)('%s serves requests', async (vendor) => {
+		const response = await request(getUrl(vendor, env))
+			.get('/server/ping')
+			.expect(200);
+
+		expect(response.text).toBe('pong');
+	});
+});


### PR DESCRIPTION
Prod's API crash-loops under `pm2-runtime` in **cluster mode**: pm2's `ProcessContainer` re-invokes each worker with the ecosystem config path and a duplicated `start` appended to argv, so `directus start` effectively runs as `start <ecosystem path> start`. commander 14 (current catalog) rejects the two excess positionals with *"too many arguments for 'start'. Expected 0 arguments but got 2"* and the worker exits 1 — older commander silently ignored them, which is why this only surfaced after the bump. Single-process (`fork`/bare `node cli.js start`) is unaffected; only cluster leaks the argv.

Fix: `allowExcessArguments()` on the `start` command restores that tolerance.

### Why the blackbox test launches real pm2

A synthetic `spawn('node', [cli, 'start', <config>, 'start'])` would only assert what I already believe about the argv shape — the class of weak test that passes over buggy code. Instead the test boots directus through the real `pm2-runtime` cluster path (a generated `ecosystem.config.cjs`, `exec_mode: 'cluster'`), so `ProcessContainer` produces the leak itself.

**Fail-without-patch, proven on CI:** the test-only commit (`486e3b9`, before the fix) went red — `Blackbox / postgres (shard 3)`:

```
FAIL tests/db/app/cli-start-excess-args.test.ts > CLI start boots under pm2-runtime cluster mode
Error: Hook timed out in 180000ms.
```

The worker crashed on the excess argv, the port never opened, `beforeAll` hit its 180s ceiling. With the fix it boots and serves `/server/ping`.

`pm2` added to the blackbox package (catalog `7.0.1`, same version prod runs).

Fixes #346

### Open questions
- Naming: the excess args are `<ecosystem path> start` regardless of pm2 — happy to widen the comment/title if you'd rather it not name pm2 specifically.
